### PR TITLE
Improve splitting of datasets

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -106,13 +106,13 @@ class BaseConcatDataset(ConcatDataset):
     """
     def __init__(self, list_of_ds):
         # if we get a list of BaseConcatDataset, get all the individual datasets
-        if isinstance(list_of_ds[0], BaseConcatDataset):
+        if list_of_ds and isinstance(list_of_ds[0], BaseConcatDataset):
             list_of_ds = [d for ds in list_of_ds for d in ds.datasets]
         super().__init__(list_of_ds)
         self.description = pd.DataFrame([ds.description for ds in list_of_ds])
         self.description.reset_index(inplace=True, drop=True)
 
-    def split(self, by=None, some_property=None, split_ids=None):
+    def split(self, by=None, property=None, split_ids=None):
         """Split the dataset based on information listed in its description
         DataFrame or based on indices.
 
@@ -124,7 +124,7 @@ class BaseConcatDataset(ConcatDataset):
             If by is a (list of) list of integers, the position in the first
             list corresponds to the split id and the integers to the
             datapoints of that split.
-        some_property: str
+        property: str
             Some property which is listed in info DataFrame.
         split_ids: list(int) | list(list(int))
             List of indices to be combined in a subset.
@@ -136,15 +136,15 @@ class BaseConcatDataset(ConcatDataset):
             dataset as value.
         """
         args_not_none = [
-            by is not None, some_property is not None, split_ids is not None]
+            by is not None, property is not None, split_ids is not None]
         if sum(args_not_none) != 1:
             raise ValueError("Splitting requires exactly one argument.")
 
-        if some_property is not None or split_ids is not None:
-            warnings.warn("Keyword arguments `some_property` and `split_ids` "
+        if property is not None or split_ids is not None:
+            warnings.warn("Keyword arguments `property` and `split_ids` "
                           "are deprecated and will be removed in the future. "
                           "Use `by` instead.")
-            by = some_property if some_property is not None else split_ids
+            by = property if property is not None else split_ids
         if isinstance(by, str):
             split_ids = {
                 k: list(v)

--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -10,6 +10,8 @@ Dataset classes.
 #
 # License: BSD (3-clause)
 
+import warnings
+
 import numpy as np
 import pandas as pd
 
@@ -110,25 +112,39 @@ class BaseConcatDataset(ConcatDataset):
         self.description = pd.DataFrame([ds.description for ds in list_of_ds])
         self.description.reset_index(inplace=True, drop=True)
 
-    def split(self, by):
+    def split(self, by=None, some_property=None, split_ids=None):
         """Split the dataset based on information listed in its description
         DataFrame or based on indices.
 
         Parameters
         ----------
         by: str | list(int) | list(list(int))
-            if by is a string, splitting is performed based on the description
+            If by is a string, splitting is performed based on the description
             DataFrame column with this name.
-            if by is a (list of) list of integers, the position in the first
+            If by is a (list of) list of integers, the position in the first
             list corresponds to the split id and the integers to the
-            datapoints of that split
+            datapoints of that split.
+        some_property: str
+            Some property which is listed in info DataFrame.
+        split_ids: list(int) | list(list(int))
+            List of indices to be combined in a subset.
 
         Returns
         -------
         splits: dict{str: BaseConcatDataset}
