### PR TITLE
Removing dilated Avg Pooling from EEGResNet

### DIFF
--- a/braindecode/models/deep4.py
+++ b/braindecode/models/deep4.py
@@ -3,7 +3,7 @@ from torch import nn
 from torch.nn import init
 from torch.nn.functional import elu
 
-from .modules import Expression, AvgPool2dWithConv, Ensure4d
+from .modules import Expression, Ensure4d
 from .functions import identity, transpose_time_to_spat, squeeze_final_output
 from ..util import np_to_var
 
@@ -90,7 +90,7 @@ class Deep4Net(nn.Sequential):
             conv_stride = 1
             pool_stride = self.pool_time_stride
         self.add_module("ensuredims", Ensure4d())
-        pool_class_dict = dict(max=nn.MaxPool2d, mean=AvgPool2dWithConv)
+        pool_class_dict = dict(max=nn.MaxPool2d, mean=nn.AvgPool2d)
         first_pool_class = pool_class_dict[self.first_pool_mode]
         later_pool_class = pool_class_dict[self.later_pool_mode]
         if self.split_first_layer:

--- a/braindecode/models/eegresnet.py
+++ b/braindecode/models/eegresnet.py
@@ -12,7 +12,7 @@ from torch.nn.functional import elu
 
 from .functions import transpose_time_to_spat, squeeze_final_output
 from ..util import np_to_var
-from .modules import Expression, AvgPool2dWithConv, Ensure4d
+from .modules import Expression, Ensure4d
 
 
 class EEGResNet(nn.Sequential):
@@ -152,8 +152,9 @@ class EEGResNet(nn.Sequential):
                 dtype=np.float32)))
             n_out_time = out.cpu().data.numpy().shape[2]
             self.final_pool_length = n_out_time
-        self.add_module('mean_pool', AvgPool2dWithConv(
-            (self.final_pool_length, 1), (1, 1)))
+        self.add_module('mean_pool', nn.AvgPool2d(
+            kernel_size=(self.final_pool_length, 1), stride=(1, 1)
+        ))
         self.add_module('conv_classifier',
                         nn.Conv2d(n_cur_filters, self.n_classes,
                                   (1, 1), bias=True))

--- a/braindecode/models/eegresnet.py
+++ b/braindecode/models/eegresnet.py
@@ -153,8 +153,7 @@ class EEGResNet(nn.Sequential):
             n_out_time = out.cpu().data.numpy().shape[2]
             self.final_pool_length = n_out_time
         self.add_module('mean_pool', AvgPool2dWithConv(
-            (self.final_pool_length, 1), (1, 1), dilation=(int(cur_dilation[0]),
-                                                           int(cur_dilation[1]))))
+            (self.final_pool_length, 1), (1, 1)))
         self.add_module('conv_classifier',
                         nn.Conv2d(n_cur_filters, self.n_classes,
                                   (1, 1), bias=True))

--- a/braindecode/models/modules.py
+++ b/braindecode/models/modules.py
@@ -47,69 +47,6 @@ class Expression(torch.nn.Module):
         )
 
 
-class AvgPool2dWithConv(torch.nn.Module):
-    """
-    Compute average pooling using a convolution, to have the dilation parameter.
-
-    Parameters
-    ----------
-    kernel_size: (int,int)
-        Size of the pooling region.
-    stride: (int,int)
-        Stride of the pooling operation.
-    dilation: int or (int,int)
-        Dilation applied to the pooling filter.
-    padding: int or (int,int)
-        Padding applied before the pooling operation.
-    """
-
-    def __init__(self, kernel_size, stride, dilation=1, padding=0):
-        super(AvgPool2dWithConv, self).__init__()
-        self.kernel_size = kernel_size
-        self.stride = stride
-        self.dilation = dilation
-        self.padding = padding
-        # don't name them "weights" to
-        # make sure these are not accidentally used by some procedure
-        # that initializes parameters or something
-        self._pool_weights = None
-
-    def forward(self, x):
-        # Create weights for the convolution on demand:
-        # size or type of x changed...
-        in_channels = x.size()[1]
-        weight_shape = (
-            in_channels,
-            1,
-            self.kernel_size[0],
-            self.kernel_size[1],
-        )
-        if self._pool_weights is None or (
-            (tuple(self._pool_weights.size()) != tuple(weight_shape)) or
-            (self._pool_weights.is_cuda != x.is_cuda) or
-            (self._pool_weights.data.type() != x.data.type())
-        ):
-            n_pool = np.prod(self.kernel_size)
-            weights = np_to_var(
-                np.ones(weight_shape, dtype=np.float32) / float(n_pool)
-            )
-            weights = weights.type_as(x)
-            if x.is_cuda:
-                weights = weights.cuda()
-            self._pool_weights = weights
-
-        pooled = F.conv2d(
-            x,
-            self._pool_weights,
-            bias=None,
-            stride=self.stride,
-            dilation=self.dilation,
-            padding=self.padding,
-            groups=in_channels,
-        )
-        return pooled
-
-
 class IntermediateOutputWrapper(torch.nn.Module):
     """Wraps network model such that outputs of intermediate layers can be returned.
     forward() returns list of intermediate activations in a network during forward pass.

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -70,6 +70,17 @@ def test_eegresnet(input_sizes):
     check_forward_pass(model, input_sizes, only_check_until_dim=2)
 
 
+def test_eegresnet_pool_length_auto(input_sizes):
+    model = EEGResNet(
+        input_sizes['n_channels'],
+        input_sizes['n_classes'],
+        input_sizes['n_in_times'],
+        final_pool_length='auto',
+        n_first_filters=2,
+    )
+    check_forward_pass(model, input_sizes, only_check_until_dim=2)
+
+
 def test_hybridnet(input_sizes):
     model = HybridNet(
         input_sizes['n_channels'], input_sizes['n_classes'],


### PR DESCRIPTION
It replaces dilated Global AVG Pooling in the `EEGResNet` with a standard implementation without dilation from pytorch and solves  #220 

I may not fully understand the Resnet architecture, so @robintibor please verify if I'm correct. I think that dilation is not needed in the Global Avg Pooling layer. It should create one number per feature map (in the case `final_pool_length=='auto'`), so we should use standard Avg Pooling from pytorch and just average without using dilated pooling kernel.