### PR TITLE
Issue 269 - warning for non default arguments in `create_fixed_length_windows`

### DIFF
--- a/braindecode/datasets/mne.py
+++ b/braindecode/datasets/mne.py
@@ -95,7 +95,7 @@ def create_from_mne_epochs(list_of_epochs, window_size_samples,
     Returns
     -------
     windows_datasets: BaseConcatDataset
-        X and y transformed to a dataset format that is compativle with skorch
+        X and y transformed to a dataset format that is compatible with skorch
         and braindecode
     """
     # Prevent circular import

--- a/braindecode/datasets/mne.py
+++ b/braindecode/datasets/mne.py
@@ -11,7 +11,7 @@ from .base import BaseDataset, BaseConcatDataset, WindowsDataset
 
 
 def create_from_mne_raw(
-        raws, trial_start_offset_samples, trial_stop_offset_samples,
+        raws, start_offset_samples, stop_offset_samples,
         window_size_samples, window_stride_samples, drop_last_window,
         descriptions=None, mapping=None, preload=False, drop_bad_windows=True):
     """Create WindowsDatasets from mne.RawArrays
@@ -20,9 +20,9 @@ def create_from_mne_raw(
     ----------
     raws: array-like
         list of mne.RawArrays
-    trial_start_offset_samples: int
+    start_offset_samples: int
         start offset from original trial onsets in samples
-    trial_stop_offset_samples: int
+    stop_offset_samples: int
         stop offset from original trial stop in samples
     window_size_samples: int
         window size
@@ -64,8 +64,8 @@ def create_from_mne_raw(
     base_datasets = BaseConcatDataset(base_datasets)
     windows_datasets = create_windows_from_events(
         base_datasets,
-        trial_start_offset_samples=trial_start_offset_samples,
-        trial_stop_offset_samples=trial_stop_offset_samples,
+        start_offset_samples=start_offset_samples,
+        stop_offset_samples=stop_offset_samples,
         window_size_samples=window_size_samples,
         window_stride_samples=window_stride_samples,
         drop_last_window=drop_last_window,

--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -177,6 +177,12 @@ def create_fixed_length_windows(
             'to indicate end of trial/recording. Using `None`.')
         stop_offset_samples = None
 
+    if start_offset_samples != 0 or stop_offset_samples not in [0, None]:
+        warnings.warn('Usage of offset_sample args in create_fixed_length_windows is deprecated and'
+                      ' will be removed in future versions. Please use '
+                      'braindecode.preprocessing.preprocess.Preprocessor("crop", tmin, tmax)'
+                      ' instead.')
+
     list_of_windows_ds = Parallel(n_jobs=n_jobs)(
         delayed(_create_fixed_length_windows)(
             ds, start_offset_samples, stop_offset_samples, window_size_samples,

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,7 +28,7 @@ Enhancements
 API changes
 ~~~~~~~~~~~
 - Removing the default sampling frequency sfreq value in :func:`braindecode.datasets.create_windows_from_events` (:gh:`256` by `Ann-Kathrin Kiessner`_, `Dan Wilson`_, `Henrik Bonsmann`_, `Vytautas Jankauskas`_)
-
+- Adding a warning for using non-default values in :func:`braindecode.preprocessing.windowers.create_fixed_length_windows` (:gh:`256` by `Ann-Kathrin Kiessner`_, `Dan Wilson`_, `Henrik Bonsmann`_, `Vytautas Jankauskas`_)
 .. _changes_0_5_1:
 
 Version 0.5.1 (2021-07-14)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -60,6 +60,8 @@ API changes
 ~~~~~~~~~~~
 - Preprocessor classes :class:`braindecode.datautil.MNEPreproc` and :class:`braindecode.datautil.NumpyPreproc` are deprecated in favor of :class:`braindecode.datautil.Preprocessor` (:gh:`197` by `Hubert Banville`_)
 - Parameter `stop_offset_samples` of :func:`braindecode.datautil.create_fixed_length_windows` must now be set to `None` instead of 0 to indicate the end of the recording (:gh:`152` by `Hubert Banville`_)
+- Parameters `trial_start_offset_samples` & `trial_stop_offset_samples` of :func:`braindecode.preprocessing.windowers.create_windows_from_events` & `braindecode.datasets.mne.create_from_mne_raw` have had the prefix `trial_` removed. (:gh:`246` by `Dan Wilson, Henrik Bonsman, Ann-Kathrin Kiessner & Vytautas Jankauskas`_)
+
 
 Authors
 ~~~~~~~

--- a/examples/plot_bcic_iv_2a_moabb_cropped.py
+++ b/examples/plot_bcic_iv_2a_moabb_cropped.py
@@ -200,20 +200,20 @@ n_preds_per_input = get_output_shape(model, n_chans, input_window_samples)[2]
 
 from braindecode.preprocessing.windowers import create_windows_from_events
 
-trial_start_offset_seconds = -0.5
+start_offset_seconds = -0.5
 # Extract sampling frequency, check that they are same in all datasets
 sfreq = dataset.datasets[0].raw.info['sfreq']
 assert all([ds.raw.info['sfreq'] == sfreq for ds in dataset.datasets])
 
 # Calculate the trial start offset in samples.
-trial_start_offset_samples = int(trial_start_offset_seconds * sfreq)
+start_offset_samples = int(start_offset_seconds * sfreq)
 
 # Create windows using braindecode function for this. It needs parameters to define how
 # trials should be used.
 windows_dataset = create_windows_from_events(
     dataset,
-    trial_start_offset_samples=trial_start_offset_samples,
-    trial_stop_offset_samples=0,
+    start_offset_samples=start_offset_samples,
+    stop_offset_samples=0,
     window_size_samples=input_window_samples,
     window_stride_samples=n_preds_per_input,
     drop_last_window=False,

--- a/examples/plot_bcic_iv_2a_moabb_trial.py
+++ b/examples/plot_bcic_iv_2a_moabb_trial.py
@@ -97,19 +97,19 @@ preprocess(dataset, preprocessors)
 
 from braindecode.preprocessing.windowers import create_windows_from_events
 
-trial_start_offset_seconds = -0.5
+start_offset_seconds = -0.5
 # Extract sampling frequency, check that they are same in all datasets
 sfreq = dataset.datasets[0].raw.info['sfreq']
 assert all([ds.raw.info['sfreq'] == sfreq for ds in dataset.datasets])
 # Calculate the trial start offset in samples.
-trial_start_offset_samples = int(trial_start_offset_seconds * sfreq)
+start_offset_samples = int(start_offset_seconds * sfreq)
 
 # Create windows using braindecode function for this. It needs parameters to define how
 # trials should be used.
 windows_dataset = create_windows_from_events(
     dataset,
-    trial_start_offset_samples=trial_start_offset_samples,
-    trial_stop_offset_samples=0,
+    start_offset_samples=start_offset_samples,
+    stop_offset_samples=0,
     preload=True,
 )
 

--- a/examples/plot_dataset_example.py
+++ b/examples/plot_dataset_example.py
@@ -55,7 +55,7 @@ print({subset_name: len(subset) for subset_name, subset in subsets.items()})
 ###############################################################################
 # Next, we use a windower to extract events from the dataset based on events:
 windows_ds = create_windows_from_events(
-    ds, trial_start_offset_samples=0, trial_stop_offset_samples=100,
+    ds, start_offset_samples=0, stop_offset_samples=100,
     window_size_samples=400, window_stride_samples=100,
     drop_last_window=False)
 

--- a/examples/plot_load_save_datasets.py
+++ b/examples/plot_load_save_datasets.py
@@ -61,8 +61,8 @@ ds_loaded = load_concat_dataset(
 # compute windows next.
 windows_ds = create_windows_from_events(
     concat_ds=ds_loaded,
-    trial_start_offset_samples=0,
-    trial_stop_offset_samples=0,
+    start_offset_samples=0,
+    stop_offset_samples=0,
 )
 
 ##############################################################################

--- a/examples/plot_mne_dataset_example.py
+++ b/examples/plot_mne_dataset_example.py
@@ -37,8 +37,8 @@ descriptions = [{"event_code": code, "subject": subject_id}
                 for code in event_codes]
 windows_datasets = create_from_mne_raw(
     parts,
-    trial_start_offset_samples=0,
-    trial_stop_offset_samples=0,
+    start_offset_samples=0,
+    stop_offset_samples=0,
     window_size_samples=500,
     window_stride_samples=500,
     drop_last_window=False,

--- a/examples/plot_relative_positioning.py
+++ b/examples/plot_relative_positioning.py
@@ -121,7 +121,7 @@ mapping = {  # We merge stages 3 and 4 following AASM standards.
 }
 
 windows_dataset = create_windows_from_events(
-    dataset, trial_start_offset_samples=0, trial_stop_offset_samples=0,
+    dataset, start_offset_samples=0, stop_offset_samples=0,
     window_size_samples=window_size_samples,
     window_stride_samples=window_size_samples, preload=True, mapping=mapping)
 

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -112,7 +112,7 @@ sfreq = 100
 window_size_samples = window_size_s * sfreq
 
 windows_dataset = create_windows_from_events(
-    dataset, trial_start_offset_samples=0, trial_stop_offset_samples=0,
+    dataset, start_offset_samples=0, stop_offset_samples=0,
     window_size_samples=window_size_samples,
     window_stride_samples=window_size_samples, preload=True, mapping=mapping)
 

--- a/examples/plot_split_dataset.py
+++ b/examples/plot_split_dataset.py
@@ -49,7 +49,7 @@ display(splits["2"].description)
 ###############################################################################
 # Similarly, we can split datasets after creating windows
 windows = create_windows_from_events(
-    ds, trial_start_offset_samples=0, trial_stop_offset_samples=0)
+    ds, start_offset_samples=0, stop_offset_samples=0)
 splits = windows.split("run")
 display(splits)
 splits = windows.split([4, 8])

--- a/test/unit_tests/datasets/test_dataset.py
+++ b/test/unit_tests/datasets/test_dataset.py
@@ -64,8 +64,8 @@ def concat_ds_targets():
 def concat_windows_dataset(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows_ds = create_windows_from_events(
-        concat_ds=concat_ds, trial_start_offset_samples=0,
-        trial_stop_offset_samples=0, window_size_samples=100,
+        concat_ds=concat_ds, start_offset_samples=0,
+        stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False)
 
     return windows_ds

--- a/test/unit_tests/datautil/test_serialization.py
+++ b/test/unit_tests/datautil/test_serialization.py
@@ -24,8 +24,8 @@ def setup_concat_windows_dataset(setup_concat_raw_dataset):
     moabb_dataset = setup_concat_raw_dataset
     return create_windows_from_events(
         concat_ds=moabb_dataset,
-        trial_start_offset_samples=0,
-        trial_stop_offset_samples=0)
+        start_offset_samples=0,
+        stop_offset_samples=0)
 
 
 def test_save_concat_raw_dataset(setup_concat_raw_dataset, tmpdir):

--- a/test/unit_tests/preprocessing/test_windowers.py
+++ b/test/unit_tests/preprocessing/test_windowers.py
@@ -53,8 +53,8 @@ def lazy_loadable_dataset(tmpdir_factory):
 
 def test_windows_from_events_preload_false(lazy_loadable_dataset):
     windows = create_windows_from_events(
-        concat_ds=lazy_loadable_dataset, trial_start_offset_samples=0,
-        trial_stop_offset_samples=0, window_size_samples=100,
+        concat_ds=lazy_loadable_dataset, start_offset_samples=0,
+        stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False)
 
     assert all([not ds.windows.preload for ds in windows.datasets])
@@ -63,8 +63,8 @@ def test_windows_from_events_preload_false(lazy_loadable_dataset):
 def test_windows_from_events_n_jobs(lazy_loadable_dataset):
     longer_dataset = BaseConcatDataset([lazy_loadable_dataset.datasets[0]] * 8)
     windows = [create_windows_from_events(
-        concat_ds=longer_dataset, trial_start_offset_samples=0,
-        trial_stop_offset_samples=0, window_size_samples=100,
+        concat_ds=longer_dataset, start_offset_samples=0,
+        stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False, preload=True,
         n_jobs=n_jobs) for n_jobs in [1, 2]]
 
@@ -85,8 +85,8 @@ def test_windows_from_events_mapping_filter(tmpdir_factory):
     concat_ds = BaseConcatDataset([base_ds])
 
     windows = create_windows_from_events(
-        concat_ds=concat_ds, trial_start_offset_samples=0,
-        trial_stop_offset_samples=0, window_size_samples=100,
+        concat_ds=concat_ds, start_offset_samples=0,
+        stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False, mapping={'T1': 0})
     description = windows.datasets[0].windows.metadata['target'].to_list()
 
@@ -108,8 +108,8 @@ def test_windows_from_events_different_events(tmpdir_factory):
     concat_ds = BaseConcatDataset([base_ds, base_ds_1])
 
     windows = create_windows_from_events(
-        concat_ds=concat_ds, trial_start_offset_samples=0,
-        trial_stop_offset_samples=0, window_size_samples=100,
+        concat_ds=concat_ds, start_offset_samples=0,
+        stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False)
     description = []
     events = []
@@ -140,7 +140,7 @@ def test_one_window_per_original_trial(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=0,
+        start_offset_samples=0, stop_offset_samples=0,
         window_size_samples=1000, window_stride_samples=1,
         drop_last_window=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -152,7 +152,7 @@ def test_stride_has_no_effect(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=0,
+        start_offset_samples=0, stop_offset_samples=0,
         window_size_samples=1000, window_stride_samples=1000,
         drop_last_window=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -164,7 +164,7 @@ def test_trial_start_offset(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-250, trial_stop_offset_samples=-750,
+        start_offset_samples=-250, stop_offset_samples=-750,
         window_size_samples=250, window_stride_samples=250,
         drop_last_window=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -177,7 +177,7 @@ def test_shifting_last_window_back_in(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-250, trial_stop_offset_samples=-750,
+        start_offset_samples=-250, stop_offset_samples=-750,
         window_size_samples=250, window_stride_samples=300,
         drop_last_window=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -190,7 +190,7 @@ def test_dropping_last_incomplete_window(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-250, trial_stop_offset_samples=-750,
+        start_offset_samples=-250, stop_offset_samples=-750,
         window_size_samples=250, window_stride_samples=300,
         drop_last_window=True)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -202,7 +202,7 @@ def test_maximally_overlapping_windows(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-2, trial_stop_offset_samples=0,
+        start_offset_samples=-2, stop_offset_samples=0,
         window_size_samples=1000, window_stride_samples=1,
         drop_last_window=False)
     description = windows.datasets[0].windows.metadata["target"].to_list()
@@ -223,7 +223,7 @@ def test_single_sample_size_windows(concat_ds_targets):
     # targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=0,
+        start_offset_samples=0, stop_offset_samples=0,
         window_size_samples=1, window_stride_samples=1,
         drop_last_window=False, mapping=dict(tongue=3, left_hand=1,
                                              right_hand=2, feet=4))
@@ -239,7 +239,7 @@ def test_overlapping_trial_offsets(concat_ds_targets):
                        match='Trial overlap not implemented.'):
         create_windows_from_events(
             concat_ds=concat_ds,
-            trial_start_offset_samples=-2000, trial_stop_offset_samples=0,
+            start_offset_samples=-2000, stop_offset_samples=0,
             window_size_samples=1000, window_stride_samples=1000,
             drop_last_window=False)
 
@@ -249,8 +249,8 @@ def test_overlapping_trial_offsets(concat_ds_targets):
 def test_drop_bad_windows(concat_ds_targets, drop_bad_windows, preload):
     concat_ds, _ = concat_ds_targets
     windows_from_events = create_windows_from_events(
-        concat_ds=concat_ds, trial_start_offset_samples=0,
-        trial_stop_offset_samples=0, window_size_samples=100,
+        concat_ds=concat_ds, start_offset_samples=0,
+        stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False, preload=preload,
         drop_bad_windows=drop_bad_windows)
 
@@ -266,13 +266,13 @@ def test_drop_bad_windows(concat_ds_targets, drop_bad_windows, preload):
 
 
 def test_windows_from_events_(lazy_loadable_dataset):
-    msg = '"trial_stop_offset_samples" too large\\. Stop of last trial ' \
-          '\\(19900\\) \\+ "trial_stop_offset_samples" \\(250\\) must be ' \
+    msg = '"stop_offset_samples" too large\\. Stop of last trial ' \
+          '\\(19900\\) \\+ "stop_offset_samples" \\(250\\) must be ' \
           'smaller than length of recording \\(20000\\)\\.'
     with pytest.raises(ValueError, match=msg):
         create_windows_from_events(
-            concat_ds=lazy_loadable_dataset, trial_start_offset_samples=0,
-            trial_stop_offset_samples=250, window_size_samples=100,
+            concat_ds=lazy_loadable_dataset, start_offset_samples=0,
+            stop_offset_samples=250, window_size_samples=100,
             window_stride_samples=100, drop_last_window=False)
 
 
@@ -367,27 +367,27 @@ def test_windows_from_events_cropped(lazy_loadable_dataset):
 
     # Extract windows
     windows1 = create_windows_from_events(
-        concat_ds=ds, trial_start_offset_samples=0, trial_stop_offset_samples=0,
+        concat_ds=ds, start_offset_samples=0, stop_offset_samples=0,
         window_size_samples=100, window_stride_samples=100,
         drop_last_window=False)
     windows2 = create_windows_from_events(
-        concat_ds=crop_ds, trial_start_offset_samples=0,
-        trial_stop_offset_samples=0, window_size_samples=100,
+        concat_ds=crop_ds, start_offset_samples=0,
+        stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False)
     assert (windows1[0][0] == windows2[0][0]).all()
 
     # Make sure events that fall outside of recording will trigger an error
     with pytest.raises(
-            ValueError, match='"trial_stop_offset_samples" too large'):
+            ValueError, match='"stop_offset_samples" too large'):
         create_windows_from_events(
-            concat_ds=ds, trial_start_offset_samples=0,
-            trial_stop_offset_samples=10000, window_size_samples=100,
+            concat_ds=ds, start_offset_samples=0,
+            stop_offset_samples=10000, window_size_samples=100,
             window_stride_samples=100, drop_last_window=False)
     with pytest.raises(
-            ValueError, match='"trial_stop_offset_samples" too large'):
+            ValueError, match='"stop_offset_samples" too large'):
         create_windows_from_events(
-            concat_ds=crop_ds, trial_start_offset_samples=0,
-            trial_stop_offset_samples=2001, window_size_samples=100,
+            concat_ds=crop_ds, start_offset_samples=0,
+            stop_offset_samples=2001, window_size_samples=100,
             window_stride_samples=100, drop_last_window=False)
 
 
@@ -428,8 +428,8 @@ def test_epochs_kwargs(lazy_loadable_dataset):
     reject = {'eeg': 43e-6}
 
     windows = create_windows_from_events(
-        concat_ds=lazy_loadable_dataset, trial_start_offset_samples=0,
-        trial_stop_offset_samples=0, window_size_samples=100,
+        concat_ds=lazy_loadable_dataset, start_offset_samples=0,
+        stop_offset_samples=0, window_size_samples=100,
         window_stride_samples=100, drop_last_window=False, picks=picks,
         on_missing=on_missing, flat=flat, reject=reject)
 
@@ -456,7 +456,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=0,
+        start_offset_samples=0, stop_offset_samples=0,
         drop_last_window=False)
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
@@ -467,7 +467,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=1, trial_stop_offset_samples=0,
+        start_offset_samples=1, stop_offset_samples=0,
         drop_last_window=False)
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
@@ -478,7 +478,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=-1, trial_stop_offset_samples=0,
+        start_offset_samples=-1, stop_offset_samples=0,
         drop_last_window=False)
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
@@ -489,7 +489,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=1,
+        start_offset_samples=0, stop_offset_samples=1,
         drop_last_window=False)
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
@@ -500,7 +500,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=0, trial_stop_offset_samples=-1,
+        start_offset_samples=0, stop_offset_samples=-1,
         drop_last_window=False)
     x, y, ind = windows[0]
     assert x.shape[-1] == ind[-1] - ind[-2]
@@ -511,7 +511,7 @@ def test_window_sizes_from_events(concat_ds_targets):
     concat_ds, targets = concat_ds_targets
     windows = create_windows_from_events(
         concat_ds=concat_ds,
-        trial_start_offset_samples=3, trial_stop_offset_samples=8,
+        start_offset_samples=3, stop_offset_samples=8,
         window_size_samples=250, window_stride_samples=250,
         drop_last_window=False)
     x, y, ind = windows[0]


### PR DESCRIPTION
Fix for #269, `create_fixed_length_windows` will display warning if non-default args provided for `trial_start_offset_samples` & `trial_stop_offset_samples`