### PR TITLE
Windowers events bug fix

### DIFF
--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -219,7 +219,8 @@ def get_balanced_batches(
 
 
 def create_mne_dummy_raw(n_channels, n_times, sfreq, include_anns=True,
-                         savedir=None, save_format='fif', overwrite=True):
+                         description=None, savedir=None, save_format='fif',
+                         overwrite=True):
     """Create an mne.io.RawArray with fake data, and optionally save it.
 
     This will overwrite already existing files.
@@ -234,6 +235,9 @@ def create_mne_dummy_raw(n_channels, n_times, sfreq, include_anns=True,
         Sampling frequency.
     include_anns : bool
         If True, also create annotations.
+    description : list | None
+        List of descriptions used for creating annotations. It should contain
+        10 elements.
     savedir : str | None
         If provided as a string, the file will be saved under that directory.
     save_format : str | list
@@ -260,7 +264,8 @@ def create_mne_dummy_raw(n_channels, n_times, sfreq, include_anns=True,
             int(sfreq * 2), int(n_times - sfreq * 2), num=n_anns).astype(int)
         onset = raw.times[inds]
         duration = [1] * n_anns
-        description = ['test'] * n_anns
+        if description is None:
+            description = ['test'] * n_anns
         anns = mne.Annotations(onset, duration, description)
         raw = raw.set_annotations(anns)
 


### PR DESCRIPTION
I wanted to use `PhysionetMI` dataset and I found a bug in `create_windows_from_events` I tried to fix it, let me know if it's ok for you. 

1.  `create_windows_from_events` function assumed that all events appear in all datasets which may be not true. If `mapping` parameter was `None` and in the first dataset, there was only event for example `T0`, in the next datasets the only event `T0` will be used. I expected that `mapping==None` reads all the events. Am I right?
2. In case any event is filtered out with the `mapping` parameter, the code crashed because it may happen that in some datasets there are not events of all types. [Line121](https://github.com/braindecode/braindecode/compare/master...sliwy:windowers_bug?expand=1#diff-c031004527cfc6287fbb1741b7f3e1ddR121) Now I am using `events_id` returned by `mne.events_from_annotations(ds.raw, mapping)` which contains only events that can be found in the dataset.
3. In case `mapping` is filtering out events it also crashed in the line [Line89](https://github.com/braindecode/braindecode/compare/master...sliwy:windowers_bug?expand=1#diff-c031004527cfc6287fbb1741b7f3e1ddR89) as `annotations` have all events and `onsets` only ones that were in the `mapping`. That is why I am introducing `filtered_durations` in [Line86-Line88](https://github.com/braindecode/braindecode/compare/master...sliwy:windowers_bug?expand=1#diff-c031004527cfc6287fbb1741b7f3e1ddR86-R88).

Example code that did not work:
```python
from braindecode.datautil import create_fixed_length_windows, create_windows_from_events
from braindecode.datasets import MOABBDataset
ds = MOABBDataset('PhysionetMI', [1])
windows = create_windows_from_events(ds, 160, 70, 1, 10, False, mapping={'T0': 0, 'T1': 1})
windows = create_windows_from_events(ds, 160, 70, 1, 10, False)
```