### PR TITLE
Removed mne installation using newest github version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,6 @@ dependencies:
 - pytest
 - pip
 - skorch
+- mne
 - pip:
-  - https://github.com/mne-tools/mne-python/zipball/master
   - https://github.com/braindecode/braindecode/zipball/master


### PR DESCRIPTION
This PR fixes tests that are crashing in travis build (I changed `requiremnts.txt` mne version in one of the previous PR but it was defined also in conda `environment.yml`). I think that we have also a problem with travis build. Travis build is not done for each PRs, so we can merge PRs with failing tests. @agramfort do you have any idea why for a PR we have only circle CI done (it does not run tests)? Is it a problem with travis configuration?