### PR TITLE
WIP: added pytest in circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,11 @@ jobs:
               echo "BUILD=$(cat build.txt)"
               ls -al ~/mne_data;
 
+        - run:
+            name: Tests
+            command: |
+              pytest
+
         # Build docs
         - run:
             name: make html


### PR DESCRIPTION
I added `pytest` run in circle CI. I am not sure but it looks to me like we are not running tests on CI (earlier tests were run in travis build but now we are not running travis build anymore).