### PR TITLE
Faster dataset iteration through precomputed target/index

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -74,13 +74,6 @@ class WindowsDataset(BaseDataset):
         # three tensors from batch, otherwise get single 2d-tensor...
         crop_inds = list(self.crop_inds[index])
         return X, y, crop_inds
-        # Alternative, using pandas metadata (~1.5 slower on my machine)
-        # (robintibor@gmail.com):
-        # y = self.windows.metadata.at[index, 'target']
-        # index = [self.windows.metadata.at[index, i] for i in
-        #     ['i_supercrop_in_trial', 'i_start_in_trial',
-        #      'i_stop_in_trial']]
-        # return X, y, index
 
     def __len__(self):
         return len(self.windows.events)

--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -6,9 +6,11 @@ Dataset classes.
 #          Lukas Gemein <l.gemein@gmail.com>
 #          Simon Brandt <simonbrandt@protonmail.com>
 #          David Sabbagh <dav.sabbagh@gmail.com>
+#          Robin Schirrmeister <robintibor@gmail.com>
 #
 # License: BSD (3-clause)
 
+import numpy as np
 import pandas as pd
 
 from torch.utils.data import Dataset, ConcatDataset
@@ -60,13 +62,25 @@ class WindowsDataset(BaseDataset):
     def __init__(self, windows, description):
         self.windows = windows
         self.description = description
+        self.y = np.array(self.windows.metadata.loc[:,'target'])
+        self.crop_inds = np.array(self.windows.metadata.loc[:,
+                              ['i_supercrop_in_trial', 'i_start_in_trial',
+                               'i_stop_in_trial']])
 
     def __getitem__(self, index):
-        x = self.windows.get_data(item=index)[0].astype('float32')
-        md = self.windows.metadata.iloc[index]
-        return x, md['target'], md[
-            ['i_supercrop_in_trial', 'i_start_in_trial',
-             'i_stop_in_trial']].to_list()
+        X = self.windows.get_data(item=index)[0].astype('float32')
+        y = self.y[index]
+        # necessary to cast as list to get list of
+        # three tensors from batch, otherwise get single 2d-tensor...
+        crop_inds = list(self.crop_inds[index])
+        return X, y, crop_inds
+        # Alternative, using pandas metadata (~1.5 slower on my machine)
+        # (robintibor@gmail.com):
+        # y = self.windows.metadata.at[index, 'target']
+        # index = [self.windows.metadata.at[index, i] for i in
+        #     ['i_supercrop_in_trial', 'i_start_in_trial',
+        #      'i_stop_in_trial']]
+        # return X, y, index
 
     def __len__(self):
         return len(self.windows.events)


### PR DESCRIPTION
Make sure our dataset iteration is fast enough, especially in case of `preload=True`. 

I noticed there is a substantial slowdown through `windows.metadata.iloc[index]` call. There are quite a [lot](https://stackoverflow.com/questions/28757389/pandas-loc-vs-iloc-vs-ix-vs-at-vs-iat) [of](https://stackoverflow.com/questions/27596832/why-is-dataframe-loc1-1-800x-slower-than-df-ix-1-and-3-500x-than-df-loc) [discussions](https://github.com/pandas-dev/pandas/issues/6683) [online](https://www.google.com/search?client=ubuntu&hs=pah&channel=fs&sxsrf=ALeKk02ANKr_FE7zt0BE721LGx7k79pLWA%3A1582891063897&ei=NwBZXuG8NoadlwTeuJiAAw&q=iloc+call+slow%3F&oq=iloc+call+slow%3F&gs_l=psy-ab.3...2321.2321..3296...0.2..0.65.65.1......0....1..gws-wiz.......0i71.HQBZ5ziAUeE&ved=0ahUKEwihtNPcmPTnAhWGzoUKHV4cBjAQ4dUDCAo&uact=5) about this. 
So for now I store the targets and crop indices as numpy arrays on window dataset creation. Overall speedup of entire skorch run on BCIC IV 2a on my machine through these changes is more than factor 7!