### PR TITLE
New base model class

### DIFF
--- a/braindecode/models/eegnet.py
+++ b/braindecode/models/eegnet.py
@@ -4,7 +4,7 @@ from torch import nn
 from torch.nn.functional import elu
 
 from .modules import Expression
-
+from .functions import squeeze_final_output
 
 class Conv2dWithConstraint(nn.Conv2d):
     def __init__(self, *args, max_norm=1, **kwargs):
@@ -41,8 +41,8 @@ class EEGNetv4(nn.Sequential):
         self,
         in_chans,
         n_classes,
-        final_conv_length="auto",
         input_time_length=None,
+        final_conv_length="auto",
         pool_mode="mean",
         F1=8,
         D=2,
@@ -54,8 +54,17 @@ class EEGNetv4(nn.Sequential):
         super().__init__()
         if final_conv_length == "auto":
             assert input_time_length is not None
-        self.__dict__.update(locals())
-        del self.self
+        self.in_chans = in_chans
+        self.n_classes = n_classes
+        self.input_time_length = input_time_length
+        self.final_conv_length = final_conv_length
+        self.pool_mode = pool_mode
+        self.F1 = F1
+        self.D = D
+        self.F2 = F2
+        self.kernel_length = kernel_length
+        self.third_kernel_size = third_kernel_size
+        self.drop_prob = drop_prob
 
         pool_class = dict(max=nn.MaxPool2d, mean=nn.AvgPool2d)[self.pool_mode]
         # b c 0 1
@@ -160,7 +169,7 @@ class EEGNetv4(nn.Sequential):
         # Transpose back to the the logic of braindecode,
         # so time in third dimension (axis=2)
         self.add_module("permute_back", Expression(_transpose_1_0))
-        self.add_module("squeeze", Expression(_squeeze_final_output))
+        self.add_module("squeeze", Expression(squeeze_final_output))
 
         _glorot_weight_zero_bias(self)
 
@@ -171,16 +180,6 @@ def _transpose_to_b_1_c_0(x):
 
 def _transpose_1_0(x):
     return x.permute(0, 1, 3, 2)
-
-
-# remove empty dim at end and potentially remove empty time dim
-# do not just use squeeze as we never want to remove first dim
-def _squeeze_final_output(x):
-    assert x.size()[3] == 1
-    x = x[:, :, :, 0]
-    if x.size()[2] == 1:
-        x = x[:, :, 0]
-    return x
 
 
 class EEGNetv1(nn.Sequential):
@@ -206,8 +205,8 @@ class EEGNetv1(nn.Sequential):
         self,
         in_chans,
         n_classes,
-        final_conv_length="auto",
         input_time_length=None,
+        final_conv_length="auto",
         pool_mode="max",
         second_kernel_size=(2, 32),
         third_kernel_size=(8, 4),
@@ -218,8 +217,8 @@ class EEGNetv1(nn.Sequential):
             assert input_time_length is not None
         self.in_chans = in_chans
         self.n_classes = n_classes
-        self.final_conv_length = final_conv_length
         self.input_time_length = input_time_length
+        self.final_conv_length = final_conv_length
         self.pool_mode = pool_mode
         self.second_kernel_size = second_kernel_size
         self.third_kernel_size = third_kernel_size
@@ -246,7 +245,7 @@ class EEGNetv1(nn.Sequential):
         n_filters_2 = 4
         # keras padds unequal padding more in front, so padding
         # too large should be ok.
