### PR TITLE
[MRG] Unifying preprocessors

### DIFF
--- a/braindecode/datasets/tuh.py
+++ b/braindecode/datasets/tuh.py
@@ -11,7 +11,6 @@ import re
 import os
 import glob
 
-import numpy as np
 import pandas as pd
 import mne
 

--- a/braindecode/datautil/__init__.py
+++ b/braindecode/datautil/__init__.py
@@ -4,7 +4,8 @@ Utilities for data manipulation.
 
 from .windowers import create_windows_from_events, create_fixed_length_windows
 from .preprocess import (zscore, scale, exponential_moving_demean,
-                         exponential_moving_standardize, filterbank)
+                         exponential_moving_standardize, filterbank,
+                         preprocess, Preprocessor)
 from .xy import create_from_X_y
 from .mne import create_from_mne_raw, create_from_mne_epochs
 from .serialization import save_concat_dataset, load_concat_dataset

--- a/braindecode/datautil/preprocess.py
+++ b/braindecode/datautil/preprocess.py
@@ -103,7 +103,7 @@ class NumpyPreproc(Preprocessor):
     """
     def __init__(self, fn, channel_wise=False, **kwargs):
         warn('NumpyPreproc is deprecated. Use Preprocessor with '
-             '`apply_on_array=True` instead.', UserWarning)
+             '`apply_on_array=True` instead.')
         assert callable(fn), 'fn must be callable.'
         super().__init__(fn, apply_on_array=True, channel_wise=channel_wise,
                          **kwargs)

--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -4,6 +4,7 @@
 
 
 import os
+import glob
 import random
 
 import numpy as np
@@ -336,3 +337,26 @@ def update_estimator_docstring(base_class, docstring):
                     splitted[1] + \
                     filtered_doc[filtered_doc.find('Attributes'):]
     return out_docstring
+
+
+def read_all_file_names(directory, extension):
+    """Read all files with specified extension from given path and sorts them
+    based on a given sorting key.
+
+    Parameters
+    ----------
+    directory: str
+        Parent directory to be searched for files of the specified type.
+    extension: str
+        File extension, i.e. ".edf" or ".txt".
+
+    Returns
+    -------
+    file_paths: list(str)
+        List of all files found in (sub)directories of path.
+    """
+    assert extension.startswith('.')
+    file_paths = glob.glob(directory + '**/*' + extension, recursive=True)
+    assert len(file_paths) > 0, (
+        f'something went wrong. Found no {extension} files in {directory}')
+    return file_paths

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -117,6 +117,8 @@ Data Utils
     filterbank
     save_concat_dataset
     load_concat_dataset
+    preprocess
+    Preprocessor
 
 Utils
 =====

--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,5 @@ dependencies:
 - skorch
 - joblib
 - pip:
-  - mne
+  - git+https://github.com/mne-tools/mne-python.git@5cc6eb8d7ebd102049843336d9d4a342f0f3e966
   - https://github.com/braindecode/braindecode/zipball/master

--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,5 @@ dependencies:
 - skorch
 - joblib
 - pip:
-  - git+https://github.com/mne-tools/mne-python.git@5cc6eb8d7ebd102049843336d9d4a342f0f3e966
+  - mne
   - https://github.com/braindecode/braindecode/zipball/master

--- a/examples/plot_bcic_iv_2a_moabb_cropped.py
+++ b/examples/plot_bcic_iv_2a_moabb_cropped.py
@@ -69,8 +69,6 @@ Cropped Decoding on BCIC IV 2a Dataset
 #     used for classification in PyTorch.
 #
 
-from collections import OrderedDict
-
 
 ######################################################################
 # Loading and preprocessing the dataset
@@ -88,8 +86,8 @@ from braindecode.datasets.moabb import MOABBDataset
 subject_id = 3
 dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[subject_id])
 
-from braindecode.datautil.preprocess import exponential_moving_standardize
-from braindecode.datautil.preprocess import preprocess
+from braindecode.datautil.preprocess import (
+    exponential_moving_standardize, preprocess, Preprocessor)
 
 low_cut_hz = 4.  # low cut frequency for filtering
 high_cut_hz = 38.  # high cut frequency for filtering
@@ -97,14 +95,13 @@ high_cut_hz = 38.  # high cut frequency for filtering
 factor_new = 1e-3
 init_block_size = 1000
 
-
-preprocessors = OrderedDict([
-    ('pick_types', dict(eeg=True, meg=False, stim=False)),  # Keep EEG sensors
-    (lambda x: x * 1e6, dict()),  # Convert from V to uV
-    ('filter', dict(l_freq=low_cut_hz, h_freq=high_cut_hz)),  # Bandpass filter
-    (exponential_moving_standardize,  # Exponential moving standardization
-        dict(factor_new=factor_new, init_block_size=init_block_size))
-])
+preprocessors = [
+    Preprocessor('pick_types', eeg=True, meg=False, stim=False),  # Keep EEG sensors
+    Preprocessor(lambda x: x * 1e6),  # Convert from V to uV
+    Preprocessor('filter', l_freq=low_cut_hz, h_freq=high_cut_hz),  # Bandpass filter
+    Preprocessor(exponential_moving_standardize,  # Exponential moving standardization
+                 factor_new=factor_new, init_block_size=init_block_size)
+]
 
 # Transform the data
 preprocess(dataset, preprocessors)
@@ -313,6 +310,7 @@ clf.fit(train_set, y=None, epochs=n_epochs)
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 import pandas as pd
+
 # Extract loss and accuracy values for plotting from history object
 results_columns = ['train_loss', 'valid_loss', 'train_accuracy', 'valid_accuracy']
 df = pd.DataFrame(clf.history[:, results_columns], columns=results_columns,

--- a/examples/plot_bcic_iv_2a_moabb_trial.py
+++ b/examples/plot_bcic_iv_2a_moabb_trial.py
@@ -8,8 +8,6 @@ labels (e.g., Right Hand, Left Hand, etc.).
 
 """
 
