### PR TITLE
[MRG] Parallelizing windowers over BaseDatasets

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -12,7 +12,6 @@ Dataset classes.
 
 import warnings
 
-import numpy as np
 import pandas as pd
 
 from torch.utils.data import Dataset, ConcatDataset

--- a/braindecode/datautil/windowers.py
+++ b/braindecode/datautil/windowers.py
@@ -13,8 +13,116 @@ import warnings
 import numpy as np
 import mne
 import pandas as pd
+from joblib import Parallel, delayed
 
 from ..datasets.base import WindowsDataset, BaseConcatDataset
+
+
+def _create_windows_from_events(
+        ds, infer_mapping, infer_window_size_stride,
+        trial_start_offset_samples, trial_stop_offset_samples,
+        window_size_samples=None, window_stride_samples=None,
+        drop_last_window=False, mapping=None, preload=False,
+        drop_bad_windows=True, picks=None, reject=None, flat=None,
+        on_missing='error'):
+    """Create WindowsDataset from BaseDataset based on events.
+
+    Parameters
+    ----------
+    ds : BaseDataset
+        Dataset containing continuous data and description.
+    infer_mapping : bool
+        If True, extract all events from all datasets and map them to
+        increasing integers starting from 0.
+    infer_window_size_stride : bool
+        If True, infer the stride from the original trial size of the first
+        trial and trial_start_offset_samples and trial_stop_offset_samples.
+
+    See `create_windows_from_events` for description of other parameters.
+
+    Returns
+    -------
+    WindowsDataset :
+        Windowed dataset.
+    """
+    if infer_mapping:
+        unique_events = np.unique(ds.raw.annotations.description)
+        new_unique_events = [x for x in unique_events if x not in mapping]
+        # mapping event descriptions to integers from 0 on
+        max_id_mapping = len(mapping)
+        mapping.update(
+            {v: k + max_id_mapping for k, v in enumerate(new_unique_events)}
+        )
+
+    events, events_id = mne.events_from_annotations(ds.raw, mapping)
+    onsets = events[:, 0]
+    # Onsets are relative to the beginning of the recording
+    filtered_durations = np.array(
+        [a['duration'] for a in ds.raw.annotations
+            if a['description'] in events_id]
+    )
+    stops = onsets + (filtered_durations * ds.raw.info['sfreq']).astype(int)
+    # XXX This could probably be simplified by using chunk_duration in
+    #     `events_from_annotations`
+
+    last_samp = ds.raw.first_samp + ds.raw.n_times
+    if stops[-1] + trial_stop_offset_samples > last_samp:
+        raise ValueError(
+            '"trial_stop_offset_samples" too large. Stop of last trial '
+            f'({stops[-1]}) + "trial_stop_offset_samples" '
+            f'({trial_stop_offset_samples}) must be smaller than length of'
+            f' recording ({len(ds)}).')
+
+    if infer_window_size_stride:
+        # window size is trial size
+        if window_size_samples is None:
+            window_size_samples = stops[0] + trial_stop_offset_samples - (
+                onsets[0] + trial_start_offset_samples)
+            window_stride_samples = window_size_samples
+        this_trial_sizes = (stops + trial_stop_offset_samples) - (
+            onsets + trial_start_offset_samples)
+        # Maybe actually this is not necessary?
+        # We could also just say we just assume window size=trial size
+        # in case not given, without this condition...
+        # but then would have to change functions overall
+        # to deal with varying window sizes hmmhmh
+        assert np.all(this_trial_sizes == window_size_samples), (
+            'All trial sizes should be the same if you do not supply a window '
+            'size.')
+
+    description = events[:, -1]
+
+    i_trials, i_window_in_trials, starts, stops = _compute_window_inds(
+        onsets, stops, trial_start_offset_samples,
+        trial_stop_offset_samples, window_size_samples,
+        window_stride_samples, drop_last_window)
+
+    events = [[start, window_size_samples, description[i_trials[i_start]]]
+              for i_start, start in enumerate(starts)]
+    events = np.array(events)
+
+    if any(np.diff(events[:, 0]) <= 0):
+        raise NotImplementedError('Trial overlap not implemented.')
+
+    description = events[:, -1]
+
+    metadata = pd.DataFrame({
+        'i_window_in_trial': i_window_in_trials,
+        'i_start_in_trial': starts,
+        'i_stop_in_trial': stops,
+        'target': description})
+
+    # window size - 1, since tmax is inclusive
+    mne_epochs = mne.Epochs(
+        ds.raw, events, events_id, baseline=None, tmin=0,
+        tmax=(window_size_samples - 1) / ds.raw.info['sfreq'],
+        metadata=metadata, preload=preload, picks=picks, reject=reject,
+        flat=flat, on_missing=on_missing)
+
+    if drop_bad_windows:
+        mne_epochs.drop_bad()
+
+    return WindowsDataset(mne_epochs, ds.description)
 
 
 def create_windows_from_events(
@@ -22,7 +130,7 @@ def create_windows_from_events(
         window_size_samples=None, window_stride_samples=None,
         drop_last_window=False, mapping=None, preload=False,
         drop_bad_windows=True, picks=None, reject=None, flat=None,
-        on_missing='error'):
+        on_missing='error', n_jobs=1):
     """Create windows based on events in mne.Raw.
 
     This function extracts windows of size window_size_samples in the interval
@@ -85,6 +193,8 @@ def create_windows_from_events(
     on_missing: str
         What to do if one or several event ids are not found in the recording.
         Valid keys are ‘error’ | ‘warning’ | ‘ignore’. See mne.Epochs.
+    n_jobs: int
+        Number of jobs to use to parallelize the windowing.
 
     Returns
     -------
@@ -99,99 +209,81 @@ def create_windows_from_events(
     # and map them to increasing integers starting from 0
     infer_mapping = mapping is None
     mapping = dict() if infer_mapping else mapping
-
     infer_window_size_stride = window_size_samples is None
 
-    list_of_windows_ds = list()
-    for ds in concat_ds.datasets:
-        if infer_mapping:
-            unique_events = np.unique(ds.raw.annotations.description)
-            new_unique_events = [x for x in unique_events if x not in mapping]
-            # mapping event descriptions to integers from 0 on
-            max_id_mapping = len(mapping)
-            mapping.update(
-                {v: k + max_id_mapping for k, v in enumerate(new_unique_events)}
-            )
-
-        events, events_id = mne.events_from_annotations(ds.raw, mapping)
-        onsets = events[:, 0]
-        # Onsets are relative to the beginning of the recording
-        filtered_durations = np.array(
-            [a['duration'] for a in ds.raw.annotations
-             if a['description'] in events_id]
-        )
-        stops = onsets + (filtered_durations * ds.raw.info['sfreq']).astype(int)
-        # XXX This could probably be simplified by using chunk_duration in
-        #     `events_from_annotations`
-
-        last_samp = ds.raw.first_samp + ds.raw.n_times
-        if stops[-1] + trial_stop_offset_samples > last_samp:
-            raise ValueError(
-                '"trial_stop_offset_samples" too large. Stop of last trial '
-                f'({stops[-1]}) + "trial_stop_offset_samples" '
-                f'({trial_stop_offset_samples}) must be smaller than length of'
-                f' recording ({len(ds)}).')
-
-        if infer_window_size_stride:
-            # window size is trial size
-            if window_size_samples is None:
-                window_size_samples = stops[0] + trial_stop_offset_samples - (
-                    onsets[0] + trial_start_offset_samples)
-                window_stride_samples = window_size_samples
-            this_trial_sizes = (stops + trial_stop_offset_samples) - (
-                onsets  + trial_start_offset_samples)
-            # Maybe actually this is not necessary?
-            # We could also just say we just assume window size=trial size
-            # in case not given, without this condition...
-            # but then would have to change functions overall
-            # to deal with varying window sizes hmmhmh
-            assert np.all(this_trial_sizes == window_size_samples), (
-                'All trial sizes should be the same if you do not supply '
-                'a window size.')
-
-        description = events[:, -1]
-
-        i_trials, i_window_in_trials, starts, stops = _compute_window_inds(
-            onsets, stops, trial_start_offset_samples,
-            trial_stop_offset_samples, window_size_samples,
-            window_stride_samples, drop_last_window)
-
-        events = [[start, window_size_samples, description[i_trials[i_start]]]
-                   for i_start, start in enumerate(starts)]
-        events = np.array(events)
-
-        if any(np.diff(events[:, 0]) <= 0):
-            raise NotImplementedError('Trial overlap not implemented.')
-
-        description = events[:, -1]
-
-        metadata = pd.DataFrame({
-            'i_window_in_trial': i_window_in_trials,
-            'i_start_in_trial': starts,
-            'i_stop_in_trial': stops,
-            'target': description})
-
-        # window size - 1, since tmax is inclusive
-        mne_epochs = mne.Epochs(
-            ds.raw, events, events_id, baseline=None, tmin=0,
-            tmax=(window_size_samples - 1) / ds.raw.info['sfreq'],
-            metadata=metadata, preload=preload, picks=picks, reject=reject,
-            flat=flat, on_missing=on_missing)
-
-        if drop_bad_windows:
-            mne_epochs.drop_bad()
-
-        windows_ds = WindowsDataset(mne_epochs, ds.description)
-        list_of_windows_ds.append(windows_ds)
+    list_of_windows_ds = Parallel(n_jobs=n_jobs)(
+        delayed(_create_windows_from_events)(
+            ds, infer_mapping, infer_window_size_stride,
+            trial_start_offset_samples, trial_stop_offset_samples,
+            window_size_samples, window_stride_samples, drop_last_window,
+            mapping, preload, drop_bad_windows, picks, reject, flat,
+            'error') for ds in concat_ds.datasets)
 
     return BaseConcatDataset(list_of_windows_ds)
+
+
+def _create_fixed_length_windows(
+        ds, start_offset_samples, stop_offset_samples, window_size_samples,
+        window_stride_samples, drop_last_window, mapping=None, preload=False,
+        drop_bad_windows=True, picks=None, reject=None, flat=None,
+        on_missing='error'):
+    """Create WindowsDataset from BaseDataset with sliding windows.
+
+    Parameters
+    ----------
+    ds : BaseDataset
+        Dataset containing continuous data and description.
+
+    See `create_fixed_length_windows` for description of other parameters.
+
+    Returns
+    -------
+    WindowsDataset :
+        Windowed dataset.
+    """
+    stop = ds.raw.n_times \
+        if stop_offset_samples is None else stop_offset_samples
+    stop = stop - window_size_samples + ds.raw.first_samp
+    # already includes last incomplete window start
+    starts = np.arange(
+        ds.raw.first_samp + start_offset_samples, stop + 1,
+        window_stride_samples)
+
+    if not drop_last_window and starts[-1] < stop:
+        # if last window does not end at trial stop, make it stop there
+        starts = np.append(starts, stop)
+
+    # TODO: handle multi-target case / non-integer target case
+    target = -1 if ds.target is None else ds.target
+    if mapping is not None:
+        target = mapping[target]
+
+    fake_events = [[start, window_size_samples, -1] for start in starts]
+    metadata = pd.DataFrame({
+        'i_window_in_trial': np.arange(len(fake_events)),
+        'i_start_in_trial': starts,
+        'i_stop_in_trial': starts + window_size_samples,
+        'target': len(fake_events) * [target]
+    })
+
+    # window size - 1, since tmax is inclusive
+    mne_epochs = mne.Epochs(
+        ds.raw, fake_events, baseline=None, tmin=0,
+        tmax=(window_size_samples - 1) / ds.raw.info['sfreq'],
+        metadata=metadata, preload=preload, picks=picks, reject=reject,
+        flat=flat, on_missing=on_missing)
+
+    if drop_bad_windows:
+        mne_epochs.drop_bad()
+
+    return WindowsDataset(mne_epochs, ds.description)
 
 
 def create_fixed_length_windows(
         concat_ds, start_offset_samples, stop_offset_samples,
         window_size_samples, window_stride_samples, drop_last_window,
         mapping=None, preload=False, drop_bad_windows=True, picks=None,
-        reject=None, flat=None, on_missing='error'):
+        reject=None, flat=None, on_missing='error', n_jobs=1):
     """Windower that creates sliding windows.
 
     Parameters
