### PR TITLE
[WIP] Adding explicit handling of `dtype` argument for preprocessor

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -237,4 +237,3 @@ class BaseConcatDataset(ConcatDataset):
     def transform(self, value):
         for i in range(len(self.datasets)):
             self.datasets[i].transform = value
-

--- a/braindecode/datautil/preprocess.py
+++ b/braindecode/datautil/preprocess.py
@@ -45,7 +45,9 @@ class Preprocessor(object):
     def __init__(self, fn, apply_on_array=True, **kwargs):
         if callable(fn) and apply_on_array:
             channel_wise = kwargs.pop('channel_wise', False)
-            kwargs = dict(fun=partial(fn, **kwargs), channel_wise=channel_wise)
+            dtype = kwargs.pop('dtype', None)
+            kwargs = dict(fun=partial(fn, **kwargs), channel_wise=channel_wise,
+                          dtype=dtype)
             fn = 'apply_function'
         self.fn = fn
         self.kwargs = kwargs

--- a/test/unit_tests/datautil/test_preprocess.py
+++ b/test/unit_tests/datautil/test_preprocess.py
@@ -178,6 +178,17 @@ def test_scale_windows(windows_concat_ds):
                                rtol=1e-4, atol=1e-4)
 
 
+def test_preprocess_dtype(windows_concat_ds):
+    dtype = np.float32
+    factor = 1e6
+    preprocessors = [
+        Preprocessor('pick_types', eeg=True, meg=False, stim=False),
+        Preprocessor(scale, factor=factor, dtype=dtype)
+    ]
+    preprocess(windows_concat_ds, preprocessors)
+    assert windows_concat_ds[0][0].dtype == dtype
+
+
 @pytest.fixture(scope='module')
 def mock_data():
     mock_input = np.random.RandomState(20200217).rand(2, 10).reshape(2, 10)


### PR DESCRIPTION
This short PR adds the explicit handling of the `dtype` argument in `Preprocessor`. This argument is then passed to the `apply_function` method of `Raw` and `Epochs` objects when `fn` is a callable and `apply_on_array` is True. This allows casting the output of the preprocessor to another type, e.g. float32 since that's what pytorch uses by default.