### PR TITLE
Fix exp standardize

### DIFF
--- a/braindecode/datautil/preprocess.py
+++ b/braindecode/datautil/preprocess.py
@@ -148,12 +148,12 @@ def exponential_moving_standardize(
     standardized = demeaned / np.maximum(eps, np.sqrt(np.array(square_ewmed)))
     standardized = np.array(standardized)
     if init_block_size is not None:
-        other_axis = tuple(range(1, len(data.shape)))
+        i_time_axis = 0
         init_mean = np.mean(
-            data[0:init_block_size], axis=other_axis, keepdims=True
+            data[0:init_block_size], axis=i_time_axis, keepdims=True
         )
         init_std = np.std(
-            data[0:init_block_size], axis=other_axis, keepdims=True
+            data[0:init_block_size], axis=i_time_axis, keepdims=True
         )
         init_block_standardized = (
                                           data[0:init_block_size] - init_mean
@@ -190,9 +190,9 @@ def exponential_moving_demean(data, factor_new=0.001, init_block_size=None):
     demeaned = df - meaned
     demeaned = np.array(demeaned)
     if init_block_size is not None:
-        other_axis = tuple(range(1, len(data.shape)))
+        i_time_axis = 0
         init_mean = np.mean(
-            data[0:init_block_size], axis=other_axis, keepdims=True
+            data[0:init_block_size], axis=i_time_axis, keepdims=True
         )
         demeaned[0:init_block_size] = data[0:init_block_size] - init_mean
     return demeaned.T

--- a/test/unit_tests/datautil/test_preprocess.py
+++ b/test/unit_tests/datautil/test_preprocess.py
@@ -166,10 +166,16 @@ def test_exponential_running_init_block_size(mock_data):
     init_block_size = 3
     standardized_data = exponential_moving_standardize(
         mock_input, init_block_size=init_block_size)
+    # mean over time axis (1!) should give 0 per channel
     np.testing.assert_allclose(
-        standardized_data[:, :init_block_size].sum(), [0], rtol=1e-4, atol=1e-4)
+        standardized_data[:, :init_block_size].mean(axis=1), 0,
+        rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(
+        standardized_data[:, :init_block_size].std(axis=1), 1,
+        rtol=1e-4, atol=1e-4)
 
+    # mean over time axis (1!) should give 0 per channel
     demeaned_data = exponential_moving_demean(
         mock_input, init_block_size=init_block_size)
     np.testing.assert_allclose(
-        demeaned_data[:, :init_block_size].sum(), [0], rtol=1e-4, atol=1e-4)
+        demeaned_data[:, :init_block_size].mean(axis=1), 0, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
Init block size was not used correctly as noticed in https://github.com/TNTLFreiburg/braindecode/issues/56
Test was too unspecific to catch it. Now fixed it and made test more specific (would have failed on old code).