-            dictionary with the name of the split as key and the dataset as
-            value
+            A dictionary with the name of the split (a string) as key and the
+            dataset as value.
         """
+        args_not_none = [
+            by is not None, some_property is not None, split_ids is not None]
+        if sum(args_not_none) != 1:
+            raise ValueError("Splitting requires exactly one argument.")
+
+        if some_property is not None or split_ids is not None:
+            warnings.warn("Keyword arguments `some_property` and `split_ids` "
+                          "are deprecated and will be removed in the future. "
+                          "Use `by` instead.")
+            by = some_property if some_property is not None else split_ids
         if isinstance(by, str):
             split_ids = {
                 k: list(v)

--- a/examples/plot_split_dataset.py
+++ b/examples/plot_split_dataset.py
@@ -1,0 +1,53 @@
+"""Split Dataset Example
+========================
+
+In this example, we show multiple ways of how to split a BaseConcatDataset.
+"""
+
+# Authors: Lukas Gemein <l.gemein@gmail.com>
+#
+# License: BSD (3-clause)
+
+from IPython.display import display
+
+from braindecode.datasets import MOABBDataset
+
+###############################################################################
+# First, we create a dataset based on BCIC IV 2a fetched with MOABB,
+ds = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[1])
+
+###############################################################################
+# ds has a pandas DataFrame with additional description of its internal datasets
+display(ds.description)
+
+###############################################################################
+# We can split the dataset based on the info in the description, for example
+# based on different runs. The returned dictionary will have string keys
+# corresponding to unique entries in the description DataFrame column
+splits = ds.split("run")
+display(splits["run_0"].description)
+display(splits["run_1"].description)
+display(splits["run_2"].description)
+display(splits["run_3"].description)
+display(splits["run_4"].description)
+display(splits["run_5"].description)
+
+###############################################################################
+# We can also split the dataset based on a list of integers corresponding to
+# rows in the description. In this case, the returned dictionary will have
+# '0' as the only key
+splits = ds.split([0, 1, 5])
+display(splits)
+display(splits["0"].description)
+
+###############################################################################
+# If we want multiple splits based on indices, we can also specify a list of
+# list of integers. In this case, the dictionary will have string keys
+# representing the id of the dataset split in the order of the given list of
+# integers
+splits = ds.split([[0, 1, 5], [2, 3, 4], [6, 7, 8, 9, 10, 11]])
+display(splits)
+display(splits["0"].description)
+display(splits["1"].description)
+display(splits["2"].description)
+

--- a/examples/plot_split_dataset.py
+++ b/examples/plot_split_dataset.py
@@ -1,7 +1,7 @@
 """Split Dataset Example
 ========================
 