-from collections import OrderedDict
-
 ######################################################################
 # Loading and preprocessing the dataset
 # -------------------------------------
@@ -62,8 +60,8 @@ dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[subject_id])
 #    `torchvision <https://pytorch.org/docs/stable/torchvision/index.html>`__.
 #
 
-from braindecode.datautil.preprocess import exponential_moving_standardize
-from braindecode.datautil.preprocess import preprocess
+from braindecode.datautil.preprocess import (
+    exponential_moving_standardize, preprocess, Preprocessor)
 
 low_cut_hz = 4.  # low cut frequency for filtering
 high_cut_hz = 38.  # high cut frequency for filtering
@@ -71,13 +69,13 @@ high_cut_hz = 38.  # high cut frequency for filtering
 factor_new = 1e-3
 init_block_size = 1000
 
-preprocessors = OrderedDict([
-    ('pick_types', dict(eeg=True, meg=False, stim=False)),  # Keep EEG sensors
-    (lambda x: x * 1e6, dict()),  # Convert from V to uV
-    ('filter', dict(l_freq=low_cut_hz, h_freq=high_cut_hz)),  # Bandpass filter
-    (exponential_moving_standardize,  # Exponential moving standardization
-        dict(factor_new=factor_new, init_block_size=init_block_size))
-])
+preprocessors = [
+    Preprocessor('pick_types', eeg=True, meg=False, stim=False),  # Keep EEG sensors
+    Preprocessor(lambda x: x * 1e6),  # Convert from V to uV
+    Preprocessor('filter', l_freq=low_cut_hz, h_freq=high_cut_hz),  # Bandpass filter
+    Preprocessor(exponential_moving_standardize,  # Exponential moving standardization
+                 factor_new=factor_new, init_block_size=init_block_size)
+]
 
 # Transform the data
 preprocess(dataset, preprocessors)
