### PR TITLE
[MRG] Adding support for on-the-fly transforms

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -18,23 +18,41 @@ import pandas as pd
 from torch.utils.data import Dataset, ConcatDataset
 
 
+def _create_description(description):
+    if description is not None:
+        if (not isinstance(description, pd.Series)
+                and not isinstance(description, dict)):
+            raise ValueError(f"'{description}' has to be either a "
+                             f"pandas.Series or a dict.")
+        if isinstance(description, dict):
+            description = pd.Series(description)
+    return description
+
+
 class BaseDataset(Dataset):
-    """A base dataset holds a mne.Raw, and a pandas.DataFrame with additional
-    description, such as subject_id, session_id, run_id, or age or gender of
-    subjects.
+    """Returns samples from an mne.io.Raw object along with a target.
+
+    Dataset which serves samples from an mne.io.Raw object along with a target.
+    The target is unique for the dataset, and is obtained through the
+    `description` attribute.
 
     Parameters
     ----------
     raw: mne.io.Raw
+        Continuous data.
     description: dict | pandas.Series | None
-        holds additional description about the continuous signal / subject
+        Holds additional description about the continuous signal / subject.
     target_name: str | None
-        name of the index in `description` that should be use to provide the
+        Name of the index in `description` that should be used to provide the
         target (e.g., to be used in a prediction task later on).
+    transform : callable | None
+        On-the-fly transform applied to the example before it is returned.
     """
-    def __init__(self, raw, description=None, target_name=None):
+    def __init__(self, raw, description=None, target_name=None,
+                 transform=None):
         self.raw = raw
         self.description = _create_description(description)
+        self.transform = transform
 
         # save target name for load/save later
         self.target_name = target_name
@@ -46,52 +64,80 @@ class BaseDataset(Dataset):
             raise ValueError(f"'{target_name}' not in description.")
 
     def __getitem__(self, index):
-        return self.raw[:, index][0], self.target
+        X, y = self.raw[:, index][0], self.target
+        if self.transform is not None:
+            X = self.transform(X)
+        return X, y
 
     def __len__(self):
         return len(self.raw)
 
+    @property
+    def transform(self):
+        return self._transform
 
-def _create_description(description):
-    if description is not None:
-        if (not isinstance(description, pd.Series)
-                and not isinstance(description, dict)):
-            raise ValueError(f"'{description}' has to be either a "
-                             f"pandas.Series or a dict")
-        if isinstance(description, dict):
-            description = pd.Series(description)
-    return description
+    @transform.setter
+    def transform(self, value):
+        if value is not None and not callable(value):
+            raise ValueError('Transform needs to be a callable.')
+        self._transform = value
 
 
 class WindowsDataset(BaseDataset):
-    """Applies a windower to a base dataset.
+    """Returns windows from an mne.Epochs object along with a target.
+
+    Dataset which serves windows from an mne.Epochs object along with their
+    target and additional information. The `metadata` attribute of the Epochs
+    object must contain a column called `target`, which will be used to return
+    the target that corresponds to a window. Additional columns
+    `i_window_in_trial`, `i_start_in_trial`, `i_stop_in_trial` are also
+    required to serve information about the windowing (e.g., useful for cropped
+    training).
+    See `braindecode.datautil.windowers` to directly create a `WindowsDataset`
+    from a `BaseDataset` object.
 
     Parameters
     ----------
-    windows: mne.Epochs
-        windows obtained through the application of a windower to a
-        BaseDataset
-    description: dict | pandas.Series | None
-        holds additional info about the windows
+    windows : mne.Epochs
+        Windows obtained through the application of a windower to a BaseDataset
+        (see `braindecode.datautil.windowers`).
+    description : dict | pandas.Series | None
+        Holds additional info about the windows.
+    transform : callable | None
+        On-the-fly transform applied to a window before it is returned.
     """
-    def __init__(self, windows, description=None):
+    def __init__(self, windows, description=None, transform=None):
         self.windows = windows
         self.description = _create_description(description)
-        self.y = np.array(self.windows.metadata.loc[:, 'target'])
-        self.crop_inds = np.array(self.windows.metadata.loc[:,
-                                  ['i_window_in_trial', 'i_start_in_trial',
-                                   'i_stop_in_trial']])
+        self.transform = transform
+
+        self.y = self.windows.metadata.loc[:, 'target'].values
+        self.crop_inds = self.windows.metadata.loc[
+            :, ['i_window_in_trial', 'i_start_in_trial',
+                'i_stop_in_trial']].values
 
     def __getitem__(self, index):
         X = self.windows.get_data(item=index)[0].astype('float32')