-        # Not padding in time so that croped training makes sense
+        # Not padding in time so that cropped training makes sense
         # https://stackoverflow.com/questions/43994604/padding-with-even-kernel-size-in-a-convolutional-layer-in-keras-theano
 
         self.add_module(
@@ -315,12 +314,12 @@ class EEGNetv1(nn.Sequential):
         self.add_module(
             "permute_2", Expression(lambda x: x.permute(0, 1, 3, 2))
         )
-        self.add_module("squeeze", Expression(_squeeze_final_output))
+        self.add_module("squeeze", Expression(squeeze_final_output))
         _glorot_weight_zero_bias(self)
 
-
 def _glorot_weight_zero_bias(model):
-    """Initalize parameters of all modules by initializing weights with glorot
+    """Initalize parameters of all modules by initializing weights with
+    glorot
      uniform/xavier initialization, and setting biases to zero. Weights from
      batch norm layers are set to 1.
 

--- a/braindecode/models/functions.py
+++ b/braindecode/models/functions.py
@@ -1,5 +1,4 @@
 import torch
-import torch as th
 
 
 def square(x):
@@ -8,7 +7,7 @@ def square(x):
 
 def safe_log(x, eps=1e-6):
     """ Prevents :math:`log(0)` by using :math:`log(max(x, eps))`."""
-    return th.log(th.clamp(x, min=eps))
+    return torch.log(torch.clamp(x, min=eps))
 
 
 def identity(x):

--- a/braindecode/models/functions.py
+++ b/braindecode/models/functions.py
@@ -1,3 +1,4 @@
+import torch
 import torch as th
 
 
@@ -12,3 +13,32 @@ def safe_log(x, eps=1e-6):
 
 def identity(x):
     return x
+
+
+def squeeze_final_output(x):
+    """Removes empty dimension at end and potentially removes empty time
+     dimension. It does  not just use squeeze as we never want to remove
+     first dimension.
+
+    Returns
+    -------
+    x: torch.Tensor
+        squeezed tensor
+    """
+
+    assert x.size()[3] == 1
+    x = x[:, :, :, 0]
+    if x.size()[2] == 1:
+        x = x[:, :, 0]
+    return x
+
+
+def transpose_time_to_spat(x):
+    """Swap time and spatial dimensions.
+
+    Returns
+    -------
+    x: torch.Tensor
+        tensor in which last and first dimensions are swapped
+    """
+    return x.permute(0, 3, 2, 1)

--- a/braindecode/models/hybrid.py
+++ b/braindecode/models/hybrid.py
@@ -3,8 +3,8 @@ from torch import nn
 from torch.nn import ConstantPad2d
 
 from .deep4 import Deep4Net
-from .shallow_fbcsp import ShallowFBCSPNet
 from .util import to_dense_prediction_model
+from .shallow_fbcsp import ShallowFBCSPNet
 
 
 class HybridNet(nn.Module):

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -57,10 +57,10 @@ def get_output_shape(model, in_chans, input_time_length):
         shape of the network output for `batch_size==1` (1, ...)
     """
     with torch.no_grad():
-        dummy_input = torch.tensor(
-            np.ones((1, in_chans, input_time_length, 1),
-                    dtype=np.float32),
-            device=next(model.parameters()).device.type,
+        dummy_input = torch.ones(
+            1, in_chans, input_time_length, 1,
+            dtype=next(model.parameters()).dtype,
+            device=next(model.parameters()).device,
         )
         output_shape = model(dummy_input).shape
     return output_shape

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -1,3 +1,4 @@
+import torch
 import numpy as np
 
 
@@ -9,7 +10,8 @@ def to_dense_prediction_model(model, axis=(2, 3)):
 
     Parameters
     ----------
-    model
+    model: torch.nn.Module
+        Model which modules will be modified
     axis: int or (int,int)
         Axis to transform (in terms of intermediate output axes)
         can either be 2, 3, or (2,3).
@@ -44,3 +46,21 @@ def to_dense_prediction_model(model, axis=(2, 3)):
             for ax in axis:
                 new_stride[ax] = 1
             module.stride = tuple(new_stride)
+
+
+def get_output_shape(model, in_chans, input_time_length):
+    """Returns shape of neural network output for batch size equal 1.
+
+    Returns
+    -------
+    output_shape: tuple
+        shape of the network output for `batch_size==1` (1, ...)
+    """
+    with torch.no_grad():
+        dummy_input = torch.tensor(
+            np.ones((1, in_chans, input_time_length, 1),
+                    dtype=np.float32),
+            device=next(model.parameters()).device.type,
+        )
+        output_shape = model(dummy_input).shape
+    return output_shape

--- a/examples/bcic_iv_2a_cropped.py
+++ b/examples/bcic_iv_2a_cropped.py
@@ -22,8 +22,8 @@ from braindecode.datautil.splitters import TrainTestSplit
 from braindecode.datautil.trial_segment import create_signal_target_from_raw_mne
 from braindecode.losses import CroppedNLLLoss
 from braindecode.models.deep4 import Deep4Net
+from braindecode.models.util import to_dense_prediction_model, get_output_shape
 from braindecode.models.shallow_fbcsp import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model
 from braindecode.scoring import CroppedTrialEpochScoring
 from braindecode.util import set_random_seeds
 
@@ -112,13 +112,7 @@ to_dense_prediction_model(model)
 if cuda:
     model.cuda()
 
-with torch.no_grad():
-    dummy_input = torch.Tensor(
-        train_set.X[:1, :, :input_time_length], device="cpu"
-    )
-    n_preds_per_input = model(dummy_input).shape[2]
-
-out = model(dummy_input)
+n_preds_per_input = get_output_shape(model, n_chans, input_time_length)[2]
 
 train_set = CroppedXyDataset(
     train_set.X, train_set.y,

--- a/examples/plot_bcic_iv_2a_moabb.py
+++ b/examples/plot_bcic_iv_2a_moabb.py
@@ -15,6 +15,9 @@ from functools import partial
 import numpy as np
 import torch
 import mne
+
+from braindecode.models.util import to_dense_prediction_model, get_output_shape
+
 mne.set_log_level('ERROR')
 
 from braindecode.datautil.windowers import create_windows_from_events
@@ -23,7 +26,6 @@ from braindecode.datasets import MOABBDataset
 from braindecode.losses import CroppedNLLLoss
 from braindecode.models.deep4 import Deep4Net
 from braindecode.models.shallow_fbcsp import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model
 from braindecode.scoring import CroppedTrialEpochScoring
 from braindecode.util import set_random_seeds
 from braindecode.datautil.signalproc import exponential_running_standardize
@@ -66,15 +68,12 @@ elif model_name == "deep":
         final_conv_length=2,
     )
 
-to_dense_prediction_model(model)
-
 if cuda:
     model.cuda()
 
-with torch.no_grad():
-    dummy_input = torch.ones(
-        1, n_chans, input_time_length, 1, dtype=torch.float32, device=device)
-    n_preds_per_input = model(dummy_input).shape[2]
+to_dense_prediction_model(model)
+
+n_preds_per_input = get_output_shape(model, n_chans, input_time_length)[2]
 
 dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[subject_id])
 

--- a/examples/plot_skorch_crop_decoding.py
+++ b/examples/plot_skorch_crop_decoding.py
@@ -14,7 +14,6 @@ Example using Skorch for crop decoding on a simpler dataset.
 
 import mne
 import numpy as np
-import torch
 from mne.io import concatenate_raws
 from torch import optim
 
@@ -23,7 +22,7 @@ from braindecode.datasets.croppedxy import CroppedXyDataset
 from braindecode.datautil.splitters import TrainTestSplit
 from braindecode.losses import CroppedNLLLoss
 from braindecode.models import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model
+from braindecode.models.util import to_dense_prediction_model, get_output_shape
 from braindecode.scoring import CroppedTrialEpochScoring
 from braindecode.util import set_random_seeds
 
@@ -88,7 +87,6 @@ n_classes = 2
 in_chans = X.shape[1]
 
 
-
 set_random_seeds(20200114, cuda=False)
 
 # final_conv_length = auto ensures we only get a single output in the time dimension
@@ -105,10 +103,7 @@ if cuda:
 input_time_length = X.shape[2]
 
 # Perform forward pass to determine how many outputs per input
-with torch.no_grad():
-    dummy_input = torch.tensor(X[:1, :, :input_time_length, None], device="cpu")
-    n_preds_per_input = model(dummy_input).shape[2]
-
+n_preds_per_input = get_output_shape(model, in_chans, input_time_length)[2]
 
 train_set = CroppedXyDataset(X[:70], y[:70],
                        input_time_length=input_time_length,

--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -13,9 +13,9 @@ from mne.io import concatenate_raws
 from torch import optim
 
 from braindecode.datautil.iterators import CropsFromTrialsIterator
+from braindecode.models.util import to_dense_prediction_model
 from braindecode.monitors import compute_preds_per_trial_from_crops
 from braindecode.models import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model
 from braindecode.util import set_random_seeds
 from braindecode.util import var_to_np, np_to_var
 

--- a/test/acceptance_tests/test_eeg_classifier.py
+++ b/test/acceptance_tests/test_eeg_classifier.py
@@ -57,7 +57,7 @@ def assert_deep_allclose(expected, actual, *args, **kwargs):
     except AssertionError as exc:
         exc.__dict__.setdefault("traces", []).append(trace)
         msg = (
-            err.message
+            exc.message
             if hasattr(exc, "message")
             else exc.args[0]
             if exc.args


### PR DESCRIPTION
I looked a little bit at the example code (I wanted to do #48 but I started looking at the example and I've seen output shape inferring and then `to_dense_prediction_model` function which modifies model in place. Both things to me look strange, so I started with removing those two parts).

In my opinion, the only way to remove it is to create one more class from which all models should inherit. This class inherits from `torch.nn.Sequential`, so it should not add too much complexity. Everything in the models stays pretty the same. Now `Model` class implements `to_dense_prediciton`, so in the example instead of calling `to_dense_prediction_model(model)` we call `model.to_dense_prediction()`, which is more an aesthetic change. In the `Model` there is also `output_shape` property that computes nn output shape. I moved also squeezing and time/spatial transposition to this class, as almost all models used it and it was defined many times in different places.

One more thing I changed is reading the parameters in models `__init__` as it was done by hacky deleting of `self`. Now it is done in a standard way. 

Let me know what do you think about adding the `Model` class. Do you think that in the future there should be more stuff to put it inside this class?
