### PR TITLE
Run braindecode on colab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,7 @@ setup(
     # Choose your license
     license='BSD 3-Clause',
 
-    install_requires=[
-        'mne @ git+https://github.com/mne-tools/mne-python.git',
-        'numpy', 'pandas', 'scipy', 'matplotlib', 'h5py',],
+    install_requires=['mne', 'numpy', 'pandas', 'scipy', 'matplotlib', 'h5py', 'skorch'],
     #tests_require = [...]
 
     # See https://PyPI.python.org/PyPI?%3Aaction=list_classifiers


### PR DESCRIPTION
I updated `setup.py` to not use mne specific version because it crashes with moabb, I added also skorch because it is core package right now.

To run on colab (after we merge this branch) at the beginning of notebook you have to run:
```python 
! pip install https://api.github.com/repos/sliwy/braindecode/zipball/master
! git clone https://github.com/NeuroTechX/moabb.git
! pip install -r moabb/requirements.txt
! pip install moabb/
! rm -r moabb/
```