### PR TITLE
Setting unit tests and regression tests

### DIFF
--- a/test/acceptance_tests/from_notebooks/test_cropped_decoding.py
+++ b/test/acceptance_tests/from_notebooks/test_cropped_decoding.py
@@ -19,7 +19,7 @@ def test_cropped_decoding():
     raw = concatenate_raws(parts)
 
     # Find the events in this dataset
-    events = mne.find_events(raw, shortest_event=0, stim_channel='STI 014')
+    events, _ = mne.events_from_annotations(raw)
 
     # Use only EEG channels
     eeg_channel_inds = mne.pick_types(raw.info, meg=False, eeg=True, stim=False,

--- a/test/acceptance_tests/from_notebooks/test_experiment_class.py
+++ b/test/acceptance_tests/from_notebooks/test_experiment_class.py
@@ -19,7 +19,7 @@ def test_experiment_class():
     raw = concatenate_raws(parts)
 
     # Find the events in this dataset
-    events = mne.find_events(raw, shortest_event=0, stim_channel='STI 014')
+    events, _ = mne.events_from_annotations(raw)
 
     # Use only EEG channels
     eeg_channel_inds = mne.pick_types(raw.info, meg=False, eeg=True, stim=False,

--- a/test/acceptance_tests/from_notebooks/test_trialwise_decoding.py
+++ b/test/acceptance_tests/from_notebooks/test_trialwise_decoding.py
@@ -19,8 +19,8 @@ def test_trialwise_decoding():
     raw = concatenate_raws(parts)
 
     # Find the events in this dataset
-    events = mne.find_events(raw, shortest_event=0, stim_channel='STI 014')
-
+    events, _ = mne.events_from_annotations(raw)
+    
     # Use only EEG channels
     eeg_channel_inds = mne.pick_types(raw.info, meg=False, eeg=True, stim=False,
                                       eog=False,


### PR DESCRIPTION
Unit tests should be populated
For regression tests, there is an error with handling MNE events and the obtained precision is not correct according to the hard-coded numbers.
This first pass correct the handling of the MNE events.