@@ -249,6 +247,7 @@ clf.fit(train_set, y=None, epochs=n_epochs)
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
 import pandas as pd
+
 # Extract loss and accuracy values for plotting from history object
 results_columns = ['train_loss', 'valid_loss', 'train_accuracy', 'valid_accuracy']
 df = pd.DataFrame(clf.history[:, results_columns], columns=results_columns,

--- a/examples/plot_dataset_example.py
+++ b/examples/plot_dataset_example.py
@@ -11,15 +11,13 @@ with Braindecode.
 #
 # License: BSD (3-clause)
 
-from collections import OrderedDict
-
 import matplotlib.pyplot as plt
 from IPython.display import display
 
 from braindecode.datasets import MOABBDataset
 from braindecode.datautil.windowers import \
     create_windows_from_events, create_fixed_length_windows
-from braindecode.datautil.preprocess import preprocess
+from braindecode.datautil.preprocess import preprocess, Preprocessor
 
 ###############################################################################
 # First, we create a dataset based on BCIC IV 2a fetched with MOABB,
@@ -40,10 +38,10 @@ for x, y in ds:
 ##############################################################################
 # We can apply preprocessing transforms that are defined in mne and work
 # in-place, such as resampling, bandpass filtering, or electrode selection.
-preprocessors = OrderedDict([
-    ('pick_types', dict(eeg=True, meg=False, stim=True)),
-    ('resample', dict(sfreq=100))
-])
+preprocessors = [
+    Preprocessor('pick_types', eeg=True, meg=False, stim=True),
+    Preprocessor('resample', sfreq=100)
+]
 print(ds.datasets[0].raw.info["sfreq"])
 preprocess(ds, preprocessors)
 print(ds.datasets[0].raw.info["sfreq"])
@@ -106,11 +104,11 @@ def crop_windows(windows, start_offset_samples, stop_offset_samples):
                  include_tmax=False)
 
 
-epochs_preprocessors = OrderedDict([
-    ('pick_types', dict(eeg=True, meg=False, stim=False)),
-    (crop_windows, dict(apply_on_array=False, start_offset_samples=100,
-                        stop_offset_samples=900))
-])
+epochs_preprocessors = [
+    Preprocessor('pick_types', eeg=True, meg=False, stim=False),
+    Preprocessor(crop_windows, apply_on_array=False, start_offset_samples=100,
+                 stop_offset_samples=900)
+]
 
 print(windows_ds.datasets[0].windows.info["ch_names"],
       len(windows_ds.datasets[0].windows.times))