-In this example, we show multiple ways of how to split a BaseConcatDataset.
+In this example, we show multiple ways of how to split datasets.
 """
 
 # Authors: Lukas Gemein <l.gemein@gmail.com>
@@ -11,6 +11,7 @@ In this example, we show multiple ways of how to split a BaseConcatDataset.
 from IPython.display import display
 
 from braindecode.datasets import MOABBDataset
+from braindecode.datautil.windowers import create_windows_from_events
 
 ###############################################################################
 # First, we create a dataset based on BCIC IV 2a fetched with MOABB,
@@ -25,12 +26,8 @@ display(ds.description)
 # based on different runs. The returned dictionary will have string keys
 # corresponding to unique entries in the description DataFrame column
 splits = ds.split("run")
-display(splits["run_0"].description)
-display(splits["run_1"].description)
-display(splits["run_2"].description)
-display(splits["run_3"].description)
+display(splits)
 display(splits["run_4"].description)
-display(splits["run_5"].description)
 
 ###############################################################################
 # We can also split the dataset based on a list of integers corresponding to
@@ -47,7 +44,15 @@ display(splits["0"].description)
 # integers
 splits = ds.split([[0, 1, 5], [2, 3, 4], [6, 7, 8, 9, 10, 11]])
 display(splits)
-display(splits["0"].description)
-display(splits["1"].description)
 display(splits["2"].description)
 
+###############################################################################
+# Similarly, we can split datasets after creating windows
+windows = create_windows_from_events(
+    ds, trial_start_offset_samples=0, trial_stop_offset_samples=0)
+splits = windows.split("run")
+display(splits)
+splits = windows.split([4, 8])
+display(splits)
+splits = windows.split([[4, 8], [5, 9, 11]])
+display(splits)

--- a/test/unit_tests/datasets/test_dataset.py
+++ b/test/unit_tests/datasets/test_dataset.py
@@ -126,3 +126,48 @@ def test_concat_concat_dataset(concat_ds_targets):
     assert len(concat_concat_ds.description) == len(descriptions)
     np.testing.assert_array_equal(cumsums, concat_concat_ds.cumulative_sizes)
     pd.testing.assert_frame_equal(descriptions, concat_concat_ds.description)
+
+
+def test_split_dataset_failure(concat_ds_targets):
+    concat_ds = concat_ds_targets[0]
+    with pytest.raises(KeyError):
+        concat_ds.split("test")
+
+    with pytest.raises(IndexError):
+        concat_ds.split([])
+
+    with pytest.raises(
+            AssertionError, match="datasets should not be an empty iterable"):
+        concat_ds.split([[]])
+
+    with pytest.raises(TypeError):
+        concat_ds.split([[[]]])
+
+    with pytest.raises(IndexError):
+        concat_ds.split([len(concat_ds.description)])
+
+
+def test_split_dataset(concat_ds_targets):
+    concat_ds = concat_ds_targets[0]
+    splits = concat_ds.split("run")
+    assert len(splits) == len(concat_ds.description["run"].unique())
+
+    splits = concat_ds.split([1])
+    assert len(splits) == 1
+    assert len(splits["0"].datasets) == 1
+
+    splits = concat_ds.split([[2]])
+    assert len(splits) == 1
+    assert len(splits["0"].datasets) == 1
+
+    splits = concat_ds.split([[0], [1, 2]])
+    assert len(splits) == 2
+    assert list(splits["0"].description.index) == [0]
+    assert len(splits["0"].datasets) == 1
+    split_ids = [1, 2]
+    assert list(splits["1"].description.index) == split_ids
+    assert len(splits["1"].datasets) == 2
+
+    for i, ds in enumerate(splits["1"].datasets):
+        np.testing.assert_array_equal(
+            ds.raw.get_data(), concat_ds.datasets[split_ids[i]].raw.get_data())

--- a/test/unit_tests/datasets/test_dataset.py
+++ b/test/unit_tests/datasets/test_dataset.py
@@ -160,14 +160,16 @@ def test_split_dataset(concat_ds_targets):
     assert len(splits) == 1
     assert len(splits["0"].datasets) == 1
 
-    splits = concat_ds.split([[0], [1, 2]])
+    original_ids = [1, 2]
+    splits = concat_ds.split([[0], original_ids])
     assert len(splits) == 2
     assert list(splits["0"].description.index) == [0]
     assert len(splits["0"].datasets) == 1
-    split_ids = [1, 2]
+    # when creating new BaseConcatDataset, index is reset
+    split_ids = [0, 1]
     assert list(splits["1"].description.index) == split_ids
     assert len(splits["1"].datasets) == 2
 
     for i, ds in enumerate(splits["1"].datasets):
         np.testing.assert_array_equal(
-            ds.raw.get_data(), concat_ds.datasets[split_ids[i]].raw.get_data())
+            ds.raw.get_data(), concat_ds.datasets[original_ids[i]].raw.get_data())

--- a/test/unit_tests/datautil/test_preprocess.py
+++ b/test/unit_tests/datautil/test_preprocess.py
@@ -180,7 +180,7 @@ def test_exponential_running_init_block_size(mock_data):
 
 
 def test_filterbank(base_concat_ds):
-    base_concat_ds = base_concat_ds.split(split_ids=[[0]])[0]
+    base_concat_ds = base_concat_ds.split([[0]])["0"]
     preprocessors = [
         MNEPreproc('pick_channels', ch_names=sorted(["C4", "Cz"]), ordered=True),
         MNEPreproc(filterbank, frequency_bands=[(0, 4), (4, 8), (8, 13)],


### PR DESCRIPTION
```split()``` now has a single argument ```by``` which ca be a string, a list of integers, or a list of list of integers.
splitting now always returns a dictionary with string keys.