@@ -231,6 +323,8 @@ def create_fixed_length_windows(
     on_missing: str
         What to do if one or several event ids are not found in the recording.
         Valid keys are ‘error’ | ‘warning’ | ‘ignore’. See mne.Epochs.
+    n_jobs: int
+        Number of jobs to use to parallelize the windowing.
 
     Returns
     -------
@@ -246,45 +340,12 @@ def create_fixed_length_windows(
             'to indicate end of trial/recording. Using `None`.')
         stop_offset_samples = None
 
-    list_of_windows_ds = []
-    for ds in concat_ds.datasets:
-        stop = ds.raw.n_times \
-            if stop_offset_samples is None else stop_offset_samples
-        stop = stop - window_size_samples + ds.raw.first_samp
-        # already includes last incomplete window start
-        starts = np.arange(
-            ds.raw.first_samp + start_offset_samples, stop + 1,
-            window_stride_samples)
-
-        if not drop_last_window and starts[-1] < stop:
-            # if last window does not end at trial stop, make it stop there
-            starts = np.append(starts, stop)
-
-        # TODO: handle multi-target case / non-integer target case
-        target = -1 if ds.target is None else ds.target
-        if mapping is not None:
-            target = mapping[target]
-
-        fake_events = [[start, window_size_samples, -1] for start in starts]
-        metadata = pd.DataFrame({
-            'i_window_in_trial': np.arange(len(fake_events)),
-            'i_start_in_trial': starts,
-            'i_stop_in_trial': starts + window_size_samples,
-            'target': len(fake_events) * [target]
-        })
-
-        # window size - 1, since tmax is inclusive
-        mne_epochs = mne.Epochs(
-            ds.raw, fake_events, baseline=None, tmin=0,
-            tmax=(window_size_samples - 1) / ds.raw.info['sfreq'],
-            metadata=metadata, preload=preload, picks=picks, reject=reject,
-            flat=flat, on_missing=on_missing)
-
-        if drop_bad_windows:
-            mne_epochs.drop_bad()
-
-        windows_ds = WindowsDataset(mne_epochs, ds.description)
-        list_of_windows_ds.append(windows_ds)
+    list_of_windows_ds = Parallel(n_jobs=n_jobs)(
+        delayed(_create_fixed_length_windows)(
+            ds, start_offset_samples, stop_offset_samples, window_size_samples,
+            window_stride_samples, drop_last_window, mapping, preload,
+            drop_bad_windows, picks, reject, flat, on_missing)
+        for ds in concat_ds.datasets)
 
     return BaseConcatDataset(list_of_windows_ds)
 
@@ -362,8 +423,8 @@ def _check_windowing_arguments(
         trial_start_offset_samples, trial_stop_offset_samples,
         window_size_samples, window_stride_samples):
     assert isinstance(trial_start_offset_samples, (int, np.integer))
-    assert (isinstance(trial_stop_offset_samples, (int, np.integer))
-        or (trial_stop_offset_samples is None))
+    assert (isinstance(trial_stop_offset_samples, (int, np.integer)) or
+           (trial_stop_offset_samples is None))
     assert isinstance(window_size_samples, (int, np.integer, type(None)))
     assert isinstance(window_stride_samples, (int, np.integer, type(None)))
     assert (window_size_samples is None) == (window_stride_samples is None)

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 - pytest
 - pip
 - skorch
+- joblib
 - pip:
   - mne
   - https://github.com/braindecode/braindecode/zipball/master

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ matplotlib
 h5py
 mne
 skorch
+joblib

--- a/test/unit_tests/datautil/test_windowers.py
+++ b/test/unit_tests/datautil/test_windowers.py
@@ -70,7 +70,10 @@ def test_windows_from_events_n_jobs(lazy_loadable_dataset):
 
     assert windows[0].description.equals(windows[1].description)
     for ds1, ds2 in zip(windows[0].datasets, windows[1].datasets):
-        assert ds1.windows == ds2.windows
+        # assert ds1.windows == ds2.windows  # Runs locally, fails in CI
+        assert np.allclose(ds1.windows.get_data(), ds2.windows.get_data())
+        assert pd.Series(ds1.windows.info).to_json() == \
+               pd.Series(ds2.windows.info).to_json()
         assert ds1.description.equals(ds2.description)
         assert np.array_equal(ds1.y, ds2.y)
         assert np.array_equal(ds1.crop_inds, ds2.crop_inds)
@@ -338,7 +341,10 @@ def test_fixed_length_windower_n_jobs(lazy_loadable_dataset):
 
     assert windows[0].description.equals(windows[1].description)
     for ds1, ds2 in zip(windows[0].datasets, windows[1].datasets):
-        assert ds1.windows == ds2.windows
+        # assert ds1.windows == ds2.windows  # Runs locally, fails in CI
+        assert np.allclose(ds1.windows.get_data(), ds2.windows.get_data())
+        assert pd.Series(ds1.windows.info).to_json() == \
+               pd.Series(ds2.windows.info).to_json()
         assert ds1.description.equals(ds2.description)
         assert np.array_equal(ds1.y, ds2.y)
         assert np.array_equal(ds1.crop_inds, ds2.crop_inds)

--- a/test/unit_tests/datautil/test_windowers.py
+++ b/test/unit_tests/datautil/test_windowers.py
@@ -61,8 +61,9 @@ def test_windows_from_events_preload_false(lazy_loadable_dataset):
 
 
 def test_windows_from_events_n_jobs(lazy_loadable_dataset):
+    longer_dataset = BaseConcatDataset([lazy_loadable_dataset.datasets[0]] * 8)
     windows = [create_windows_from_events(
-        concat_ds=lazy_loadable_dataset, trial_start_offset_samples=0,
+        concat_ds=longer_dataset, trial_start_offset_samples=0,
         trial_stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False, preload=True,
         n_jobs=n_jobs) for n_jobs in [1, 2]]
@@ -176,7 +177,7 @@ def test_shifting_last_window_back_in(concat_ds_targets):
     assert len(description) == len(targets) * 2
     np.testing.assert_array_equal(description[0::2], targets)
     np.testing.assert_array_equal(description[1::2], targets)
-    
+
 
 def test_dropping_last_incomplete_window(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
@@ -324,8 +325,9 @@ def test_fixed_length_windower(start_offset_samples, window_size_samples,
 
 
 def test_fixed_length_windower_n_jobs(lazy_loadable_dataset):
+    longer_dataset = BaseConcatDataset([lazy_loadable_dataset.datasets[0]] * 8)
     windows = [create_fixed_length_windows(
-        concat_ds=lazy_loadable_dataset, start_offset_samples=0,
+        concat_ds=longer_dataset, start_offset_samples=0,
         stop_offset_samples=None, window_size_samples=100,
         window_stride_samples=100, drop_last_window=True, preload=True,
         n_jobs=n_jobs) for n_jobs in [1, 2]]
@@ -433,7 +435,7 @@ def test_epochs_kwargs(lazy_loadable_dataset):
     assert epochs.reject == reject
     assert epochs.flat == flat
 
-    
+
 def test_window_sizes_from_events(concat_ds_targets):
     # no fixed window size, no offsets
     expected_n_samples = 1000
@@ -445,7 +447,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
     assert x.shape[-1] == expected_n_samples
-    
+
     # no fixed window size, positive trial start offset
     expected_n_samples = 999
     concat_ds, targets = concat_ds_targets
@@ -456,7 +458,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
     assert x.shape[-1] == expected_n_samples
-    
+
     # no fixed window size, negative trial start offset
     expected_n_samples = 1001
     concat_ds, targets = concat_ds_targets
@@ -467,7 +469,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
     assert x.shape[-1] == expected_n_samples
-    
+
     # no fixed window size, positive trial stop offset
     expected_n_samples = 1001
     concat_ds, targets = concat_ds_targets
@@ -478,7 +480,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
     assert x.shape[-1] == expected_n_samples
-    
+
     # no fixed window size, negative trial stop offset
     expected_n_samples = 999
     concat_ds, targets = concat_ds_targets

--- a/test/unit_tests/datautil/test_windowers.py
+++ b/test/unit_tests/datautil/test_windowers.py
@@ -68,8 +68,12 @@ def test_windows_from_events_n_jobs(lazy_loadable_dataset):
         window_stride_samples=100, drop_last_window=False, preload=True,
         n_jobs=n_jobs) for n_jobs in [1, 2]]
 
+    assert windows[0].description.equals(windows[1].description)
     for ds1, ds2 in zip(windows[0].datasets, windows[1].datasets):
         assert ds1.windows == ds2.windows
+        assert ds1.description.equals(ds2.description)
+        assert np.array_equal(ds1.y, ds2.y)
+        assert np.array_equal(ds1.crop_inds, ds2.crop_inds)
 
 
 def test_windows_from_events_mapping_filter(tmpdir_factory):
@@ -332,8 +336,12 @@ def test_fixed_length_windower_n_jobs(lazy_loadable_dataset):
         window_stride_samples=100, drop_last_window=True, preload=True,
         n_jobs=n_jobs) for n_jobs in [1, 2]]
 
+    assert windows[0].description.equals(windows[1].description)
     for ds1, ds2 in zip(windows[0].datasets, windows[1].datasets):
         assert ds1.windows == ds2.windows
+        assert ds1.description.equals(ds2.description)
+        assert np.array_equal(ds1.y, ds2.y)
+        assert np.array_equal(ds1.crop_inds, ds2.crop_inds)
 
 
 def test_windows_from_events_cropped(lazy_loadable_dataset):


### PR DESCRIPTION
In my previous experiments on large datasets I found that an easy way to dramatically speed up the preprocessing is to parallelize the windowing step over `BaseDatasets` using joblib. This PR introduces this feature through a small refactoring of the windowing functions. I ended up adding `joblib` as a dependency - I wasn't sure whether it should actually be a soft dependency though (i.e. only try to import it if using this feature).

Also, I wasn't sure how to test that multiple processes are actually used when `n_jobs>1`. For the moment I only made sure that the results were the same as with `n_jobs=1`.