### PR TITLE
Fixing evaluation of fully connected layer size in sleep stager

### DIFF
--- a/braindecode/models/sleep_stager_chambon_2018.py
+++ b/braindecode/models/sleep_stager_chambon_2018.py
@@ -85,8 +85,12 @@ class SleepStagerChambon2018(nn.Module):
         )
 
     def _len_last_layer(self, n_channels, input_size):
-        return len(self.feature_extractor(
-            torch.Tensor(1, 1, n_channels, input_size)).flatten())
+        self.feature_extractor.eval()
+        with torch.no_grad():
+            out = self.feature_extractor(
+                torch.Tensor(1, 1, n_channels, input_size))
+        self.feature_extractor.train()
+        return len(out.flatten())
 
     def forward(self, x):
         """Forward pass.


### PR DESCRIPTION
Another quick fix to `SleepStagerChambon2018`. I realized I recently introduced a bug in the private method that computes the size of the last fully connected layer (it was accumulating the gradient and updating the batch norm and dropout layers, which shouldn't happen). This PR fixes this issue.