### PR TITLE
trialwise and cropped test decoding rewritten to use new model API, EpochsDataset…

### DIFF
--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -5,13 +5,14 @@
 
 import mne
 import numpy as np
+import torch
 from mne.io import concatenate_raws
 from skorch.helper import predefined_split
 from torch import optim
 
 from braindecode import EEGClassifier
 from braindecode.datasets.croppedxy import CroppedXyDataset
-from braindecode.losses import CroppedNLLLoss
+from braindecode.losses import CroppedLoss
 from braindecode.models import ShallowFBCSPNet
 from braindecode.models.util import to_dense_prediction_model, get_output_shape
 from braindecode.util import set_random_seeds
@@ -98,7 +99,8 @@ def test_cropped_decoding():
     clf = EEGClassifier(
         model,
         cropped=True,
-        criterion=CroppedNLLLoss,
+        criterion=CroppedLoss,
+        criterion__loss_function=torch.nn.functional.nll_loss,
         optimizer=optim.Adam,
         train_split=train_split,
         batch_size=32,

--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -132,7 +132,7 @@ def test_cropped_decoding():
             ]
         ),
         rtol=1e-4,
-        atol=1e-5,
+        atol=1e-4,
     )
     np.testing.assert_allclose(
         clf.history[:, 'train_accuracy'],

--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -3,119 +3,18 @@
 #
 # License: BSD-3
 
-from collections import namedtuple
-
 import mne
 import numpy as np
-import torch as th
-import torch.nn.functional as F
 from mne.io import concatenate_raws
+from skorch.helper import predefined_split
 from torch import optim
 
-from braindecode.datautil.iterators import CropsFromTrialsIterator
-from braindecode.models.util import to_dense_prediction_model
+from braindecode import EEGClassifier
+from braindecode.datasets.croppedxy import CroppedXyDataset
+from braindecode.losses import CroppedNLLLoss
 from braindecode.models import ShallowFBCSPNet
+from braindecode.models.util import to_dense_prediction_model, get_output_shape
 from braindecode.util import set_random_seeds
-from braindecode.util import var_to_np, np_to_var
-
-
-def _compute_preds_per_trial_from_crops(all_preds, input_time_length, X):
-    """
-    Compute predictions per trial from predictions for crops.
-
-    Parameters
-    ----------
-    all_preds: list of 2darrays (classes x time)
-        All predictions for the crops.
-    input_time_length: int
-        Temporal length of one input to the model.
-    X: ndarray
-        Input tensor the crops were taken from.
-
-    Returns
-    -------
-    preds_per_trial: list of 2darrays (classes x time)
-        Predictions for each trial, without overlapping predictions.
-    """
-    trial_n_samples = [trial.shape[1] for trial in X]
-    return _compute_preds_per_trial_from_trial_n_samples(
-        all_preds, input_time_length, trial_n_samples
-    )
-
-
-def _compute_preds_per_trial_from_trial_n_samples(
-    all_preds, input_time_length, trial_n_samples
-):
-    """
-        Compute predictions per trial from predictions for supercrops.
-        Collect supercrop predictions into trials the supercrops
-        were extracted from, remove duplicates.
-        Parameters
-        ----------
-        all_preds: list of 2darrays (classes x time)
-            All predictions for the crops.
-        input_time_length: int
-            Temporal length of one input to the model.
-        trial_n_samples: ndarray or list of int
-            Number of samples for each trial.
-        Returns
-        -------
-        preds_per_trial: list of 2darrays (classes x time)
-            Predictions for each trial, without overlapping predictions.
-        """
-    n_preds_per_input = all_preds[0].shape[2]
-    n_receptive_field = input_time_length - n_preds_per_input + 1
-    n_preds_per_trial = [
-        n_samples - n_receptive_field + 1 for n_samples in trial_n_samples
-    ]
-    preds_per_trial = _compute_preds_per_trial_from_n_preds_per_trial(
-        all_preds, n_preds_per_trial
-    )
-    return preds_per_trial
-
-
-def _compute_preds_per_trial_from_n_preds_per_trial(
-    all_preds, n_preds_per_trial
-):
-    """
-    Compute predictions per trial from predictions for crops.
-    Parameters
-    ----------
-    all_preds: list of 2darrays (classes x time)
-        All predictions for the crops.
-    input_time_length: int
-        Temporal length of one input to the model.
-    n_preds_per_trial: list of int
-        Number of predictions for each trial.
-    Returns
-    -------
-    preds_per_trial: list of 2darrays (classes x time)
-        Predictions for each trial, without overlapping predictions.
-    """
-    # all_preds_arr has shape forward_passes x classes x time
-    all_preds_arr = np.concatenate(all_preds, axis=0)
-    preds_per_trial = []
-    i_pred_block = 0
-    for n_needed_preds in n_preds_per_trial:
-        preds_this_trial = []
-        while n_needed_preds > 0:
-            # - n_needed_preds: only has an effect
-            # in case there are more samples than we actually still need
-            # in the block.
-            # That can happen since final block of a trial can overlap
-            # with block before so we can have some redundant preds.
-            pred_samples = all_preds_arr[i_pred_block, :, -n_needed_preds:]
-            preds_this_trial.append(pred_samples)
-            n_needed_preds -= pred_samples.shape[1]
-            i_pred_block += 1
-
-        preds_this_trial = np.concatenate(preds_this_trial, axis=1)
-        preds_per_trial.append(preds_this_trial)
-    assert i_pred_block == len(all_preds_arr), (
-        "Expect that all prediction forward passes are needed, "
-        "used {:d}, existing {:d}".format(i_pred_block, len(all_preds_arr))
-    )
-    return preds_per_trial
 
 
 def test_cropped_decoding():
@@ -142,7 +41,6 @@ def test_cropped_decoding():
 
     # Find the events in this dataset
     events, _ = mne.events_from_annotations(raw)
-
     # Use only EEG channels
     eeg_channel_inds = mne.pick_types(
         raw.info, meg=False, eeg=True, stim=False, eog=False, exclude="bads"
@@ -165,11 +63,6 @@ def test_cropped_decoding():
     X = (epoched.get_data() * 1e6).astype(np.float32)
     y = (epoched.events[:, 2] - 2).astype(np.int64)  # 2,3 -> 0,1
 
-    SignalAndTarget = namedtuple("SignalAndTarget", "X y")
-
-    train_set = SignalAndTarget(X[:60], y=y[:60])
-    test_set = SignalAndTarget(X[60:], y=y[60:])
-
     # Set if you want to use GPU
     # You can also use torch.cuda.is_available() to determine if cuda is available on your machine.
     cuda = False
@@ -178,7 +71,7 @@ def test_cropped_decoding():
     # This will determine how many crops are processed in parallel
     input_time_length = 450
     n_classes = 2
-    in_chans = train_set.X.shape[1]
+    in_chans = X.shape[1]
     # final_conv_length determines the size of the receptive field of the ConvNet
     model = ShallowFBCSPNet(
         in_chans=in_chans,
@@ -191,121 +84,77 @@ def test_cropped_decoding():
     if cuda:
         model.cuda()
 
-    optimizer = optim.Adam(model.parameters())
-    # determine output size
-    test_input = np_to_var(
-        np.ones((2, in_chans, input_time_length, 1), dtype=np.float32)
-    )
-    if cuda:
-        test_input = test_input.cuda()
-    out = model(test_input)
-    n_preds_per_input = out.cpu().data.numpy().shape[2]
-    print("{:d} predictions per input/trial".format(n_preds_per_input))
+    # Perform forward pass to determine how many outputs per input
+    n_preds_per_input = get_output_shape(model, in_chans, input_time_length)[2]
 
-    iterator = CropsFromTrialsIterator(
+    train_set = CroppedXyDataset(X[:60], y[:60],
+                                 input_time_length=input_time_length,
+                                 n_preds_per_input=n_preds_per_input)
+    valid_set = CroppedXyDataset(X[60:], y=y[60:],
+                                 input_time_length=input_time_length,
+                                 n_preds_per_input=n_preds_per_input)
+    train_split = predefined_split(valid_set)
+
+    clf = EEGClassifier(
+        model,
+        cropped=True,
+        criterion=CroppedNLLLoss,
+        optimizer=optim.Adam,
+        train_split=train_split,
         batch_size=32,
-        input_time_length=input_time_length,
-        n_preds_per_input=n_preds_per_input,
+        callbacks=['accuracy'],
     )
 
-    losses = []
-    accuracies = []
-    for i_epoch in range(4):
-        # Set model to training mode
-        model.train()
-        for batch_X, batch_y in iterator.get_batches(train_set, shuffle=False):
-            net_in = np_to_var(batch_X)
-            if cuda:
-                net_in = net_in.cuda()
-            net_target = np_to_var(batch_y)
-            if cuda:
-                net_target = net_target.cuda()
-            # Remove gradients of last backward pass from all parameters
-            optimizer.zero_grad()
-            outputs = model(net_in)
-            # Mean predictions across trial
-            # Note that this will give identical gradients to computing
-            # a per-prediction loss (at least for the combination of log softmax activation
-            # and negative log likelihood loss which we are using here)
-            outputs = th.mean(outputs, dim=2, keepdim=False)
-            loss = F.nll_loss(outputs, net_target)
-            loss.backward()
-            optimizer.step()
+    clf.fit(train_set, y=None, epochs=4)
 
-        # Print some statistics each epoch
-        model.eval()
-        print("Epoch {:d}".format(i_epoch))
-        for setname, dataset in (("Train", train_set), ("Test", test_set)):
-            # Collect all predictions and losses
-            all_preds = []
-            all_losses = []
-            batch_sizes = []
-            for batch_X, batch_y in iterator.get_batches(
-                dataset, shuffle=False
-            ):
-                net_in = np_to_var(batch_X)
-                if cuda:
-                    net_in = net_in.cuda()
-                net_target = np_to_var(batch_y)
-                if cuda:
-                    net_target = net_target.cuda()
-                outputs = model(net_in)
-                all_preds.append(var_to_np(outputs))
-                outputs = th.mean(outputs, dim=2, keepdim=False)
-                loss = F.nll_loss(outputs, net_target)
-                loss = float(var_to_np(loss))
-                all_losses.append(loss)
-                batch_sizes.append(len(batch_X))
-            # Compute mean per-input loss
-            loss = np.mean(
-                np.array(all_losses)
-                * np.array(batch_sizes)
-                / np.mean(batch_sizes)
-            )
-            print("{:6s} Loss: {:.5f}".format(setname, loss))
-            losses.append(loss)
-            # Assign the predictions to the trials
-            preds_per_trial = _compute_preds_per_trial_from_crops(
-                all_preds, input_time_length, dataset.X
-            )
-            # preds per trial are now trials x classes x timesteps/predictions
-            # Now mean across timesteps for each trial to get per-trial predictions
-            meaned_preds_per_trial = np.array(
-                [np.mean(p, axis=1) for p in preds_per_trial]
-            )
-            predicted_labels = np.argmax(meaned_preds_per_trial, axis=1)
-            accuracy = np.mean(predicted_labels == dataset.y)
-            accuracies.append(accuracy * 100)
-            print("{:6s} Accuracy: {:.1f}%".format(setname, accuracy * 100))
     np.testing.assert_allclose(
-        np.array(losses),
+        clf.history[:, 'train_loss'],
         np.array(
             [
-                1.31657708,
-                1.73548156,
-                1.02950428,
-                1.43932164,
-                0.78677772,
-                1.12382019,
-                0.55920881,
-                0.87277424,
+                1.455306,
+                1.455934,
+                1.210563,
+                1.065806
+            ]
+        ),
+        rtol=1e-4,
+        atol=1e-5,
+    )
+
+    np.testing.assert_allclose(
+        clf.history[:, 'valid_loss'],
+        np.array(
+            [
+                2.547288,
+                1.51785,
+                1.394036,
+                1.064355
             ]
         ),
         rtol=1e-4,
         atol=1e-5,
     )
     np.testing.assert_allclose(
-        np.array(accuracies),
+        clf.history[:, 'train_accuracy'],
         np.array(
             [
-                50.0,
-                46.66666667,
-                50.0,
-                46.66666667,
-                50.0,
-                46.66666667,
-                66.66666667,
-                50.0,
+                0.5,
+                0.5,
+                0.5,
+                0.533333
+            ]
+        ),
+        rtol=1e-4,
+        atol=1e-5,
+    )
+    np.testing.assert_allclose(
+        clf.history[:, 'valid_accuracy'],
+        np.array(
+            [
+                0.533333,
+                0.466667,
+                0.533333,
+                0.5
             ]
         ),
         rtol=1e-4,

--- a/test/acceptance_tests/test_trialwise_decoding.py
+++ b/test/acceptance_tests/test_trialwise_decoding.py
@@ -105,7 +105,6 @@ def test_trialwise_decoding():
         optimizer=torch.optim.Adam,
         train_split=train_valid_split,
         optimizer__lr=0.001,
-        iterator_train__shuffle=True,
         batch_size=30,
         callbacks=["accuracy"],
         device=device,

--- a/test/acceptance_tests/test_trialwise_decoding.py
+++ b/test/acceptance_tests/test_trialwise_decoding.py
@@ -3,18 +3,31 @@
 #
 # License: BSD-3
 
-from collections import namedtuple
-
 import mne
 import numpy as np
-import torch.nn.functional as F
+import torch
 from mne.io import concatenate_raws
-from numpy.random import RandomState
-from torch import optim
+from skorch.helper import predefined_split
+from torch.utils.data import Dataset, Subset
 
+from braindecode.classifier import EEGClassifier
 from braindecode.models import ShallowFBCSPNet
-from braindecode.util import np_to_var, var_to_np, get_balanced_batches
 from braindecode.util import set_random_seeds
+
+
+class EpochsDataset(Dataset):
+    def __init__(self, windows):
+        self.windows = windows
+        self.y = np.array(self.windows.events[:, -1])
+        self.y = self.y - self.y.min()
+
+    def __getitem__(self, index):
+        X = self.windows.get_data(item=index)[0].astype('float32')[:, :, None]
+        y = self.y[index]
+        return X, y
+
+    def __len__(self):
+        return len(self.windows.events)
 
 
 def test_trialwise_decoding():
@@ -38,6 +51,7 @@ def test_trialwise_decoding():
 
     # Concatenate them
     raw = concatenate_raws(parts)
+    raw.apply_function(lambda x: x * 1000000)
 
     # Find the events in this dataset
     events, _ = mne.events_from_annotations(raw)
@@ -59,125 +73,94 @@ def test_trialwise_decoding():
         preload=True,
     )
 
-    # Convert data from volt to millivolt
-    # Pytorch expects float32 for input and int64 for labels.
-    X = (epoched.get_data() * 1e6).astype(np.float32)
-    y = (epoched.events[:, 2] - 2).astype(np.int64)  # 2,3 -> 0,1
+    ds = EpochsDataset(epoched)
 
-    SignalAndTarget = namedtuple("SignalAndTarget", "X y")
+    train_set = Subset(ds, np.arange(60))
+    valid_set = Subset(ds, np.arange(60, len(ds)))
 
-    train_set = SignalAndTarget(X[:60], y=y[:60])
-    test_set = SignalAndTarget(X[60:], y=y[60:])
+    train_valid_split = predefined_split(valid_set)
 
-    # Set if you want to use GPU
-    # You can also use torch.cuda.is_available() to determine if cuda is available on your machine.
     cuda = False
+    if cuda:
+        device = 'cuda'
+    else:
+        device = 'cpu'
     set_random_seeds(seed=20170629, cuda=cuda)
     n_classes = 2
-    in_chans = train_set.X.shape[1]
-    # final_conv_length = auto ensures we only get a single output in the time dimension
+    in_chans = train_set[0][0].shape[0]
+    input_time_length = train_set[0][0].shape[1]
     model = ShallowFBCSPNet(
         in_chans=in_chans,
         n_classes=n_classes,
-        input_time_length=train_set.X.shape[2],
+        input_time_length=input_time_length,
         final_conv_length="auto",
     )
     if cuda:
         model.cuda()
 
-    optimizer = optim.Adam(model.parameters())
-
-    rng = RandomState((2017, 6, 30))
-    losses = []
-    accuracies = []
-    for i_epoch in range(6):
-        i_trials_in_batch = get_balanced_batches(
-            len(train_set.X), rng, shuffle=True, batch_size=30
-        )
-        # Set model to training mode
-        model.train()
-        for i_trials in i_trials_in_batch:
-            # Have to add empty fourth dimension to X
-            batch_X = train_set.X[i_trials][:, :, :, None]
-            batch_y = train_set.y[i_trials]
-            net_in = np_to_var(batch_X)
-            if cuda:
-                net_in = net_in.cuda()
-            net_target = np_to_var(batch_y)
-            if cuda:
-                net_target = net_target.cuda()
-            # Remove gradients of last backward pass from all parameters
-            optimizer.zero_grad()
-            # Compute outputs of the network
-            outputs = model(net_in)
-            # Compute the loss
-            loss = F.nll_loss(outputs, net_target)
-            # Do the backpropagation
-            loss.backward()
-            # Update parameters with the optimizer
-            optimizer.step()
-
-        # Print some statistics each epoch
-        model.eval()
-        print("Epoch {:d}".format(i_epoch))
-        for setname, dataset in (("Train", train_set), ("Test", test_set)):
-            # Here, we will use the entire dataset at once, which is still possible
-            # for such smaller datasets. Otherwise we would have to use batches.
-            net_in = np_to_var(dataset.X[:, :, :, None])
-            if cuda:
-                net_in = net_in.cuda()
-            net_target = np_to_var(dataset.y)
-            if cuda:
-                net_target = net_target.cuda()
-            outputs = model(net_in)
-            loss = F.nll_loss(outputs, net_target)
-            losses.append(float(var_to_np(loss)))
-            print("{:6s} Loss: {:.5f}".format(setname, float(var_to_np(loss))))
-            predicted_labels = np.argmax(var_to_np(outputs), axis=1)
-            accuracy = np.mean(dataset.y == predicted_labels)
-            accuracies.append(accuracy * 100)
-            print("{:6s} Accuracy: {:.1f}%".format(setname, accuracy * 100))
+    clf = EEGClassifier(
+        model,
+        cropped=False,
+        criterion=torch.nn.NLLLoss,
+        optimizer=torch.optim.Adam,
+        train_split=train_valid_split,
+        optimizer__lr=0.001,
+        iterator_train__shuffle=True,
+        batch_size=30,
+        callbacks=["accuracy"],
+        device=device,
+    )
+    clf.fit(train_set, y=None, epochs=6)
 
     np.testing.assert_allclose(
-        np.array(losses),
-        np.array(
-            [
-                0.91796708,
-                1.2714895,
-                0.4999536,
-                0.94365239,
-                0.39268905,
-                0.89928466,
-                0.37648854,
-                0.8940345,
-                0.35774994,
-                0.86749417,
-                0.35080773,
-                0.80767328,
-            ]
-        ),
+        clf.history[:, 'train_loss'],
+        np.array([
+            1.1114974617958069,
+            1.0976492166519165,
+            0.668171226978302,
+            0.5880511999130249,
+            0.7054798305034637,
+            0.5272344648838043
+        ]),
         rtol=1e-4,
         atol=1e-5,
     )
-
     np.testing.assert_allclose(
-        np.array(accuracies),
-        np.array(
-            [
-                55.0,
-                63.33333333,
-                71.66666667,
-                63.33333333,
-                81.66666667,
-                60.0,
-                78.33333333,
-                63.33333333,
-                83.33333333,
-                66.66666667,
-                80.0,
-                66.66666667,
-            ]
-        ),
+        clf.history[:, 'valid_loss'],
+        np.array([
+            0.8467752933502197,
+            0.9804958701133728,
+            0.9134824872016907,
+            0.8305345773696899,
+            0.8263336420059204,
+            0.8535978198051453
+        ]),
+        rtol=1e-4,
+        atol=1e-5,
+    )
+    np.testing.assert_allclose(
+        clf.history[:, 'train_accuracy'],
+        np.array([
+            0.7166666666666667,
+            0.6666666666666666,
+            0.85,
+            0.9333333333333333,
+            0.9166666666666666,
+            0.9
+        ]),
+        rtol=1e-4,
+        atol=1e-5,
+    )
+    np.testing.assert_allclose(
+        clf.history[:, 'valid_accuracy'],
+        np.array([
+            0.6,
+            0.5666666666666667,
+            0.5333333333333333,
+            0.5333333333333333,
+            0.6,
+            0.6666666666666666
+        ]),
         rtol=1e-4,
         atol=1e-5,
     )


### PR DESCRIPTION
#97 
I've tried to rewrite the `test/acceptance_tests/test_trialwise_decoding.py`. It does not reproduce the same results as the old test. I couldn't make skorch give the same results (even if I took exactly the same net and made batches sampling the same) as the previous code. Below there is a comparison of results, it is probably not really significant as the dataset contains only 60 observations, so I don't know if we should care a lot.
![image](https://user-images.githubusercontent.com/11686357/77862892-9c97c980-721e-11ea-999f-6264d9abdba7.png)
Epochs on x-axis.
 @robintibor let me know if you agree that current flow does not have to reproduce previous results.

One more thing is that I wanted to use the same dataset as in the previous test, so I had to read raw files with mne, then create epochs and pass it to the fit method. To do this I created a small dataset class implementing sampling from `mne.Epochs` object. `mne.Epochs` object as it is the simplest way to integrate with any different dataset that is now not implemented in braindecode. Code of the class is below (If you think it may be helpful we can add it to braindecode Dataset):
```python
import numpy as np
from torch.utils.data import Dataset
class EpochsDataset(Dataset):
    def __init__(self, windows):
        self.windows = windows
        self.y = np.array(self.windows.events[:, -1])
        self.y = self.y - self.y.min()

    def __getitem__(self, index):
        X = self.windows.get_data(item=index)[0].astype('float32')[:, :, None]
        y = self.y[index]
        return X, y

    def __len__(self):
        return len(self.windows.events)
````
Next thing will be to change reading data to use braindecode datasets but for now I can't do this - I need to spend more time on it as I get some errors. When I confirm that it's not my fault I will let you know where the problem is.