+        if self.transform is not None:
+            X = self.transform(X)
         y = self.y[index]
-        # necessary to cast as list to get list of
-        # three tensors from batch, otherwise get single 2d-tensor...
-        crop_inds = list(self.crop_inds[index])
+        # necessary to cast as list to get list of three tensors from batch,
+        # otherwise get single 2d-tensor...
+        crop_inds = self.crop_inds[index].tolist()
         return X, y, crop_inds
 
     def __len__(self):
         return len(self.windows.events)
+
+    @property
+    def transform(self):
+        return self._transform
+
+    @transform.setter
+    def transform(self, value):
+        if value is not None and not callable(value):
+            raise ValueError('Transform needs to be a callable.')
+        self._transform = value
 
 
 class BaseConcatDataset(ConcatDataset):
@@ -183,3 +229,12 @@ class BaseConcatDataset(ConcatDataset):
             all_dfs.append(df)
 
         return pd.concat(all_dfs)
+
+    @property
+    def transform(self):
+        return [ds.transform for ds in self.datasets]
+
+    @transform.setter
+    def transform(self, value):
+        for i in range(len(self.datasets)):
+            self.datasets[i].transform = value

--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -111,10 +111,10 @@ class WindowsDataset(BaseDataset):
         self.description = _create_description(description)
         self.transform = transform
 
-        self.y = self.windows.metadata.loc[:, 'target'].values
+        self.y = self.windows.metadata.loc[:, 'target'].to_numpy()
         self.crop_inds = self.windows.metadata.loc[
             :, ['i_window_in_trial', 'i_start_in_trial',
-                'i_stop_in_trial']].values
+                'i_stop_in_trial']].to_numpy()
 
     def __getitem__(self, index):
         X = self.windows.get_data(item=index)[0].astype('float32')

--- a/test/unit_tests/datasets/test_dataset.py
+++ b/test/unit_tests/datasets/test_dataset.py
@@ -28,10 +28,10 @@ def set_up():
                        [400, 0, 4],
                        [500, 0, 3]])
     window_idxs = [(0, 0, 100),
-                      (0, 100, 200),
-                      (1, 0, 100),
-                      (2, 0, 100),
-                      (2, 50, 150)]
+                   (0, 100, 200),
+                   (1, 0, 100),
+                   (2, 0, 100),
+                   (2, 50, 150)]
     i_window_in_trial, i_start_in_trial, i_stop_in_trial = list(
         zip(*window_idxs))
     metadata = pd.DataFrame(
@@ -71,7 +71,7 @@ def concat_windows_dataset(concat_ds_targets):
 
 
 def test_get_item(set_up):
-    _, _, mne_epochs, windows_dataset, events, window_idxs  = set_up
+    _, _, mne_epochs, windows_dataset, events, window_idxs = set_up
     for i, epoch in enumerate(mne_epochs.get_data()):
         x, y, inds = windows_dataset[i]
         np.testing.assert_allclose(epoch, x)
@@ -198,3 +198,30 @@ def test_metadata(concat_windows_dataset):
 def test_no_metadata(concat_ds_targets):
     with pytest.raises(TypeError, match='Metadata dataframe can only be'):
         concat_ds_targets[0].get_metadata()
+
+
+def test_on_the_fly_transforms_base_dataset(concat_ds_targets):
+    concat_ds, targets = concat_ds_targets
+    original_X = concat_ds[0][0]
+    factor = 10
+    transform = lambda x: x * factor
+    concat_ds.transform = transform
+    transformed_X = concat_ds[0][0]
+
+    assert (factor * original_X == transformed_X).all()
+
+    with pytest.raises(ValueError):
+        concat_ds.transform = 0
+
+
+def test_on_the_fly_transforms_windows_dataset(concat_windows_dataset):
+    original_X = concat_windows_dataset[0][0]
+    factor = 10
+    transform = lambda x: x * factor
+    concat_windows_dataset.transform = transform
+    transformed_X = concat_windows_dataset[0][0]
+
+    assert (factor * original_X == transformed_X).all()
+
+    with pytest.raises(ValueError):
+        concat_windows_dataset.transform = 0


### PR DESCRIPTION
This PR adds support for on-the-fly transforms in `BaseDataset` and `WindowsDataset`. It also adds a similar API to modify the underlying transforms in `BaseConcatDataset`.

 It is based on the way transforms are implemented in torchvision: https://pytorch.org/tutorials/beginner/data_loading_tutorial.html