### PR TITLE
Fixing test failure due to fft functions in torch changing namespace

### DIFF
--- a/braindecode/visualization/gradients.py
+++ b/braindecode/visualization/gradients.py
@@ -32,7 +32,7 @@ def compute_amplitude_gradients_for_X(model, X):
 
     try:
         iffted = torch.fft.irfft(
-            fft_coefs, signal_ndim=1, signal_sizes=(X.shape[2],))
+            fft_coefs, n=X.shape[2], dim=2)
     except AttributeError:
         iffted = torch.irfft(  # Deprecated since 1.7
             fft_coefs, signal_ndim=1, signal_sizes=(X.shape[2],))

--- a/braindecode/visualization/gradients.py
+++ b/braindecode/visualization/gradients.py
@@ -30,16 +30,20 @@ def compute_amplitude_gradients_for_X(model, X):
         (torch.cos(phases_th), torch.sin(phases_th)), dim=-1)
     fft_coefs = fft_coefs.squeeze(3)
 
-    iffted = torch.irfft(
-        fft_coefs, signal_ndim=1, signal_sizes=(X.shape[2],))
+    try:
+        iffted = torch.fft.irfft(
+            fft_coefs, signal_ndim=1, signal_sizes=(X.shape[2],))
+    except AttributeError:
+        iffted = torch.irfft(  # Deprecated since 1.7
+            fft_coefs, signal_ndim=1, signal_sizes=(X.shape[2],))
 
     outs = model(iffted)
 
     n_filters = outs.shape[1]
     amp_grads_per_filter = np.full((n_filters,) + ffted.shape,
-                            np.nan, dtype=np.float32)
+                                   np.nan, dtype=np.float32)
     for i_filter in range(n_filters):
-        mean_out = torch.mean(outs[:,i_filter])
+        mean_out = torch.mean(outs[:, i_filter])
         mean_out.backward(retain_graph=True)
         amp_grads = to_numpy(amps_th.grad.clone())
         amp_grads_per_filter[i_filter] = amp_grads


### PR DESCRIPTION
In torch v1.7 the `fft` functions were moved to their own module: https://github.com/pytorch/pytorch/issues/42175
This PR fixes a test failure in `test/unit_tests/visualization/test_gradients.py` due to this change.