### PR TITLE
Update documentation of windowers.py

### DIFF
--- a/braindecode/datautil/windowers.py
+++ b/braindecode/datautil/windowers.py
@@ -55,7 +55,7 @@ def create_windows_from_events(
         trial size of the first trial and trial_start_offset_samples and
         trial_stop_offset_samples.
     window_stride_samples: int | None
-        Stride between windows, in samples. If None, the window size is
+        Stride between windows, in samples. If None, the window stride is
         inferred from the original trial size of the first trial and
         trial_start_offset_samples and trial_stop_offset_samples.
     drop_last_window: bool

--- a/braindecode/datautil/windowers.py
+++ b/braindecode/datautil/windowers.py
@@ -59,7 +59,7 @@ def create_windows_from_events(
         inferred from the original trial size of the first trial and
         trial_start_offset_samples and trial_stop_offset_samples.
     drop_last_window: bool
-        If True, an additional overlapping window that ends at
+        If False, an additional overlapping window that ends at
         trial_stop_offset_samples will be extracted around each event when the
         last window does not end exactly at trial_stop_offset_samples.
     mapping: dict(str: int)


### PR DESCRIPTION
The documentation string of the parameter drop_last_window of such function starts with "If True, an additional overlapping window...", whereas is should be saying "If False, ad additional overlapping window...".