### PR TITLE
Moved files using datasets to datautil to fix circular imports

### DIFF
--- a/braindecode/datasets/__init__.py
+++ b/braindecode/datasets/__init__.py
@@ -4,5 +4,3 @@ Loader code for some datasets.
 from .base import WindowsDataset, BaseDataset, BaseConcatDataset
 from .moabb import MOABBDataset
 from .tuh import TUHAbnormal
-from .mne import create_from_mne_raw, create_from_mne_epochs
-from .xy import create_from_X_y

--- a/braindecode/datautil/__init__.py
+++ b/braindecode/datautil/__init__.py
@@ -4,3 +4,5 @@ Utilities for data manipulation.
 
 from .windowers import create_windows_from_events, create_fixed_length_windows
 from .preprocess import zscore, scale, exponential_moving_demean, exponential_moving_standardize
+from .xy import create_from_X_y
+from .mne import create_from_mne_raw, create_from_mne_epochs

--- a/braindecode/datautil/mne.py
+++ b/braindecode/datautil/mne.py
@@ -2,8 +2,8 @@ import numpy as np
 import pandas as pd
 import mne
 
-from .base import BaseDataset, BaseConcatDataset, WindowsDataset
-from ..datautil.windowers import (
+from braindecode.datasets.base import BaseDataset, BaseConcatDataset, WindowsDataset
+from braindecode.datautil.windowers import (
     _check_windowing_arguments, create_windows_from_events)
 
 
@@ -50,7 +50,7 @@ def create_from_mne_raw(
         if len(descriptions) != len(raws):
             raise ValueError(
                 f"length of 'raws' ({len(raws)}) and 'description' "
-                f"({len(description)}) has to match")
+                f"({len(descriptions)}) has to match")
         base_datasets = [BaseDataset(raw, desc) for raw, desc in
                          zip(raws, descriptions)]
     else:

--- a/braindecode/datautil/mne.py
+++ b/braindecode/datautil/mne.py
@@ -2,8 +2,8 @@ import numpy as np
 import pandas as pd
 import mne
 
-from braindecode.datasets.base import BaseDataset, BaseConcatDataset, WindowsDataset
-from braindecode.datautil.windowers import (
+from ..datasets.base import BaseDataset, BaseConcatDataset, WindowsDataset
+from ..datautil.windowers import (
     _check_windowing_arguments, create_windows_from_events)
 
 

--- a/braindecode/datautil/xy.py
+++ b/braindecode/datautil/xy.py
@@ -3,8 +3,8 @@ import pandas as pd
 import logging
 import mne
 
-from .base import BaseDataset, BaseConcatDataset
-from ..datautil.windowers import (
+from braindecode.datasets.base import BaseDataset, BaseConcatDataset
+from braindecode.datautil.windowers import (
     create_fixed_length_windows,)
 
 log = logging.getLogger(__name__)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -90,9 +90,6 @@ Datasets
     BaseConcatDataset
     WindowsDataset
     MOABBDataset
-    create_from_X_y
-    create_from_mne_raw
-    create_from_mne_epochs
 
 
 Data Utils
@@ -105,6 +102,9 @@ Data Utils
 .. autosummary::
    :toctree: generated/
 
+    create_from_X_y
+    create_from_mne_raw
+    create_from_mne_epochs
     create_fixed_length_windows
     create_windows_from_events
     exponential_moving_demean

--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,7 @@ dependencies:
 - pytorch
 - pytest
 - pip
-- skorch
+- skorch==0.7
 - mne
 - pip:
   - https://github.com/braindecode/braindecode/zipball/master

--- a/examples/plot_custom_dataset_example.py
+++ b/examples/plot_custom_dataset_example.py
@@ -11,7 +11,7 @@
 
 import mne
 
-from braindecode.datasets.xy import create_from_X_y
+from braindecode.datautil.xy import create_from_X_y
 
 ###############################################################################
 # To set up the example, we first fetch some data using mne:

--- a/examples/plot_custom_dataset_example.py
+++ b/examples/plot_custom_dataset_example.py
@@ -11,7 +11,7 @@
 
 import mne
 
-from braindecode.datautil.xy import create_from_X_y
+from braindecode.datautil import create_from_X_y
 
 ###############################################################################
 # To set up the example, we first fetch some data using mne:

--- a/examples/plot_mne_dataset_example.py
+++ b/examples/plot_mne_dataset_example.py
@@ -11,7 +11,7 @@
 
 import mne
 
-from braindecode.datasets.mne import (
+from braindecode.datautil.mne import (
     create_from_mne_raw, create_from_mne_epochs)
 
 ###############################################################################

--- a/examples/plot_mne_dataset_example.py
+++ b/examples/plot_mne_dataset_example.py
@@ -11,7 +11,7 @@
 
 import mne
 
-from braindecode.datautil.mne import (
+from braindecode.datautil import (
     create_from_mne_raw, create_from_mne_epochs)
 
 ###############################################################################

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ scipy
 matplotlib
 h5py
 mne
-skorch
+skorch==0.7

--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -11,7 +11,7 @@ from skorch.helper import predefined_split
 from torch import optim
 
 from braindecode import EEGClassifier
-from braindecode.datasets.xy import create_from_X_y
+from braindecode.datautil.xy import create_from_X_y
 from braindecode.training.losses import CroppedLoss
 from braindecode.models import ShallowFBCSPNet
 from braindecode.models.util import to_dense_prediction_model, get_output_shape

--- a/test/acceptance_tests/test_eeg_classifier.py
+++ b/test/acceptance_tests/test_eeg_classifier.py
@@ -12,7 +12,7 @@ from torch import optim
 from torch.nn.functional import nll_loss
 
 from braindecode.classifier import EEGClassifier
-from braindecode.datasets.xy import create_from_X_y
+from braindecode.datautil.xy import create_from_X_y
 from braindecode.training.losses import CroppedLoss
 from braindecode.models import ShallowFBCSPNet
 from braindecode.models.util import to_dense_prediction_model

--- a/test/unit_tests/datasets/test_mne.py
+++ b/test/unit_tests/datasets/test_mne.py
@@ -1,7 +1,7 @@
 import numpy as np
 import mne
 
-from braindecode.datasets.mne import  (
+from braindecode.datautil.mne import  (
     create_from_mne_raw, create_from_mne_epochs)
 
 def test_create_from_single_raw():

--- a/test/unit_tests/datasets/test_xy.py
+++ b/test/unit_tests/datasets/test_xy.py
@@ -5,7 +5,7 @@
 # License: BSD-3
 
 import numpy as np
-from braindecode.datasets.xy import create_from_X_y
+from braindecode.datautil.xy import create_from_X_y
 
 
 def test_crops_data_loader_explicit():

--- a/test/unit_tests/test_scoring.py
+++ b/test/unit_tests/test_scoring.py
@@ -15,7 +15,7 @@ from skorch.utils import to_numpy, to_tensor
 from torch import optim
 from torch.utils.data import Dataset, DataLoader
 from braindecode.classifier import EEGClassifier
-from braindecode.datasets.xy import create_from_X_y
+from braindecode.datautil.xy import create_from_X_y
 from braindecode.training.scoring import CroppedTrialEpochScoring
 from braindecode.training.scoring import PostEpochTrainScoring
 from braindecode.models import ShallowFBCSPNet


### PR DESCRIPTION
I took a quick look at #130 and I moved two files which uses things from datautil (`xy.py` and `mne.py`) to the datautil module. Now I can do `from braindecode.datautil import *`. @robintibor @agramfort let me know what you think, is it a good place for those files? They are just functions creating datasets.

@Simon-Free can you check if it works now?

One more thing is that I hardcoded skorch version as our tests does not work with the newest one. #129 