--- a/examples/plot_relative_positioning.py
+++ b/examples/plot_relative_positioning.py
@@ -77,17 +77,16 @@ dataset = SleepPhysionet(
 # we don't need to apply resampling.
 #
 
-from braindecode.datautil.preprocess import (
-    MNEPreproc, NumpyPreproc, preprocess)
+from collections import OrderedDict
+
+from braindecode.datautil.preprocess import preprocess
 
 high_cut_hz = 30
 
-preprocessors = [
-    # convert from volt to microvolt, directly modifying the numpy array
-    NumpyPreproc(fn=lambda x: x * 1e6),
-    # bandpass filter
-    MNEPreproc(fn='filter', l_freq=None, h_freq=high_cut_hz, n_jobs=n_jobs),
-]
+preprocessors = OrderedDict([
+    (lambda x: x * 1e6, dict()),
+    ('filter', dict(l_freq=None, h_freq=high_cut_hz, n_jobs=n_jobs))
+])
 
 # Transform the data
 preprocess(dataset, preprocessors)
@@ -141,7 +140,7 @@ windows_dataset = create_windows_from_events(
 
 from braindecode.datautil.preprocess import zscore
 
-preprocess(windows_dataset, [MNEPreproc(fn=zscore)])
+preprocess(windows_dataset, OrderedDict([(zscore, dict())]))
 
 
 ######################################################################
@@ -333,8 +332,8 @@ from skorch.callbacks import Checkpoint, EarlyStopping, EpochScoring
 from braindecode import EEGClassifier
 
 lr = 5e-3
-batch_size = 256
-n_epochs = 50
+batch_size = 512
+n_epochs = 25
 num_workers = 0 if n_jobs <= 1 else n_jobs
 
 cp = Checkpoint(dirname='', f_criterion=None, f_optimizer=None, f_history=None)

--- a/examples/plot_relative_positioning.py
+++ b/examples/plot_relative_positioning.py
@@ -77,16 +77,14 @@ dataset = SleepPhysionet(
 # we don't need to apply resampling.
 #
 
-from collections import OrderedDict
-
-from braindecode.datautil.preprocess import preprocess
+from braindecode.datautil.preprocess import preprocess, Preprocessor
 
 high_cut_hz = 30
 
-preprocessors = OrderedDict([
-    (lambda x: x * 1e6, dict()),
-    ('filter', dict(l_freq=None, h_freq=high_cut_hz, n_jobs=n_jobs))
-])
+preprocessors = [
+    Preprocessor(lambda x: x * 1e6),
+    Preprocessor('filter', l_freq=None, h_freq=high_cut_hz, n_jobs=n_jobs)
+]
 
 # Transform the data
 preprocess(dataset, preprocessors)
@@ -140,7 +138,7 @@ windows_dataset = create_windows_from_events(
 
 from braindecode.datautil.preprocess import zscore
 
-preprocess(windows_dataset, OrderedDict([(zscore, dict())]))
+preprocess(windows_dataset, [Preprocessor(zscore)])
 
 
 ######################################################################

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -73,17 +73,16 @@ dataset = SleepPhysionet(
 # Physionet data is already sampled at a lower 100 Hz.
 #
 
-from braindecode.datautil.preprocess import (
-    MNEPreproc, NumpyPreproc, preprocess)
+from collections import OrderedDict
+
+from braindecode.datautil.preprocess import preprocess
 
 high_cut_hz = 30
 
-preprocessors = [
-    # convert from volt to microvolt, directly modifying the numpy array
-    NumpyPreproc(fn=lambda x: x * 1e6),
-    # bandpass filter
-    MNEPreproc(fn='filter', l_freq=None, h_freq=high_cut_hz),
-]
+preprocessors = OrderedDict([
+    (lambda x: x * 1e6, dict()),
+    ('filter', dict(l_freq=None, h_freq=high_cut_hz))
+])
 
 # Transform the data
 preprocess(dataset, preprocessors)
@@ -133,7 +132,7 @@ windows_dataset = create_windows_from_events(
 
 from braindecode.datautil.preprocess import zscore
 
-preprocess(windows_dataset, [MNEPreproc(fn=zscore)])
+preprocess(windows_dataset, OrderedDict([(zscore, dict())]))
 
 
 ######################################################################

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -73,16 +73,14 @@ dataset = SleepPhysionet(
 # Physionet data is already sampled at a lower 100 Hz.
 #
 
-from collections import OrderedDict
-
-from braindecode.datautil.preprocess import preprocess
+from braindecode.datautil.preprocess import preprocess, Preprocessor
 
 high_cut_hz = 30
 
-preprocessors = OrderedDict([
-    (lambda x: x * 1e6, dict()),
-    ('filter', dict(l_freq=None, h_freq=high_cut_hz))
-])
+preprocessors = [
+    Preprocessor(lambda x: x * 1e6),
+    Preprocessor('filter', l_freq=None, h_freq=high_cut_hz)
+]
 
 # Transform the data
 preprocess(dataset, preprocessors)
@@ -132,7 +130,7 @@ windows_dataset = create_windows_from_events(
 
 from braindecode.datautil.preprocess import zscore
 
-preprocess(windows_dataset, OrderedDict([(zscore, dict())]))
+preprocess(windows_dataset, [Preprocessor(zscore)])
 
 
 ######################################################################

--- a/examples/tuh_eeg_corpus.py
+++ b/examples/tuh_eeg_corpus.py
@@ -176,9 +176,9 @@ preprocessors = [
     Preprocessor('set_eeg_reference', ref_channels='average', ch_type='eeg'),
     Preprocessor(custom_rename_channels, mapping=ch_mapping,
                  apply_on_array=False),
-    Preprocessor("pick_channels", ch_names=short_ch_names, ordered=True),
+    Preprocessor('pick_channels', ch_names=short_ch_names, ordered=True),
     Preprocessor(lambda x: x * 1e6),
-    Preprocessor("resample", sfreq=sfreq),
+    Preprocessor('resample', sfreq=sfreq),
 ]
 
 

--- a/examples/tuh_eeg_corpus.py
+++ b/examples/tuh_eeg_corpus.py
@@ -18,7 +18,7 @@ plt.style.use('seaborn')
 import mne
 
 from braindecode.datasets import TUH
-from braindecode.datautil.preprocess import preprocess, MNEPreproc, NumpyPreproc
+from braindecode.datautil.preprocess import preprocess, Preprocessor
 from braindecode.datautil.windowers import create_fixed_length_windows
 from braindecode.datautil.serialization import (
     save_concat_dataset, load_concat_dataset)
@@ -86,7 +86,7 @@ def select_by_duration(ds, tmin=0, tmax=None):
     return split
 
 
-tmin = 5*60
+tmin = 5 * 60
 tmax = None
 tuh = select_by_duration(tuh, tmin, tmax)
 
@@ -166,17 +166,19 @@ def custom_crop(raw, tmin=0.0, tmax=None, include_tmax=True):
     raw.crop(tmin=tmin, tmax=tmax, include_tmax=include_tmax)
 
 
-tmin = 1*60
-tmax = 6*60
+tmin = 1 * 60
+tmax = 6 * 60
 sfreq = 100
 
 preprocessors = [
-    MNEPreproc(custom_crop, tmin=tmin, tmax=tmax, include_tmax=False),
-    MNEPreproc('set_eeg_reference', ref_channels='average', ch_type='eeg'),
-    MNEPreproc(custom_rename_channels, mapping=ch_mapping),
-    MNEPreproc("pick_channels", ch_names=short_ch_names, ordered=True),
-    NumpyPreproc(lambda x: x * 1e6),
-    MNEPreproc("resample", sfreq=sfreq),
+    Preprocessor(custom_crop, tmin=tmin, tmax=tmax, include_tmax=False,
+                 apply_on_array=False),
+    Preprocessor('set_eeg_reference', ref_channels='average', ch_type='eeg'),
+    Preprocessor(custom_rename_channels, mapping=ch_mapping,
+                 apply_on_array=False),
+    Preprocessor("pick_channels", ch_names=short_ch_names, ordered=True),
+    Preprocessor(lambda x: x * 1e6),
+    Preprocessor("resample", sfreq=sfreq),
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ pandas
 scipy
 matplotlib
 h5py
-mne
 skorch
 joblib
+git+https://github.com/mne-tools/mne-python.git@5cc6eb8d7ebd102049843336d9d4a342f0f3e966

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ matplotlib
 h5py
 skorch
 joblib
-git+https://github.com/mne-tools/mne-python.git@5cc6eb8d7ebd102049843336d9d4a342f0f3e966
+mne

--- a/test/unit_tests/datautil/test_preprocess.py
+++ b/test/unit_tests/datautil/test_preprocess.py
@@ -3,22 +3,22 @@
 #
 # License: BSD-3
 
-import numpy as np
 import pytest
+import numpy as np
 
 from braindecode.datasets import MOABBDataset
 from braindecode.datautil.preprocess import preprocess, zscore, scale, \
-    MNEPreproc, NumpyPreproc, filterbank, exponential_moving_demean, \
+    Preprocessor, filterbank, exponential_moving_demean, \
     exponential_moving_standardize
 from braindecode.datautil.windowers import create_fixed_length_windows
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def base_concat_ds():
     return MOABBDataset(dataset_name='BNCI2014001', subject_ids=[1, 2])
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def windows_concat_ds(base_concat_ds):
     return create_fixed_length_windows(
         base_concat_ds, start_offset_samples=100, stop_offset_samples=None,
@@ -42,28 +42,57 @@ def test_no_raw_or_epochs():
 
 
 def test_method_not_available(base_concat_ds):
-    preprocessors = [MNEPreproc('this_method_is_not_real', )]
+    preprocessors = [Preprocessor('this_method_is_not_real', )]
     with pytest.raises(AttributeError):
         preprocess(base_concat_ds, preprocessors)
 
 
-def test_transform_base_method(base_concat_ds):
-    preprocessors = [MNEPreproc("resample", sfreq=50)]
+def test_preprocess_raw_str(base_concat_ds):
+    preprocessors = [Preprocessor('resample', sfreq=50)]
     preprocess(base_concat_ds, preprocessors)
     assert base_concat_ds.datasets[0].raw.info['sfreq'] == 50
 
 
-def test_transform_windows_method(windows_concat_ds):
-    preprocessors = [MNEPreproc("filter", l_freq=7, h_freq=13)]
+def test_preprocess_windows_str(windows_concat_ds):
+    preprocessors = [Preprocessor('filter', l_freq=7, h_freq=13)]
     raw_window = windows_concat_ds[0][0]
     preprocess(windows_concat_ds, preprocessors)
     assert not np.array_equal(raw_window, windows_concat_ds[0][0])
 
 
+def test_preprocess_raw_callable_on_array(base_concat_ds):
+    # Case tested in test_zscore_continuous
+    pass
+
+
+def test_preprocess_windows_callable_on_array(windows_concat_ds):
+    # Case tested in test_zscore_windows
+    pass
+
+
+def test_preprocess_raw_callable_on_object(base_concat_ds):
+    # Case tested in test_filterbank
+    pass
+
+
+def test_preprocess_windows_callable_on_object(windows_concat_ds):
+
+    def modify_windows_object(epochs, factor=1):
+        epochs._data *= factor
+
+    factor = 10
+    preprocessors = [Preprocessor(modify_windows_object, apply_on_array=False,
+                                  factor=factor)]
+    raw_window = windows_concat_ds[0][0]
+    preprocess(windows_concat_ds, preprocessors)
+    np.testing.assert_allclose(windows_concat_ds[0][0], raw_window * factor,
+                               rtol=1e-4, atol=1e-4)
+
+
 def test_zscore_continuous(base_concat_ds):
     preprocessors = [
-        MNEPreproc('pick_types', eeg=True, meg=False, stim=False),
-        MNEPreproc('apply_function', fun=zscore, channel_wise=True)
+        Preprocessor('pick_types', eeg=True, meg=False, stim=False),
+        Preprocessor(zscore, channel_wise=True)
     ]
     preprocess(base_concat_ds, preprocessors)
     for ds in base_concat_ds.datasets:
@@ -81,8 +110,8 @@ def test_zscore_continuous(base_concat_ds):
 
 def test_zscore_windows(windows_concat_ds):
     preprocessors = [
-        MNEPreproc('pick_types', eeg=True, meg=False, stim=False),
-        MNEPreproc(zscore, )
+        Preprocessor('pick_types', eeg=True, meg=False, stim=False),
+        Preprocessor(zscore)
     ]
     preprocess(windows_concat_ds, preprocessors)
     for ds in windows_concat_ds.datasets:
@@ -101,33 +130,30 @@ def test_zscore_windows(windows_concat_ds):
 def test_scale_continuous(base_concat_ds):
     factor = 1e6
     preprocessors = [
-        MNEPreproc('pick_types', eeg=True, meg=False, stim=False),
-        NumpyPreproc(scale, factor=factor)
+        Preprocessor('pick_types', eeg=True, meg=False, stim=False),
+        Preprocessor(scale, factor=factor)
     ]
-    raw_timepoint = base_concat_ds[0][0]
+    raw_timepoint = base_concat_ds[0][0][:22]  # only keep EEG channels
     preprocess(base_concat_ds, preprocessors)
-    expected = np.ones_like(raw_timepoint) * factor
-    np.testing.assert_allclose(base_concat_ds[0][0] / raw_timepoint, expected,
+    np.testing.assert_allclose(base_concat_ds[0][0], raw_timepoint * factor,
                                rtol=1e-4, atol=1e-4)
 
 
 def test_scale_windows(windows_concat_ds):
     factor = 1e6
     preprocessors = [
-        MNEPreproc('pick_types', eeg=True, meg=False, stim=False),
-        MNEPreproc(scale, factor=factor)
+        Preprocessor('pick_types', eeg=True, meg=False, stim=False),
+        Preprocessor(scale, factor=factor)
     ]
-    raw_window = windows_concat_ds[0][0]
+    raw_window = windows_concat_ds[0][0][:22]  # only keep EEG channels
     preprocess(windows_concat_ds, preprocessors)
-    expected = np.ones_like(raw_window) * factor
-    np.testing.assert_allclose(windows_concat_ds[0][0] / raw_window, expected,
+    np.testing.assert_allclose(windows_concat_ds[0][0], raw_window * factor,
                                rtol=1e-4, atol=1e-4)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope='module')
 def mock_data():
-    np.random.seed(20200217)
-    mock_input = np.random.rand(2, 10).reshape(2, 10)
+    mock_input = np.random.RandomState(20200217).rand(2, 10).reshape(2, 10)
     expected_standardized = np.array(
         [[ 0.        , -1.41385996, -1.67770482,  1.95328935,  0.61618697,
           -0.55294099, -1.08890304,  1.04546089, -1.368485  , -1.08669994],
@@ -174,28 +200,30 @@ def test_exponential_running_init_block_size(mock_data):
     demeaned_data = exponential_moving_demean(
         mock_input, init_block_size=init_block_size)
     np.testing.assert_allclose(
-        demeaned_data[:, :init_block_size].mean(axis=1), 0, rtol=1e-4, atol=1e-4)
+        demeaned_data[:, :init_block_size].mean(axis=1), 0, rtol=1e-4,
+        atol=1e-4)
 
 
 def test_filterbank(base_concat_ds):
-    base_concat_ds = base_concat_ds.split([[0]])["0"]
+    base_concat_ds = base_concat_ds.split([[0]])['0']
     preprocessors = [
-        MNEPreproc('pick_channels', ch_names=sorted(["C4", "Cz"]), ordered=True),
-        MNEPreproc(filterbank, frequency_bands=[(0, 4), (4, 8), (8, 13)],
-                   drop_original_signals=False),
+        Preprocessor('pick_channels', ch_names=sorted(['C4', 'Cz']),
+                     ordered=True),
+        Preprocessor(filterbank, frequency_bands=[(0, 4), (4, 8), (8, 13)],
+                     drop_original_signals=False, apply_on_array=False)
     ]
     preprocess(base_concat_ds, preprocessors)
     for x, y in base_concat_ds:
         break
     assert x.shape[0] == 8
     freq_band_annots = [
-        ch.split("_")[-1]
+        ch.split('_')[-1]
         for ch in base_concat_ds.datasets[0].raw.ch_names
         if '_' in ch]
     assert len(np.unique(freq_band_annots)) == 3
     np.testing.assert_array_equal(base_concat_ds.datasets[0].raw.ch_names, [
-        "C4", "C4_0-4", "C4_4-8", "C4_8-13",
-        "Cz", "Cz_0-4", "Cz_4-8", "Cz_8-13",
+        'C4', 'C4_0-4', 'C4_4-8', 'C4_8-13',
+        'Cz', 'Cz_0-4', 'Cz_4-8', 'Cz_8-13',
     ])
 
 

--- a/test/unit_tests/datautil/test_preprocess.py
+++ b/test/unit_tests/datautil/test_preprocess.py
@@ -3,8 +3,6 @@
 #
 # License: BSD-3
 
-from collections import OrderedDict
-
 import numpy as np
 import pytest
 
@@ -185,7 +183,7 @@ def test_filterbank(base_concat_ds):
         MNEPreproc('pick_channels', ch_names=sorted(["C4", "Cz"]), ordered=True),
         MNEPreproc(filterbank, frequency_bands=[(0, 4), (4, 8), (8, 13)],
                    drop_original_signals=False),
-        ]
+    ]
     preprocess(base_concat_ds, preprocessors)
     for x, y in base_concat_ds:
         break

--- a/test/unit_tests/datautil/test_windowers.py
+++ b/test/unit_tests/datautil/test_windowers.py
@@ -16,7 +16,7 @@ from braindecode.datasets.base import BaseDataset, BaseConcatDataset
 from braindecode.datasets.moabb import fetch_data_with_moabb
 from braindecode.datautil import (
     create_windows_from_events, create_fixed_length_windows)
-from braindecode.datautil.preprocess import MNEPreproc, preprocess
+from braindecode.datautil.preprocess import Preprocessor, preprocess
 from braindecode.util import create_mne_dummy_raw
 
 
@@ -362,7 +362,7 @@ def test_windows_from_events_cropped(lazy_loadable_dataset):
     ds.datasets[0].raw.annotations.crop(tmin, tmax)
 
     crop_ds = copy.deepcopy(lazy_loadable_dataset)
-    crop_transform = MNEPreproc('crop', tmin=tmin, tmax=tmax)
+    crop_transform = Preprocessor('crop', tmin=tmin, tmax=tmax)
     preprocess(crop_ds, [crop_transform])
 
     # Extract windows
@@ -403,7 +403,7 @@ def test_windows_fixed_length_cropped(lazy_loadable_dataset):
     ds.datasets[0].raw.annotations.crop(tmin, tmax)
 
     crop_ds = copy.deepcopy(lazy_loadable_dataset)
-    crop_transform = MNEPreproc('crop', tmin=tmin, tmax=tmax)
+    crop_transform = Preprocessor('crop', tmin=tmin, tmax=tmax)
     preprocess(crop_ds, [crop_transform])
 
     # Extract windows


### PR DESCRIPTION
Following the discussion in  #160, I took a shot at unifying the preprocessors now that `apply_function` is available for the `Epochs` object too (https://github.com/mne-tools/mne-python/pull/9235).

This is still work in progress, and I wanted to hear what @gemeinl @robintibor @agramfort think before going further. Notably, I made the choice to keep the following three cases possible:
1. `fn` is a string -> the corresponding method of Raw or Epochs is used
2. `fn` is a callable and `apply_on_array` is True -> the `apply_function` method of Raw or Epochs is used to apply the callable on the underlying numpy array
3. `fn` is a callable and `apply_on_array` is False -> the callable must modify the Raw or Epochs object directly (e.g. by modifying its `_data` attribute inplace or calling its methods)

I'm not sure `apply_on_array` is the best choice of name for this. Also, although case 3 seems like it might enable bad practice in some cases, it was required to allow the existing `preprocess.filterbank` function to work and so I included it.

The following are still missing:
- I haven't modified the examples yet.
- Version check for the latest MNE main (commit 5cc6eb8d7ebd102049843336d9d4a342f0f3e966 from 2021-04-05, which is not in the latest release v0.22.1)
- If we decide to go with this new unified preprocessor object we might be able to go back to defining the preprocessing steps inside an OrderedDict as pairs (`fn`, `kwargs`) instead of a list of preprocessor objects.