### PR TITLE
Removing the default sampling frequency from create_from_X_y, #143.

### DIFF
--- a/braindecode/datasets/xy.py
+++ b/braindecode/datasets/xy.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 def create_from_X_y(
-        X, y, drop_last_window, sfreq=None, ch_names=None, window_size_samples=None,
+        X, y, drop_last_window, sfreq, ch_names=None, window_size_samples=None,
         window_stride_samples=None):
     """Create a BaseConcatDataset of WindowsDatasets from X and y to be used for
     decoding with skorch and braindecode, where X is a list of pre-cut trials
@@ -26,12 +26,13 @@ def create_from_X_y(
         list of pre-cut trials as n_trials x n_channels x n_times
     y: array-like
         targets corresponding to the trials
-    sfreq: common sampling frequency of all trials
-    ch_names: array-like
-        channel names of the trials
     drop_last_window: bool
         whether or not have a last overlapping window, when
         windows/windows do not equally divide the continuous signal
+    sfreq: float
+        Sampling frequency of signals.
+    ch_names: array-like
+        Names of the channels.
     window_size_samples: int
         window size
     window_stride_samples: int
@@ -48,9 +49,6 @@ def create_from_X_y(
         create_fixed_length_windows, )
     n_samples_per_x = []
     base_datasets = []
-    if sfreq is None:
-        sfreq = 100
-        log.info("No sampling frequency given, set to 100 Hz.")
     if ch_names is None:
         ch_names = [str(i) for i in range(X.shape[1])]
         log.info(f"No channel names given, set to 0-{X.shape[1]}).")

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -21,6 +21,9 @@ What's new
 Current (0.5.2.dev0)
 --------------------
 
+API changes
+~~~~~~~~~~~
+- Removing the default sampling frequency sfreq value in :func:`braindecode.datasets.create_windows_from_events` (:gh:`256` by `Ann-Kathrin Kiessner`_, `Dan Wilson`_, `Henrik Bonsmann`_, `Vytautas Jankauskas`_)
 
 .. _changes_0_5_1:
 
@@ -68,3 +71,7 @@ Authors
 .. _Robin Tibor Schirrmeister: https://github.com/robintibor
 .. _Lukas Gemein: https://github.com/gemeinl
 .. _Maciej Śliwowski: https://github.com/sliwy
+.. _Ann-Kathrin Kiessner: https://github.com/Ann-KathrinKiessner
+.. _Dan Wilson: https://github.com/dcwil
+.. _Henrik Bonsmann: https://github.com/HenrikBons
+.. _Vytautas Jankauskas: https://github.com/vytjan

--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -90,11 +90,13 @@ def test_cropped_decoding():
 
     train_set = create_from_X_y(X[:60], y[:60],
                                 drop_last_window=False,
+                                sfreq=100,
                                 window_size_samples=input_window_samples,
                                 window_stride_samples=n_preds_per_input)
 
     valid_set = create_from_X_y(X[60:], y[60:],
                                 drop_last_window=False,
+                                sfreq=100,
                                 window_size_samples=input_window_samples,
                                 window_stride_samples=n_preds_per_input)
 

--- a/test/acceptance_tests/test_eeg_classifier.py
+++ b/test/acceptance_tests/test_eeg_classifier.py
@@ -150,11 +150,13 @@ def test_eeg_classifier():
 
     train_set = create_from_X_y(X[:48], y[:48],
                                 drop_last_window=False,
+                                sfreq=100,
                                 window_size_samples=input_window_samples,
                                 window_stride_samples=n_preds_per_input)
 
     valid_set = create_from_X_y(X[48:60], y[48:60],
                                 drop_last_window=False,
+                                sfreq=100,
                                 window_size_samples=input_window_samples,
                                 window_stride_samples=n_preds_per_input)
 

--- a/test/unit_tests/datasets/test_xy.py
+++ b/test/unit_tests/datasets/test_xy.py
@@ -13,11 +13,13 @@ def test_crops_data_loader_explicit():
 
     n_time_in = 10
     n_time_out = 4
+    sfreq = 100
 
     expected_crops = [np.arange(0, 10), np.arange(4, 14), np.arange(5, 15)]
 
     dataset = create_from_X_y(
         X[None, None], y,
+        sfreq=sfreq,
         window_size_samples=n_time_in,
         window_stride_samples=n_time_out,
         drop_last_window=False

--- a/test/unit_tests/training/test_scoring.py
+++ b/test/unit_tests/training/test_scoring.py
@@ -88,7 +88,7 @@ def test_cropped_trial_epoch_scoring():
     ):
         dataset_valid = create_from_X_y(
             np.zeros((4, 1, 10)), np.concatenate(y_true),
-            window_size_samples=10, window_stride_samples=4, drop_last_window=False)
+            sfreq=100, window_size_samples=10, window_stride_samples=4, drop_last_window=False)
 
         mock_skorch_net = MockSkorchNet()
         cropped_trial_epoch_scoring = CroppedTrialEpochScoring(


### PR DESCRIPTION
Fixes the #143 
Also, not sure if it's fine to swap the order of arguments of the create_from_X_y, but as drop_last_window seems to be an optional, it could be better to assign a default value for it maybe?

And finally, since 4 of us (@Ann-KathrinKiessner, @dcwil, @HenrikBons) worked on this small issue for introduction, we'd like to know if (or how) we should add ourselves to the author's list of the respective files.