### PR TITLE
Annotations for moabb

### DIFF
--- a/braindecode/datasets/datasets.py
+++ b/braindecode/datasets/datasets.py
@@ -18,6 +18,122 @@ import mne
 
 from .base import BaseDataset, BaseConcatDataset
 
+from mne import Annotations
+from mne.utils import _validate_type
+import collections
+
+try:
+    from mne import annotations_from_events
+except ImportError:
+    # XXX: Remove try/except once the following function is in an MNE release
+    #      (probably 19.3).
+    from mne import Annotations
+    from mne.utils import _validate_type
+    import collections
+
+    def _check_event_description(event_desc, events):
+        """Check event_id and convert to default format."""
+        if event_desc is None:  # convert to int to make typing-checks happy
+            event_desc = list(np.unique(events[:, 2]))
+
+        if isinstance(event_desc, dict):
+            for val in event_desc.values():
+                _validate_type(val, (str, None), "Event names")
+        elif isinstance(event_desc, collections.Iterable):
+            event_desc = np.asarray(event_desc)
+            if event_desc.ndim != 1:
+                raise ValueError(
+                    "event_desc must be 1D, got shape {}".format(
+                        event_desc.shape
+                    )
+                )
+            event_desc = dict(zip(event_desc, map(str, event_desc)))
+        elif callable(event_desc):
+            pass
+        else:
+            raise ValueError(
+                "Invalid type for event_desc (should be None, list, "
+                "1darray, dict or callable). Got {}".format(type(event_desc))
+            )
+
+        return event_desc
+
+
+    def _select_events_based_on_id(events, event_desc):
+        """Get a collection of events and returns index of selected."""
+        event_desc_ = dict()
+        func = event_desc.get if isinstance(event_desc, dict) else event_desc
+        event_ids = events[np.unique(events[:, 2], return_index=True)[1], 2]
+        for e in event_ids:
+            trigger = func(e)
+            if trigger is not None:
+                event_desc_[e] = trigger
+
+        event_sel = [ii for ii, e in enumerate(events) if e[2] in event_desc_]
+
+        # if len(event_sel) == 0:
+        #     raise ValueError('Could not find any of the events you specified.')
+
+        return event_sel, event_desc_
+
+    def annotations_from_events(
+        events,
+        sfreq,
+        event_desc=None,
+        first_samp=0,
+        orig_time=None,
+        verbose=None,
+    ):
+        """Convert an event array to an Annotations object.
+        Parameters
+        ----------
+        events : ndarray, shape (n_events, 3)
+            The events.
+        sfreq : float
+            Sampling frequency.
+        event_desc : dict | array-like | callable | None
+            Events description. Can be:
+            - **dict**: map integer event codes (keys) to descriptions (values).
+            Only the descriptions present will be mapped, others will be ignored.
+            - **array-like**: list, or 1d array of integers event codes to include.
+            Only the event codes present will be mapped, others will be ignored.
+            Event codes will be passed as string descriptions.
+            - **callable**: must take a integer event code as input and return a
+            string description or None to ignore it.
+            - **None**: Use integer event codes as descriptions.
+        first_samp : int
+            The first data sample (default=0). See :attr:`mne.io.Raw.first_samp`
+            docstring.
+        orig_time : float | str | datetime | tuple of int | None
+            Determines the starting time of annotation acquisition. If None
+            (default), starting time is determined from beginning of raw data
+            acquisition. For details, see :meth:`mne.Annotations` docstring.
+        %(verbose)s
+        Returns
+        -------
+        annot : instance of Annotations
+            The annotations.
+        Notes
+        -----
+        Annotations returned by this function will all have zero (null) duration.
+        """
+        event_desc = _check_event_description(event_desc, events)
+        event_sel, event_desc_ = _select_events_based_on_id(events, event_desc)
+        events_sel = events[event_sel]
+        onsets = (events_sel[:, 0] - first_samp) / sfreq
+        descriptions = [event_desc_[e[2]] for e in events_sel]
+        durations = np.zeros(len(events_sel))  # dummy durations
+
+        # Create annotations
+        annots = Annotations(
+            onset=onsets,
+            duration=durations,
+            description=descriptions,
+            orig_time=orig_time,
+        )
+
+        return annots
+
 
 def _find_dataset_in_moabb(dataset_name):
     # soft dependency on moabb

--- a/braindecode/datasets/datasets.py
+++ b/braindecode/datasets/datasets.py
@@ -22,6 +22,7 @@ from mne import Annotations
 from mne.utils import _validate_type
 import collections
 
+
 try:
     from mne import annotations_from_events
 except ImportError:

--- a/braindecode/datautil/windowers.py
+++ b/braindecode/datautil/windowers.py
@@ -60,9 +60,7 @@ def create_windows_from_events(
 
     list_of_windows_ds = []
     for ds in concat_ds.datasets:
-
-        # TODO: how to get events without 'stim' channel?
-        events = mne.find_events(ds.raw)
+        events = mne.events_from_annotations(ds.raw)
         onsets = events[:, 0]
         description = events[:, -1]
         i_trials, i_supercrop_in_trials, starts, stops = _compute_supercrop_inds(

--- a/test/unit_tests/datasets/test_dataset.py
+++ b/test/unit_tests/datasets/test_dataset.py
@@ -51,8 +51,8 @@ def set_up():
 def concat_ds_targets():
     raws, description = fetch_data_with_moabb(
         dataset_name="BNCI2014001", subject_ids=4)
-    events = mne.find_events(raws[0])
-    targets = events[:, -1]
+    events, _ = mne.events_from_annotations(raws[0])
+    targets = events[:, -1] - 1
     ds = [BaseDataset(raws[i], description.iloc[i]) for i in range(3)]
     concat_ds = BaseConcatDataset(ds)
     return concat_ds, targets

--- a/test/unit_tests/datautil/test_windowers.py
+++ b/test/unit_tests/datautil/test_windowers.py
@@ -19,8 +19,8 @@ from braindecode.datautil import (
 def concat_ds_targets():
     raws, description = fetch_data_with_moabb(
         dataset_name="BNCI2014001", subject_ids=4)
-    events = mne.find_events(raws[0])
-    targets = events[:, -1]
+    events, _ = mne.events_from_annotations(raws[0])
+    targets = events[:, -1] - 1
     ds = BaseDataset(raws[0], description.iloc[0])
     concat_ds = BaseConcatDataset([ds])
     return concat_ds, targets


### PR DESCRIPTION
The MOABB datasets will now be equipped with the annotations object. The trial onset and duration are set correctly based on information from MOABB.

The annotation object stores the string description of events. Thus, the original mapping is discarded and replaced by a custom one when applying the event windower. By default, the event mapping will start from 0, as requested by training for classification. The mapping is passed to mne.Epochs and stored on windows level.