### PR TITLE
In TUHAbnormal added pathological label to base datasets.

### DIFF
--- a/braindecode/datasets/tuh.py
+++ b/braindecode/datasets/tuh.py
@@ -208,8 +208,9 @@ class TUHAbnormal(TUH):
         # set target name and target of base datasets
         for ds_i, ds in enumerate(self.datasets):
             ds.target_name = target_name
-            ds.target = self.description[target_name][ds_i]
-            ds.description['pathological'] = self.description.loc[ds_i, 'pathological']
+            ds.target = self.description.loc[ds_i, target_name]
+            for k in additional_descriptions.columns:
+                ds.description[k] = self.description.loc[ds_i, k]
 
     @staticmethod
     def _parse_additional_description_from_file_path(file_path):

--- a/braindecode/datasets/tuh.py
+++ b/braindecode/datasets/tuh.py
@@ -209,6 +209,7 @@ class TUHAbnormal(TUH):
         for ds_i, ds in enumerate(self.datasets):
             ds.target_name = target_name
             ds.target = self.description[target_name][ds_i]
+            ds.description['pathological'] = self.description.loc[ds_i, 'pathological']
 
     @staticmethod
     def _parse_additional_description_from_file_path(file_path):


### PR DESCRIPTION
Through adding of the TUH class, pathology labels in TUHAbnormal are added manually to the concat dataset description. However, this results in accidentally dropping the labels when using `split()`, since it uses the descriptions of base datasets. 