### PR TITLE
MRG: Sleep staging example

### DIFF
--- a/braindecode/datasets/sleep_physionet.py
+++ b/braindecode/datasets/sleep_physionet.py
@@ -1,3 +1,8 @@
+# Authors: Hubert Banville <hubert.jbanville@gmail.com>
+#
+# License: BSD (3-clause)
+
+
 import os
 
 import numpy as np
@@ -31,10 +36,10 @@ class SleepPhysionet(BaseConcatDataset):
     crop_wake_mins: float
         Number of minutes of wake time to keep before the first sleep event
         and after the last sleep event. Used to reduce the imbalance in this
-        dataset. Ignore if
+        dataset. Default of 30 mins.
     """
     def __init__(self, subject_ids=None, recording_ids=None, preload=False,
-                 load_eeg_only=True, crop_wake_mins=0):
+                 load_eeg_only=True, crop_wake_mins=30):
         if subject_ids is None:
             subject_ids = range(83)
         if recording_ids is None:

--- a/braindecode/datasets/sleep_physionet.py
+++ b/braindecode/datasets/sleep_physionet.py
@@ -1,0 +1,81 @@
+import os
+
+import numpy as np
+import pandas as pd
+import mne
+from mne.datasets.sleep_physionet.age import fetch_data
+
+from .base import BaseDataset, BaseConcatDataset
+
+
+class SleepPhysionet(BaseConcatDataset):
+    """Sleep Physionet dataset.
+
+    Sleep dataset from https://physionet.org/content/sleep-edfx/1.0.0/. Contains
+    overnight recordings from 20 healthy subjects.
+
+    See [MNE example](https://mne.tools/stable/auto_tutorials/sample-datasets/plot_sleep.html).
+
+    Parameters
+    ----------
+    subject_ids: list(int) | int
+        (list of) int of subject(s) to be loaded.
+    recording_ids: list(int)
+        Recordings to load per subject (each subject except 13 has two
+        recordings). Can be [1], [2] or [1, 2].
+    preload: bool
+        if True, preload the data of the Raw objects.
+    load_eeg_only: bool
+        If True, only load the EEG channels and discard the others (EOG, EMG,
+        temperature, respiration) to avoid resampling the other signals.
+
+    TODO:
+    - Include all recordings from extended version (PR to MNE?)
+    - Crop before and after each file
+    """
+    def __init__(self, subject_ids=None, recording_ids=None, preload=False,
+                 load_eeg_only=True):
+        if subject_ids is None:
+            subject_ids = range(20)
+        if recording_ids is None:
+            recording_ids = [1, 2]
+
+        paths = fetch_data(subject_ids, recording=recording_ids)
+
+        all_base_ds = list()
+        for p in paths:
+            raw, desc = self._load_raw(
+                p[0], p[1], preload=preload, load_eeg_only=load_eeg_only)
+            base_ds = BaseDataset(raw, desc)
+            all_base_ds.append(base_ds)
+        super().__init__(all_base_ds)
+
+    @staticmethod
+    def _load_raw(raw_fname, ann_fname, preload, load_eeg_only=True):
+        ch_mapping = {
+            'EOG horizontal': 'eog',
+            'Resp oro-nasal': 'misc',
+            'EMG submental': 'misc',
+            'Temp rectal': 'misc',
+            'Event marker': 'misc'
+        }
+        exclude = ch_mapping.keys() if load_eeg_only else ()
+
+        raw = mne.io.read_raw_edf(raw_fname, preload=preload, exclude=exclude)
+        annots = mne.read_annotations(ann_fname)
+        raw.set_annotations(annots, emit_warning=False)
+
+        # Rename EEG channels
+        ch_names = {
+            i: i.replace('EEG ', '') for i in raw.ch_names if 'EEG' in i}
+        mne.rename_channels(raw.info, ch_names)
+
+        if not load_eeg_only:
+            raw.set_channel_types(ch_mapping)
+
+        basename = os.path.basename(raw_fname)
+        subj_nb = int(basename[3:5])
+        sess_nb = int(basename[5])
+        desc = pd.Series({'subject': subj_nb, 'recording': sess_nb}, name='')
+
+        return raw, desc

--- a/braindecode/datautil/preprocess.py
+++ b/braindecode/datautil/preprocess.py
@@ -66,7 +66,7 @@ class NumpyPreproc(MNEPreproc):
     fn: callable
         Function that preprocesses the numpy array
     channel_wise: bool
-        Whether to apply the functiona
+        Whether to apply the function
     kwargs:
         Keyword arguments will be forwarded to the function
     """

--- a/braindecode/datautil/preprocess.py
+++ b/braindecode/datautil/preprocess.py
@@ -215,12 +215,11 @@ def exponential_moving_demean(data, factor_new=0.001, init_block_size=None):
 
 
 def zscore(data):
-    """Zscore continuous or windowed data in-place
+    """Zscore normalize continuous or windowed data in-place.
 
     Parameters
     ----------
-    data: np.ndarray (n_channels x n_times) or (n_windows x n_channels x
-    n_times)
+    data: np.ndarray (n_channels, n_times) or (n_windows, n_channels, n_times)
         continuous or windowed signal
 
     Returns
@@ -228,6 +227,7 @@ def zscore(data):
     zscored: np.ndarray (n_channels x n_times) or (n_windows x n_channels x
     n_times)
         normalized continuous or windowed data
+
     ..note:
         If this function is supposed to preprocess continuous data, it should be
         given to raw.apply_function().

--- a/braindecode/models/__init__.py
+++ b/braindecode/models/__init__.py
@@ -8,3 +8,4 @@ from .hybrid import HybridNet
 from .shallow_fbcsp import ShallowFBCSPNet
 from .eegresnet import EEGResNet
 from .tcn import TCN
+from .sleep_stager import ChambonSleepStager

--- a/braindecode/models/__init__.py
+++ b/braindecode/models/__init__.py
@@ -8,4 +8,4 @@ from .hybrid import HybridNet
 from .shallow_fbcsp import ShallowFBCSPNet
 from .eegresnet import EEGResNet
 from .tcn import TCN
-from .sleep_stager import ChambonSleepStager
+from .sleep_stager import SleepStager

--- a/braindecode/models/__init__.py
+++ b/braindecode/models/__init__.py
@@ -8,4 +8,4 @@ from .hybrid import HybridNet
 from .shallow_fbcsp import ShallowFBCSPNet
 from .eegresnet import EEGResNet
 from .tcn import TCN
-from .sleep_stager import SleepStager
+from .sleep_stager_chambon_2018 import SleepStagerChambon2018

--- a/braindecode/models/sleep_stager.py
+++ b/braindecode/models/sleep_stager.py
@@ -88,13 +88,3 @@ class ChambonSleepStager(nn.Module):
 
         x = self.feature_extractor(x)
         return self.fc(x.flatten(start_dim=1))
-
-
-if __name__ == '__main__':
-
-    n_channels = 2
-    sfreq = 128
-    x = torch.rand(1, n_channels, sfreq * 30)
-
-    net = ChambonSleepStager(n_channels, sfreq)
-    y = net(x)

--- a/braindecode/models/sleep_stager.py
+++ b/braindecode/models/sleep_stager.py
@@ -1,0 +1,69 @@
+import torch
+from torch import nn
+
+
+class ChambonSleepStager(nn.Module):
+    """
+    XXX: Write docstring
+    """
+    def __init__(self, n_channels, sfreq, n_conv_chs=8, time_conv_size_s=0.5,
+                 max_pool_size_s=0.125, n_classes=5, input_size_s=30,
+                 dropout=0.25):
+        super().__init__()
+
+        time_conv_size = int(time_conv_size_s * sfreq)
+        max_pool_size = int(max_pool_size_s * sfreq)
+        input_size = int(input_size_s * sfreq)
+        pad_size = time_conv_size // 2
+        self.n_channels = n_channels
+        len_last_layer = self._len_last_layer(
+            n_channels, input_size, max_pool_size, n_conv_chs)
+
+        if n_channels > 1:
+            self.spatial_conv = nn.Conv2d(1, n_channels, (n_channels, 1))
+
+        self.feature_extractor = nn.Sequential(
+            nn.Conv2d(
+                1, n_conv_chs, (1, time_conv_size), padding=(0, pad_size)),
+            nn.ReLU(),
+            nn.MaxPool2d((1, max_pool_size)),
+            nn.Conv2d(
+                n_conv_chs, n_conv_chs, (1, time_conv_size),
+                padding=(0, pad_size)),
+            nn.ReLU(),
+            nn.MaxPool2d((1, max_pool_size))
+        )
+        self.fc = nn.Sequential(
+            nn.Dropout(dropout),
+            nn.Linear(len_last_layer, n_classes)
+        )
+
+    @staticmethod
+    def _len_last_layer(n_channels, input_size, max_pool_size, n_conv_chs):
+        return n_channels * (input_size // (max_pool_size ** 2)) * n_conv_chs
+
+    def forward(self, x):
+        """
+        Arguments
+        ---------
+        x: torch.Tensor
+            Batch of EEG windows of shape (batch_size, n_channels, n_times).
+        """
+        x = x.unsqueeze(1)
+
+        if self.n_channels > 1:
+            x = self.spatial_conv(x)
+            x = x.transpose(1, 2)
+
+        x = self.feature_extractor(x)
+        return self.fc(x.flatten(start_dim=1))
+
+
+if __name__ == '__main__':
+
+    n_channels = 2
+    sfreq = 128
+    x = torch.rand(1, n_channels, sfreq * 30)
+
+    net = ChambonSleepStager(n_channels, sfreq)
+    y = net(x)

--- a/braindecode/models/sleep_stager.py
+++ b/braindecode/models/sleep_stager.py
@@ -3,8 +3,38 @@ from torch import nn
 
 
 class ChambonSleepStager(nn.Module):
-    """
-    XXX: Write docstring
+    """Sleep staging architecture from [1]_.
+
+    Convolutional neural network for sleep staging described in [1]_.
+
+    Parameters
+    ----------
+    n_channels : int
+        Number of EEG channels.
+    sfreq : float
+        EEG sampling frequency.
+    n_conv_chs : int
+        Number of convolutional channels. Set to 8 in [1]_.
+    time_conv_size_s : float
+        Size of filters in temporal convolution layers, in seconds. Set to 0.5
+        in [1]_ (64 samples at sfreq=128).
+    max_pool_size_s : float
+        Max pooling size, in seconds. Set to 0.125 in [1]_ (16 samples at
+        sfreq=128).
+    n_classes : int
+        Number of classes.
+    input_size_s : float
+        Size of the input, in seconds.
+    dropout : float
+        Dropout rate before the output dense layer.
+
+    References
+    ----------
+    .. [1] Chambon, S., Galtier, M. N., Arnal, P. J., Wainrib, G., &
+           Gramfort, A. (2018). A deep learning architecture for temporal sleep
+           stage classification using multivariate and multimodal time series.
+           IEEE Transactions on Neural Systems and Rehabilitation Engineering,
+           26(4), 758-769.
     """
     def __init__(self, n_channels, sfreq, n_conv_chs=8, time_conv_size_s=0.5,
                  max_pool_size_s=0.125, n_classes=5, input_size_s=30,
@@ -43,8 +73,9 @@ class ChambonSleepStager(nn.Module):
         return n_channels * (input_size // (max_pool_size ** 2)) * n_conv_chs
 
     def forward(self, x):
-        """
-        Arguments
+        """Forward pass.
+
+        Parameters
         ---------
         x: torch.Tensor
             Batch of EEG windows of shape (batch_size, n_channels, n_times).

--- a/braindecode/models/sleep_stager.py
+++ b/braindecode/models/sleep_stager.py
@@ -1,8 +1,13 @@
+# Authors: Hubert Banville <hubert.jbanville@gmail.com>
+#
+# License: BSD (3-clause)
+
+
 import torch
 from torch import nn
 
 
-class ChambonSleepStager(nn.Module):
+class SleepStager(nn.Module):
     """Sleep staging architecture from [1]_.
 
     Convolutional neural network for sleep staging described in [1]_.

--- a/braindecode/models/sleep_stager_chambon_2018.py
+++ b/braindecode/models/sleep_stager_chambon_2018.py
@@ -3,11 +3,10 @@
 # License: BSD (3-clause)
 
 
-import torch
 from torch import nn
 
 
-class SleepStager(nn.Module):
+class SleepStagerChambon2018(nn.Module):
     """Sleep staging architecture from [1]_.
 
     Convolutional neural network for sleep staging described in [1]_.

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -159,7 +159,7 @@ print(valid_set.datasets[0].windows)
 
 import torch
 from braindecode.util import set_random_seeds
-from braindecode.models import SleepStager
+from braindecode.models import SleepStagerChambon2018
 
 cuda = torch.cuda.is_available()  # check if GPU is available
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
@@ -174,7 +174,7 @@ n_classes = 5
 n_channels = train_set[0][0].shape[0]
 input_size_samples = train_set[0][0].shape[1]
 
-model = SleepStager(
+model = SleepStagerChambon2018(
     n_channels,
     sfreq,
     n_classes=n_classes,

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -120,8 +120,7 @@ windows_dataset = create_windows_from_events(
 
 from braindecode.datautil.preprocess import zscore
 
-# preprocess(windows_dataset, [NumpyPreproc(fn=zscore)])
-# XXX This currently fails! We need a way to preprocess Epochs too.
+preprocess(windows_dataset, [MNEPreproc(fn=zscore)])
 
 
 ######################################################################

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -144,7 +144,7 @@ preprocess(windows_dataset, [MNEPreproc(fn=zscore)])
 ######################################################################
 # We can easily split the dataset using additional info stored in the
 # `description` attribute of :class:`braindecode.datasets.BaseDataset`,
-# in this case ``session`` column. Here, we split the examples per subject.
+# in this case using the ``subject`` column. Here, we split the examples per subject.
 #
 
 splitted = windows_dataset.split('subject')

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -90,7 +90,7 @@ mapping = {  # We merge stages 3 and 4 following AASM standards.
 }
 
 windows_dataset = create_windows_from_events(
-    dataset, trial_start_offset_samples=0, trial_stop_offset_samples=None,
+    dataset, trial_start_offset_samples=0, trial_stop_offset_samples=0,
     preload=True, mapping=mapping)
 
 

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -48,7 +48,6 @@ from braindecode.datasets.sleep_physionet import SleepPhysionet
 
 dataset = SleepPhysionet(
     subject_ids=[0, 1], recording_ids=[1], crop_wake_mins=30)
-# XXX Enable crop_wake_mins once MNE handles cropped files
 
 
 ######################################################################
@@ -144,7 +143,6 @@ valid_set = splitted[1]
 # Print number of examples per class
 print(train_set.datasets[0].windows)
 print(valid_set.datasets[0].windows)
-# XXX Format in a table?
 
 
 ######################################################################

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -137,8 +137,8 @@ preprocess(windows_dataset, [MNEPreproc(fn=zscore)])
 #
 
 splitted = windows_dataset.split('subject')
-train_set = splitted[0]
-valid_set = splitted[1]
+train_set = splitted['0']
+valid_set = splitted['1']
 
 # Print number of examples per class
 print(train_set.datasets[0].windows)

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -1,0 +1,254 @@
+"""
+Sleep staging on Sleep Physionet dataset
+========================================
+
+This tutorial shows how to train and test a sleep staging neural network with
+Braindecode on the Sleep Physionet dataset.
+"""
+
+
+######################################################################
+# Loading and preprocessing the dataset
+# -------------------------------------
+#
+
+######################################################################
+# Loading
+# ~~~~~~~
+#
+
+######################################################################
+# First, we load the data using the braindecode SleepPhysionet class. We load
+# two recordings from two different individuals: we will use the first one to
+# train our network and the second one to evaluate performance (as in the _MNE
+# sleep staging example).
+#
+# .. _MNE: https://mne.tools/stable/auto_tutorials/sample-datasets/plot_sleep.html
+#
+# .. note::
+#    To load your own datasets either via mne or from
+#    preprocessed X/y numpy arrays, see `MNE Dataset
+#    Tutorial <./plot_mne_dataset_example.html>`__ and `Numpy Dataset
+#    Tutorial <./plot_custom_dataset_example.html>`__.
+#
+
+from braindecode.datasets.sleep_physionet import SleepPhysionet
+
+dataset = SleepPhysionet(subject_ids=[0, 1], recording_ids=[1])
+
+
+######################################################################
+# Preprocessing
+# ~~~~~~~~~~~~~
+#
+
+
+######################################################################
+# Next, we preprocess the dataset. We apply a lowpass filter and normalize the
+# data channel-wise.
+#
+
+from braindecode.datautil.preprocess import zscore
+from braindecode.datautil.preprocess import MNEPreproc, NumpyPreproc
+
+high_cut_hz = 30  # high cut frequency for filtering
+
+preprocessors = [
+    # convert from volt to microvolt, directly modifying the numpy array
+    NumpyPreproc(fn=lambda x: x * 1e6),
+    # bandpass filter
+    MNEPreproc(fn='filter', h_freq=high_cut_hz),
+    # channel-wise z-score normalization
+    NumpyPreproc(fn=zscore)
+]
+
+# Transform the data
+preprocess(dataset, preprocessors)
+
+# XXX MAKE SURE THE DATA IS PREPROCESSED AS EXPECTED!!!
+
+
+######################################################################
+# Extract windows
+# ~~~~~~~~~~~~~~~
+#
+
+
+######################################################################
+# We now extract windows to be used in the classification task.
+
+from braindecode.datautil.windowers import create_windows_from_events
+
+
+mapping = {  # We merge stages 3 and 4 following AASM standards.
+    'Sleep stage W': 1,
+    'Sleep stage 1': 2,
+    'Sleep stage 2': 3,
+    'Sleep stage 3': 4,
+    'Sleep stage 4': 4,
+    'Sleep stage R': 5
+}
+
+windows_dataset = create_windows_from_events(
+    dataset, trial_start_offset_samples=0, trial_stop_offset_samples=None,
+    preload=True, mapping=mapping)
+
+
+######################################################################
+# Split dataset into train and valid
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+
+######################################################################
+# We can easily split the dataset using additional info stored in the
+# description attribute, in this case ``session`` column. We select
+# ``session_T`` for training and ``session_E`` for validation.
+#
+
+splitted = windows_dataset.split('subject')
+train_set = splitted['0']
+valid_set = splitted['1']
+# XXX Make sure this works!
+
+
+######################################################################
+# Create model
+# ------------
+#
+
+######################################################################
+# We can now create the deep learning model. Here, we use the sleep staging
+# architecture introduced in `A deep learning architecture for temporal sleep
+# stage classification using multivariate and multimodal time series
+# <https://arxiv.org/abs/1707.03321>`__.
+#
+
+import torch
+from braindecode.util import set_random_seeds
+from braindecode.models import ChambonStagerNet
+
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+if cuda:
+    torch.backends.cudnn.benchmark = True
+seed = 87  # random seed to make results reproducible
+# Set random seed to be able to reproduce results
+set_random_seeds(seed=seed, cuda=cuda)
+
+n_classes=4
+# Extract number of chans and time steps from dataset
+n_chans = train_set[0][0].shape[0]
+input_window_samples = train_set[0][0].shape[1]
+
+model = ShallowFBCSPNet(
+    n_chans,
+    n_classes,
+    input_window_samples=input_window_samples,
+    final_conv_length='auto',
+)
+
+# Send model to GPU
+if cuda:
+    model.cuda()
+
+
+
+######################################################################
+# Training
+# --------
+#
+
+
+######################################################################
+# Now we train the network! EEGClassifier is a Braindecode object
+# responsible for managing the training of neural networks. It inherits
+# from skorch.NeuralNetClassifier, so the training logic is the same as in
+# `Skorch <https://skorch.readthedocs.io/en/stable/>`__.
+#
+
+
+######################################################################
+#    **Note**: In this tutorial, we use some default parameters that we
+#    have found to work well for motor decoding, however we strongly
+#    encourage you to perform your own hyperparameter optimization using
+#    cross validation on your training data.
+#
+
+from skorch.callbacks import LRScheduler
+from skorch.helper import predefined_split
+
+from braindecode import EEGClassifier
+# These values we found good for shallow network:
+lr = 0.0625 * 0.01
+weight_decay = 0
+
+# For deep4 they should be:
+# lr = 1 * 0.01
+# weight_decay = 0.5 * 0.001
+
+batch_size = 64
+n_epochs = 4
+
+clf = EEGClassifier(
+    model,
+    criterion=torch.nn.NLLLoss,
+    optimizer=torch.optim.AdamW,
+    train_split=predefined_split(valid_set),  # using valid_set for validation
+    optimizer__lr=lr,
+    optimizer__weight_decay=weight_decay,
+    batch_size=batch_size,
+    callbacks=[
+        "accuracy", ("lr_scheduler", LRScheduler('CosineAnnealingLR', T_max=n_epochs - 1)),
+    ],
+    device=device,
+)
+# Model training for a specified number of epochs. `y` is None as it is already supplied
+# in the dataset.
+clf.fit(train_set, y=None, epochs=n_epochs)
+
+
+######################################################################
+# Plot Results
+# ------------
+#
+
+
+######################################################################
+# Now we use the history stored by Skorch throughout training to plot
+# accuracy and loss curves.
+#
+
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+import pandas as pd
+# Extract loss and accuracy values for plotting from history object
+results_columns = ['train_loss', 'valid_loss', 'train_accuracy', 'valid_accuracy']
+df = pd.DataFrame(clf.history[:, results_columns], columns=results_columns,
+                  index=clf.history[:, 'epoch'])
+
+# get percent of misclass for better visual comparison to loss
+df = df.assign(train_misclass=100 - 100 * df.train_accuracy,
+               valid_misclass=100 - 100 * df.valid_accuracy)
+
+plt.style.use('seaborn')
+fig, ax1 = plt.subplots(figsize=(8, 3))
+df.loc[:, ['train_loss', 'valid_loss']].plot(
+    ax=ax1, style=['-', ':'], marker='o', color='tab:blue', legend=False, fontsize=14)
+
+ax1.tick_params(axis='y', labelcolor='tab:blue', labelsize=14)
+ax1.set_ylabel("Loss", color='tab:blue', fontsize=14)
+
+ax2 = ax1.twinx()  # instantiate a second axes that shares the same x-axis
+
+df.loc[:, ['train_misclass', 'valid_misclass']].plot(
+    ax=ax2, style=['-', ':'], marker='o', color='tab:red', legend=False)
+ax2.tick_params(axis='y', labelcolor='tab:red', labelsize=14)
+ax2.set_ylabel("Misclassification Rate [%]", color='tab:red', fontsize=14)
+ax2.set_ylim(ax2.get_ylim()[0], 85)  # make some room for legend
+ax1.set_xlabel("Epoch", fontsize=14)
+
+# where some data has already been plotted to ax
+handles = []
+handles.append(Line2D([0], [0], color='black', linewidth=1, linestyle='-', label='Train'))
+handles.append(Line2D([0], [0], color='black', linewidth=1, linestyle=':', label='Valid'))
+plt.legend(handles, [h.get_label() for h in handles], fontsize=14)
+plt.tight_layout()

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -1,18 +1,28 @@
 """
-Sleep staging on Sleep Physionet dataset
-========================================
+Sleep staging on the Sleep Physionet dataset
+============================================
 
 This tutorial shows how to train and test a sleep staging neural network with
-Braindecode. We follow the approach of [1]_, but on the openly accessible Sleep
-Physionet dataset.
+Braindecode. We follow the approach of [1]_ on the openly accessible Sleep
+Physionet dataset [1]_ [2]_.
 
 References
 ----------
-.. [1] Chambon, S., Galtier, M. N., Arnal, P. J., Wainrib, G., &
-        Gramfort, A. (2018). A deep learning architecture for temporal sleep
-        stage classification using multivariate and multimodal time series.
-        IEEE Transactions on Neural Systems and Rehabilitation Engineering,
-        26(4), 758-769.
+.. [1] Chambon, S., Galtier, M., Arnal, P., Wainrib, G. and Gramfort, A.
+      (2018)A Deep Learning Architecture for Temporal Sleep Stage
+      Classification Using Multivariate and Multimodal Time Series.
+      IEEE Trans. on Neural Systems and Rehabilitation Engineering 26:
+      (758-769)
+
+.. [2] B Kemp, AH Zwinderman, B Tuk, HAC Kamphuisen, JJL Oberyé. Analysis of
+       a sleep-dependent neuronal feedback loop: the slow-wave
+       microcontinuity of the EEG. IEEE-BME 47(9):1185-1194 (2000).
+
+.. [3] Goldberger AL, Amaral LAN, Glass L, Hausdorff JM, Ivanov PCh,
+       Mark RG, Mietus JE, Moody GB, Peng C-K, Stanley HE. (2000)
+       PhysioBank, PhysioToolkit, and PhysioNet: Components of a New
+       Research Resource for Complex Physiologic Signals.
+       Circulation 101(23):e215-e220
 """
 # Authors: Hubert Banville <hubert.jbanville@gmail.com>
 #
@@ -30,17 +40,18 @@ References
 #
 
 ######################################################################
-# First, we load the data using the braindecode SleepPhysionet class. We load
+# First, we load the data using the
+# :class:`braindecode.datasets.sleep_physionet.SleepPhysionet` class. We load
 # two recordings from two different individuals: we will use the first one to
-# train our network and the second one to evaluate performance (as in the _MNE
+# train our network and the second one to evaluate performance (as in the `MNE`_
 # sleep staging example).
 #
 # .. _MNE: https://mne.tools/stable/auto_tutorials/sample-datasets/plot_sleep.html
 #
 # .. note::
-#    To load your own datasets either via mne or from
-#    preprocessed X/y numpy arrays, see `MNE Dataset
-#    Tutorial <./plot_mne_dataset_example.html>`__ and `Numpy Dataset
+#    To load your own datasets either via MNE or from
+#    preprocessed X/y numpy arrays, see the `MNE Dataset
+#    Tutorial <./plot_mne_dataset_example.html>`__ and the `Numpy Dataset
 #    Tutorial <./plot_custom_dataset_example.html>`__.
 #
 
@@ -57,15 +68,15 @@ dataset = SleepPhysionet(
 
 
 ######################################################################
-# Next, we preprocess the raw data. We apply a lowpass filter and normalize the
-# data channel-wise. We omit the downsampling step of Chambon et al. (2018) as
-# the Sleep Physionet data is already sampled at a lower 100 Hz.
+# Next, we preprocess the raw data. We apply convert the data to microvolts and
+# apply a lowpass filter. We omit the downsampling step of [1]_ as the Sleep
+# Physionet data is already sampled at a lower 100 Hz.
 #
 
 from braindecode.datautil.preprocess import (
     MNEPreproc, NumpyPreproc, preprocess)
 
-high_cut_hz = 30  # high cut frequency for filtering
+high_cut_hz = 30
 
 preprocessors = [
     # convert from volt to microvolt, directly modifying the numpy array
@@ -85,7 +96,7 @@ preprocess(dataset, preprocessors)
 
 
 ######################################################################
-# We now extract windows to be used in the classification task.
+# We extract 30-s windows to be used in the classification task.
 
 from braindecode.datautil.windowers import create_windows_from_events
 
@@ -132,8 +143,8 @@ preprocess(windows_dataset, [MNEPreproc(fn=zscore)])
 
 ######################################################################
 # We can easily split the dataset using additional info stored in the
-# description attribute, in this case ``session`` column. We select
-# ``session_T`` for training and ``session_E`` for validation.
+# `description` attribute of :class:`braindecode.datasets.BaseDataset`,
+# in this case ``session`` column. Here, we split the examples per subject.
 #
 
 splitted = windows_dataset.split('subject')
@@ -151,10 +162,9 @@ print(valid_set.datasets[0].windows)
 #
 
 ######################################################################
-# We can now create the deep learning model. Here, we use the sleep staging
-# architecture introduced in `A deep learning architecture for temporal sleep
-# stage classification using multivariate and multimodal time series
-# <https://arxiv.org/abs/1707.03321>`__.
+# We can now create the deep learning model. In this tutorial, we use the sleep
+# staging architecture introduced in [1]_, which is a four-layer convolutional
+# neural network.
 #
 
 import torch
@@ -165,9 +175,8 @@ cuda = torch.cuda.is_available()  # check if GPU is available
 device = 'cuda' if torch.cuda.is_available() else 'cpu'
 if cuda:
     torch.backends.cudnn.benchmark = True
-seed = 87
 # Set random seed to be able to reproduce results
-set_random_seeds(seed=seed, cuda=cuda)
+set_random_seeds(seed=87, cuda=cuda)
 
 n_classes = 5
 # Extract number of channels and time steps from dataset
@@ -193,19 +202,20 @@ if cuda:
 
 
 ######################################################################
-# We can now train our network. EEGClassifier is a Braindecode object that is
-# responsible for managing the training of neural networks. It inherits
-# from skorch.NeuralNetClassifier, so the training logic is the same as in
+# We can now train our network. :class:`braindecode.EEGClassifier` is a
+# braindecode object that is responsible for managing the training of neural
+# networks. It inherits from :class:`skorch.NeuralNetClassifier`, so the
+# training logic is the same as in
 # `Skorch <https://skorch.readthedocs.io/en/stable/>`__.
 #
 
 
 ######################################################################
-#    **Note**: We use different hyperparameters from Chambon et al. (2018), as
+#    **Note**: We use different hyperparameters from [1]_, as
 #    these hyperparameters were optimized on a different dataset (MASS SS3) and
 #    with a different number of recordings. Generally speaking, it is
 #    recommended to perform hyperparameter optimization if reusing this code on
-#    a different dataset.
+#    a different dataset or with more recordings.
 #
 
 from skorch.helper import predefined_split
@@ -241,26 +251,29 @@ clf.fit(train_set, y=None, epochs=n_epochs)
 
 
 ######################################################################
-# Plot Results
+# Plot results
 # ------------
 #
 
 
 ######################################################################
-# We use the history stored by Skorch during training to plot the accuracy and
-# loss curves.
+# We use the history stored by Skorch during training to plot the performance of
+# the model throughout training. Specifically, we plot the loss and the balanced
+# misclassification rate (1 - balanced accuracy) for the training and validation
+# sets.
 #
 
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 import pandas as pd
 
-# Extract loss and accuracy values for plotting from history object
+# Extract loss and balanced accuracy values for plotting from history object
 df = pd.DataFrame(clf.history.to_list())
-df[['train_bal_acc', 'valid_bal_acc']] *= 100
+df[['train_mis_clf', 'valid_mis_clf']] = 100 - df[
+    ['train_bal_acc', 'valid_bal_acc']] * 100
 
 # get percent of misclass for better visual comparison to loss
-plt.style.use('seaborn')
+plt.style.use('seaborn-talk')
 fig, ax1 = plt.subplots(figsize=(8, 3))
 df.loc[:, ['train_loss', 'valid_loss']].plot(
     ax=ax1, style=['-', ':'], marker='o', color='tab:blue', legend=False,
@@ -271,10 +284,11 @@ ax1.set_ylabel("Loss", color='tab:blue', fontsize=14)
 
 ax2 = ax1.twinx()  # instantiate a second axes that shares the same x-axis
 
-df.loc[:, ['train_bal_acc', 'valid_bal_acc']].plot(
+df.loc[:, ['train_mis_clf', 'valid_mis_clf']].plot(
     ax=ax2, style=['-', ':'], marker='o', color='tab:red', legend=False)
 ax2.tick_params(axis='y', labelcolor='tab:red', labelsize=14)
-ax2.set_ylabel('Balanced accuracy [%]', color='tab:red', fontsize=14)
+ax2.set_ylabel('Balanced misclassification rate [%]', color='tab:red',
+               fontsize=14)
 ax2.set_ylim(ax2.get_ylim()[0], 85)  # make some room for legend
 ax1.set_xlabel('Epoch', fontsize=14)
 
@@ -288,9 +302,8 @@ plt.legend(handles, [h.get_label() for h in handles], fontsize=14)
 plt.tight_layout()
 
 
-
 ######################################################################
-# Finally, we also plot the confusion matrix and classification report:
+# Finally, we also display the confusion matrix and classification report:
 #
 
 from sklearn.metrics import confusion_matrix
@@ -302,3 +315,14 @@ y_pred = clf.predict(valid_set)
 print(confusion_matrix(y_true, y_pred))
 
 print(classification_report(y_true, y_pred))
+
+
+######################################################################
+# Our model was able to perform reasonably well given the low amount of data
+# available, reaching a balanced accuracy of around 55% in a 5-class
+# classification task (chance-level = 20%) on held-out data.
+#
+# To further improve performance, more recordings can be included in the
+# training set, and various modifications can be made to the model (e.g.,
+# aggregating the representation of multiple consecutive windows [1]_).
+#

--- a/test/unit_tests/datasets/test_sleep_physionet.py
+++ b/test/unit_tests/datasets/test_sleep_physionet.py
@@ -1,0 +1,14 @@
+from braindecode.datasets.sleep_physionet import SleepPhysionet
+from braindecode.datasets.base import BaseConcatDataset
+
+
+def test_sleep_physionet():
+    sp = SleepPhysionet(
+        subject_ids=[0], recording_ids=[1], preload=True, load_eeg_only=True)
+    assert isinstance(sp, BaseConcatDataset)
+
+
+def test_all_signals():
+    sp = SleepPhysionet(
+        subject_ids=[0], recording_ids=[1], preload=True, load_eeg_only=False)
+    assert len(sp.datasets[0].raw.ch_names) == 7

--- a/test/unit_tests/datasets/test_sleep_physionet.py
+++ b/test/unit_tests/datasets/test_sleep_physionet.py
@@ -12,3 +12,11 @@ def test_all_signals():
     sp = SleepPhysionet(
         subject_ids=[0], recording_ids=[1], preload=True, load_eeg_only=False)
     assert len(sp.datasets[0].raw.ch_names) == 7
+
+
+def test_crop_wake():
+    sp = SleepPhysionet(
+        subject_ids=[0], recording_ids=[1], preload=True, load_eeg_only=True,
+        crop_wake_mins=30)
+    sfreq = sp.datasets[0].raw.info['sfreq']
+    assert len(sp) / (3600 * sfreq) < 7

--- a/test/unit_tests/datasets/test_sleep_physionet.py
+++ b/test/unit_tests/datasets/test_sleep_physionet.py
@@ -19,4 +19,5 @@ def test_crop_wake():
         subject_ids=[0], recording_ids=[1], preload=True, load_eeg_only=True,
         crop_wake_mins=30)
     sfreq = sp.datasets[0].raw.info['sfreq']
-    assert len(sp) / (3600 * sfreq) < 7
+    duration_h = len(sp) / (3600 * sfreq)
+    assert duration_h < 7 and duration_h > 6

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -1,5 +1,6 @@
 # Authors: Alexandre Gramfort
 #          Lukas Gemein <l.gemein@gmail.com>
+#          Hubert Banville <hubert.jbanville@gmail.com>
 #
 # License: BSD-3
 
@@ -10,7 +11,7 @@ import pytest
 
 from braindecode.models import (
     Deep4Net, EEGNetv4, EEGNetv1, HybridNet, ShallowFBCSPNet, EEGResNet, TCN,
-    SleepStager)
+    SleepStagerChambon2018)
 
 
 def test_shallow_fbcsp_net():
@@ -125,7 +126,7 @@ def test_sleep_stager(n_channels, sfreq, n_classes, input_size_s):
     max_pool_size_s = 0.125
     n_examples = 10
 
-    model = ChambonSleepStager(
+    model = SleepStagerChambon2018(
         n_channels, sfreq, n_conv_chs=8, time_conv_size_s=time_conv_size_s,
         max_pool_size_s=max_pool_size_s, n_classes=n_classes,
         input_size_s=input_size_s, dropout=0.25)

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -3,16 +3,14 @@
 #
 # License: BSD-3
 
+
 import numpy as np
-
 import torch
+import pytest
 
-from braindecode.models import Deep4Net
-from braindecode.models import EEGNetv4, EEGNetv1
-from braindecode.models import HybridNet
-from braindecode.models import ShallowFBCSPNet
-from braindecode.models import EEGResNet
-from braindecode.models import TCN
+from braindecode.models import (
+    Deep4Net, EEGNetv4, EEGNetv1, HybridNet, ShallowFBCSPNet, EEGResNet, TCN,
+    ChambonSleepStager)
 
 
 def test_shallow_fbcsp_net():
@@ -113,12 +111,27 @@ def test_tcn():
         n_filters=5, n_blocks=2, kernel_size=4, drop_prob=.5,
         add_log_softmax=True)
     n_in_times = model.min_len
-    X = rng.randn(n_samples, n_channels, n_in_times, 1)
-    X = torch.Tensor(X.astype(np.float32))
-    y_pred = model(X)
-    assert y_pred.shape == (n_samples, n_classes)
     X = rng.randn(n_samples, n_channels, n_in_times)
     X = torch.Tensor(X.astype(np.float32))
     y_pred = model(X)
     assert y_pred.shape == (n_samples, n_classes)
 
+
+@pytest.mark.parametrize('n_channels,sfreq,n_classes,input_size_s',
+                         [(20, 128, 5, 30), (10, 256, 4, 20), (1, 64, 2, 30)])
+def test_chambon_sleep_stager(n_channels, sfreq, n_classes, input_size_s):
+    rng = np.random.RandomState(42)
+    time_conv_size_s = 0.5
+    max_pool_size_s = 0.125
+    n_examples = 10
+
+    model = ChambonSleepStager(
+        n_channels, sfreq, n_conv_chs=8, time_conv_size_s=time_conv_size_s,
+        max_pool_size_s=max_pool_size_s, n_classes=n_classes,
+        input_size_s=input_size_s, dropout=0.25)
+
+    X = rng.randn(n_examples, n_channels, int(sfreq * input_size_s))
+    X = torch.from_numpy(X.astype(np.float32))
+
+    y_pred = model(X)
+    assert y_pred.shape == (n_examples, n_classes)

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -10,7 +10,7 @@ import pytest
 
 from braindecode.models import (
     Deep4Net, EEGNetv4, EEGNetv1, HybridNet, ShallowFBCSPNet, EEGResNet, TCN,
-    ChambonSleepStager)
+    SleepStager)
 
 
 def test_shallow_fbcsp_net():
@@ -119,7 +119,7 @@ def test_tcn():
 
 @pytest.mark.parametrize('n_channels,sfreq,n_classes,input_size_s',
                          [(20, 128, 5, 30), (10, 256, 4, 20), (1, 64, 2, 30)])
-def test_chambon_sleep_stager(n_channels, sfreq, n_classes, input_size_s):
+def test_sleep_stager(n_channels, sfreq, n_classes, input_size_s):
     rng = np.random.RandomState(42)
     time_conv_size_s = 0.5
     max_pool_size_s = 0.125


### PR DESCRIPTION
I have started making a sleep staging example based on [this paper](https://ieeexplore.ieee.org/abstract/document/8307462/?casa_token=FVbhoYtuaIEAAAAA:PqILZbwMgZB7q_jVUHEWmUkdFS-AYnnpUM5-tysyb7qwr8lodey0kZH7GLTnezTo1K4hPsLbRFUQwg) and the [Sleep Physionet dataset](https://physionet.org/content/sleep-edfx/1.0.0/).

It's still work in progress, but feedback would already be useful!

Next steps:
* Add z-scoring of windows
* Use `crop_wake_mins` to trim Wake regions in Sleep Physionet
* Adapt hyperparameters to this low-data setting
* Plot learning curve/confusion matrix
* Add a short discussion at the end of the example on other models, refs, etc.