### PR TITLE
[WIP] Moving towards annotations object

### DIFF
--- a/braindecode/datasets/croppedxy.py
+++ b/braindecode/datasets/croppedxy.py
@@ -36,8 +36,9 @@ class CroppedXyDataset(Dataset):
         for i_trial, trial in enumerate(X):
             idx = _compute_supercrop_inds(
                 np.array([0]),
-                0,
                 trial.shape[1],
+                0,
+                0,
                 input_time_length,
                 n_preds_per_input,
                 drop_samples=False,

--- a/braindecode/datasets/croppedxy.py
+++ b/braindecode/datasets/croppedxy.py
@@ -35,12 +35,12 @@ class CroppedXyDataset(Dataset):
         i_supercrop_to_idx = []
         for i_trial, trial in enumerate(X):
             idx = _compute_supercrop_inds(
-                np.array([0]),
-                trial.shape[1],
-                0,
-                0,
-                input_time_length,
-                n_preds_per_input,
+                starts=np.array([0]),
+                stops=trial.shape[1],
+                start_offset=0,
+                stop_offset=0,
+                size=input_time_length,
+                stride=n_preds_per_input,
                 drop_samples=False,
             )
             for _, i_supercrop_in_trial, start, stop in zip(*idx):

--- a/braindecode/datasets/datasets.py
+++ b/braindecode/datasets/datasets.py
@@ -28,13 +28,16 @@ def _find_dataset_in_moabb(dataset_name):
             return dataset()
     raise ValueError("'dataset_name' not found in moabb datasets")
 
-
 def _fetch_and_unpack_moabb_data(dataset, subject_ids):
     data = dataset.get_data(subject_ids)
     raws, subject_ids, session_ids, run_ids = [], [], [], []
     for subj_id, subj_data in data.items():
         for sess_id, sess_data in subj_data.items():
             for run_id, raw in sess_data.items():
+                # set annotation if empty
+                if len(raw.annotations) == 0:
+                    annots = _annotations_from_raw(raw, dataset)
+                    raw.set_annotations(annots)
                 raws.append(raw)
                 subject_ids.append(subj_id)
                 session_ids.append(sess_id)
@@ -42,6 +45,22 @@ def _fetch_and_unpack_moabb_data(dataset, subject_ids):
     description = pd.DataFrame(zip(subject_ids, session_ids, run_ids),
                                columns=["subject", "session", "run"])
     return raws, description
+
+
+def _annotations_from_raw(raw, dataset):
+    # find events from stim channel
+    events = mne.find_events(raw)
+
+    # get annotations from events
+    event_desc = {k: v for v, k in dataset.event_id.items()}
+    annots = mne.annotations_from_events(events, raw.info['sfreq'], event_desc)
+
+    # set trial on and offset given by moabb
+    onset, offset = dataset.interval
+    annots.onset += onset
+    annots.duration += offset - onset
+
+    return annots
 
 
 def fetch_data_with_moabb(dataset_name, subject_ids):

--- a/braindecode/datasets/datasets.py
+++ b/braindecode/datasets/datasets.py
@@ -36,7 +36,9 @@ def _fetch_and_unpack_moabb_data(dataset, subject_ids):
             for run_id, raw in sess_data.items():
                 # set annotation if empty
                 if len(raw.annotations) == 0:
-                    annots = _annotations_from_raw(raw, dataset)
+                    annots = _annotations_from_moabb_stim_channel(
+                        raw, dataset
+                    )
                     raw.set_annotations(annots)
                 raws.append(raw)
                 subject_ids.append(subj_id)
@@ -47,7 +49,7 @@ def _fetch_and_unpack_moabb_data(dataset, subject_ids):
     return raws, description
 
 
-def _annotations_from_raw(raw, dataset):
+def _annotations_from_moabb_stim_channel(raw, dataset):
     # find events from stim channel
     events = mne.find_events(raw)
 

--- a/braindecode/datautil/windowers.py
+++ b/braindecode/datautil/windowers.py
@@ -244,11 +244,12 @@ def _compute_supercrop_inds(
                 i_trials.append(start_i)
 
     # update stops to now be event stops instead of trial stops
-    stops = np.array(supercrop_starts) + size
-    if not len(i_supercrop_in_trials) == len(supercrop_starts) == len(stops):
+    supercrop_stops = np.array(supercrop_starts) + size
+    if not (len(i_supercrop_in_trials) == len(supercrop_starts) ==
+            len(supercrop_stops)):
         raise ValueError(f'{len(i_supercrop_in_trials)} == '
-                         f'{len(supercrop_starts)} == {len(stops)}')
-    return i_trials, i_supercrop_in_trials, supercrop_starts, stops
+                         f'{len(supercrop_starts)} == {len(supercrop_stops)}')
+    return i_trials, i_supercrop_in_trials, supercrop_starts, supercrop_stops
 
 
 def _check_windowing_arguments(

--- a/braindecode/datautil/windowers.py
+++ b/braindecode/datautil/windowers.py
@@ -245,7 +245,9 @@ def _compute_supercrop_inds(
 
     # update stops to now be event stops instead of trial stops
     stops = np.array(supercrop_starts) + size
-    assert len(i_supercrop_in_trials) == len(supercrop_starts) == len(stops)
+    if not len(i_supercrop_in_trials) == len(supercrop_starts) == len(stops):
+        raise ValueError(f'{len(i_supercrop_in_trials)} == '
+                         f'{len(supercrop_starts)} == {len(stops)}')
     return i_trials, i_supercrop_in_trials, supercrop_starts, stops
 
 

--- a/braindecode/datautil/windowers.py
+++ b/braindecode/datautil/windowers.py
@@ -210,20 +210,21 @@ def _compute_supercrop_inds(
     -------
         trial, i_supercrop_in_trial, start sample and stop sample of supercrops
     """
-    # trial ends are defined by trial starts (onsets may be shifted by offset)
-    # and end
+
+    onsets = [onsets] if isinstance(onsets, int) else onsets
+    stops = [stops] if isinstance(stops, int) else stops
+
     i_supercrop_in_trials, i_trials, starts = [], [], []
-    for onset_i, onset in enumerate(onsets):
+    for onset_i, (onset, stop) in enumerate(zip(onsets, stops)):
         # between original trial onsets (shifted by start_offset) and stops,
         # generate possible supercrop starts with given stride
-        stop = stops[onset_i]
         possible_starts = np.arange(
             onset + start_offset, stop + stop_offset, stride)
 
         # possible supercrop start is actually a start, if supercrop size fits
         # in trial start and stop
         for i_supercrop, s in enumerate(possible_starts):
-            if (s + size) <= stops[onset_i]:
+            if (s + size) <= stop + stop_offset:
                 starts.append(s)
                 i_supercrop_in_trials.append(i_supercrop)
                 i_trials.append(onset_i)

--- a/examples/plot_bcic_iv_2a_moabb.py
+++ b/examples/plot_bcic_iv_2a_moabb.py
@@ -68,7 +68,7 @@ dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[1])
 windows_dataset = create_windows_from_events(
     dataset, trial_start_offset_samples=-125, trial_stop_offset_samples=1000,
     supercrop_size_samples=1000, supercrop_stride_samples=n_preds_per_input,
-    drop_samples=False, mapping={1:0, 2:1, 3:2, 4:3})
+    drop_samples=False)
 
 
 class TrainTestBCICIV2aSplit(object):

--- a/examples/plot_bcic_iv_2a_moabb.py
+++ b/examples/plot_bcic_iv_2a_moabb.py
@@ -66,7 +66,7 @@ with torch.no_grad():
 dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[1])
 
 windows_dataset = create_windows_from_events(
-    dataset, trial_start_offset_samples=-125, trial_stop_offset_samples=1000,
+    dataset, trial_start_offset_samples=-125, trial_stop_offset_samples=0,
     supercrop_size_samples=1000, supercrop_stride_samples=n_preds_per_input,
     drop_samples=False)
 

--- a/test/unit_tests/datasets/test_dataset.py
+++ b/test/unit_tests/datasets/test_dataset.py
@@ -51,8 +51,8 @@ def set_up():
 def concat_ds_targets():
     raws, description = fetch_data_with_moabb(
         dataset_name="BNCI2014001", subject_ids=4)
-    events = mne.find_events(raws[0])
-    targets = events[:, -1]
+    events, _ = mne.events_from_annotations(raws[0])
+    targets = events[:, -1] - 1
     ds = [BaseDataset(raws[i], description.iloc[i]) for i in range(3)]
     concat_ds = BaseConcatDataset(ds)
     return concat_ds, targets

--- a/test/unit_tests/datautil/test_windowers.py
+++ b/test/unit_tests/datautil/test_windowers.py
@@ -19,8 +19,8 @@ from braindecode.datautil import (
 def concat_ds_targets():
     raws, description = fetch_data_with_moabb(
         dataset_name="BNCI2014001", subject_ids=4)
-    events = mne.find_events(raws[0])
-    targets = events[:, -1]
+    events, _ = mne.events_from_annotations(raws[0])
+    targets = events[:, -1] - 1
     ds = BaseDataset(raws[0], description.iloc[0])
     concat_ds = BaseConcatDataset([ds])
     return concat_ds, targets

--- a/test/unit_tests/datautil/test_windowers.py
+++ b/test/unit_tests/datautil/test_windowers.py
@@ -30,7 +30,7 @@ def test_one_supercrop_per_original_trial(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=1000,
+        trial_start_offset_samples=0, trial_stop_offset_samples=0,
         supercrop_size_samples=1000, supercrop_stride_samples=1,
         drop_samples=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -42,7 +42,7 @@ def test_stride_has_no_effect(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=1000,
+        trial_start_offset_samples=0, trial_stop_offset_samples=0,
         supercrop_size_samples=1000, supercrop_stride_samples=1000,
         drop_samples=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -54,7 +54,7 @@ def test_trial_start_offset(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-250, trial_stop_offset_samples=250,
+        trial_start_offset_samples=-250, trial_stop_offset_samples=-750,
         supercrop_size_samples=250, supercrop_stride_samples=250,
         drop_samples=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -67,7 +67,7 @@ def test_shifting_last_supercrop_back_in(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-250, trial_stop_offset_samples=250,
+        trial_start_offset_samples=-250, trial_stop_offset_samples=-750,
         supercrop_size_samples=250, supercrop_stride_samples=300,
         drop_samples=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -80,7 +80,7 @@ def test_dropping_last_incomplete_supercrop(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-250, trial_stop_offset_samples=250,
+        trial_start_offset_samples=-250, trial_stop_offset_samples=-750,
         supercrop_size_samples=250, supercrop_stride_samples=300,
         drop_samples=True)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -92,7 +92,7 @@ def test_maximally_overlapping_supercrops(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-2, trial_stop_offset_samples=1000,
+        trial_start_offset_samples=-2, trial_stop_offset_samples=0,
         supercrop_size_samples=1000, supercrop_stride_samples=1,
         drop_samples=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -106,7 +106,7 @@ def test_single_sample_size_supercrops(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=1000,
+        trial_start_offset_samples=0, trial_stop_offset_samples=0,
         supercrop_size_samples=1, supercrop_stride_samples=1,
         drop_samples=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -121,7 +121,7 @@ def test_overlapping_trial_offsets(concat_ds_targets):
                        match='Trial overlap not implemented.'):
         create_windows_from_events(
             concat_ds=concat_ds,
-            trial_start_offset_samples=-2000, trial_stop_offset_samples=1000,
+            trial_start_offset_samples=-2000, trial_stop_offset_samples=0,
             supercrop_size_samples=1000, supercrop_stride_samples=1000,
             drop_samples=False)
 


### PR DESCRIPTION
-windower now expects annotations object to get events
-tests adapted to new annotation object
-removed custom mapping from bcic IV 2a example

The MOABB datasets will now be equipped with the annotations object. The trial onset and duration are set correctly based on information from MOABB.

The annotation object stores the string description of events. Thus, the original mapping is discarded and replaced by a custom one when applying the event windower. By default, the event mapping will start from 0, as requested by training for classification. The mapping is passed to mne.Epochs and stored on windows level.