### PR TITLE
FIX class documentation for inherited methods

### DIFF
--- a/braindecode/models/deep4.py
+++ b/braindecode/models/deep4.py
@@ -14,16 +14,17 @@ from ..util import np_to_th
 
 class Deep4Net(nn.Sequential):
     """
-    Deep ConvNet model from [1]_.
+    Deep ConvNet model from [Schirrmeister2017]_.
 
     References
     ----------
-
-    .. [1] Schirrmeister, R. T., Springenberg, J. T., Fiederer, L. D. J.,
-       Glasstetter, M., Eggensperger, K., Tangermann, M., Hutter, F. & Ball, T. (2017).
+    .. [Schirrmeister2017] Schirrmeister, R. T., Springenberg, J. T., Fiederer,
+       L. D. J., Glasstetter, M., Eggensperger, K., Tangermann, M., Hutter, F.
+       & Ball, T. (2017).
        Deep learning with convolutional neural networks for EEG decoding and
        visualization.
-       Human Brain Mapping , Aug. 2017. Online: http://dx.doi.org/10.1002/hbm.23730
+       Human Brain Mapping , Aug. 2017.
+       Online: http://dx.doi.org/10.1002/hbm.23730
     """
 
     def __init__(

--- a/braindecode/models/eegnet.py
+++ b/braindecode/models/eegnet.py
@@ -33,7 +33,6 @@ class EEGNetv4(nn.Sequential):
 
     References
     ----------
-
     .. [EEGNet4] Lawhern, V. J., Solon, A. J., Waytowich, N. R., Gordon,
        S. M., Hung, C. P., & Lance, B. J. (2018).
        EEGNet: A Compact Convolutional Network for EEG-based
@@ -198,7 +197,6 @@ class EEGNetv1(nn.Sequential):
 
     References
     ----------
-
     .. [EEGNet] Lawhern, V. J., Solon, A. J., Waytowich, N. R., Gordon,
        S. M., Hung, C. P., & Lance, B. J. (2016).
        EEGNet: A Compact Convolutional Network for EEG-based

--- a/braindecode/models/hybrid.py
+++ b/braindecode/models/hybrid.py
@@ -12,18 +12,19 @@ from .shallow_fbcsp import ShallowFBCSPNet
 
 
 class HybridNet(nn.Module):
-    """Hybrid ConvNet model from [3]_.
+    """Hybrid ConvNet model from [Schirrmeister2017]_.
 
     Very hardcoded at the moment.
 
     References
     ----------
-
-    .. [3] Schirrmeister, R. T., Springenberg, J. T., Fiederer, L. D. J.,
-       Glasstetter, M., Eggensperger, K., Tangermann, M., Hutter, F. & Ball, T. (2017).
+    .. [Schirrmeister2017] Schirrmeister, R. T., Springenberg, J. T., Fiederer,
+       L. D. J., Glasstetter, M., Eggensperger, K., Tangermann, M., Hutter, F.
+       & Ball, T. (2017).
        Deep learning with convolutional neural networks for EEG decoding and
        visualization.
-       Human Brain Mapping , Aug. 2017. Online: http://dx.doi.org/10.1002/hbm.23730
+       Human Brain Mapping , Aug. 2017.
+       Online: http://dx.doi.org/10.1002/hbm.23730
     """
 
     def __init__(self, in_chans, n_classes, input_window_samples):

--- a/braindecode/models/hybrid.py
+++ b/braindecode/models/hybrid.py
@@ -87,6 +87,13 @@ class HybridNet(nn.Module):
         )
 
     def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            Batch of EEG windows of shape (batch_size, n_channels, n_times).
+        """
         deep_out = self.reduced_deep_model(x)
         shallow_out = self.reduced_shallow_model(x)
 

--- a/braindecode/models/shallow_fbcsp.py
+++ b/braindecode/models/shallow_fbcsp.py
@@ -14,7 +14,7 @@ from .functions import (
 
 
 class ShallowFBCSPNet(nn.Sequential):
-    """Shallow ConvNet model from [2]_.
+    """Shallow ConvNet model from [Schirrmeister2017]_.
 
     Parameters
     ----------
@@ -23,11 +23,13 @@ class ShallowFBCSPNet(nn.Sequential):
 
     References
     ----------
-    .. [2] Schirrmeister, R. T., Springenberg, J. T., Fiederer, L. D. J.,
-       Glasstetter, M., Eggensperger, K., Tangermann, M., Hutter, F. & Ball, T. (2017).
+    .. [Schirrmeister2017] Schirrmeister, R. T., Springenberg, J. T., Fiederer,
+       L. D. J., Glasstetter, M., Eggensperger, K., Tangermann, M., Hutter, F.
+       & Ball, T. (2017).
        Deep learning with convolutional neural networks for EEG decoding and
        visualization.
-       Human Brain Mapping , Aug. 2017. Online: http://dx.doi.org/10.1002/hbm.23730
+       Human Brain Mapping , Aug. 2017.
+       Online: http://dx.doi.org/10.1002/hbm.23730
     """
 
     def __init__(

--- a/braindecode/models/sleep_stager_chambon_2018.py
+++ b/braindecode/models/sleep_stager_chambon_2018.py
@@ -9,9 +9,9 @@ import numpy as np
 
 class SleepStagerChambon2018(nn.Module):
     """
-    Sleep staging architecture from [1]_.
+    Sleep staging architecture from [Chambon2018]_.
 
-    Convolutional neural network for sleep staging described in [1]_.
+    Convolutional neural network for sleep staging described in [Chambon2018]_.
 
     Parameters
     ----------
@@ -42,7 +42,7 @@ class SleepStagerChambon2018(nn.Module):
 
     References
     ----------
-    .. [1] Chambon, S., Galtier, M. N., Arnal, P. J., Wainrib, G., &
+    .. [Chambon2018] Chambon, S., Galtier, M. N., Arnal, P. J., Wainrib, G., &
            Gramfort, A. (2018). A deep learning architecture for temporal sleep
            stage classification using multivariate and multimodal time series.
            IEEE Transactions on Neural Systems and Rehabilitation Engineering,

--- a/braindecode/models/tcn.py
+++ b/braindecode/models/tcn.py
@@ -12,8 +12,9 @@ from .functions import squeeze_final_output
 
 
 class TCN(nn.Module):
-    """Temporal Convolutional Network (TCN) as described in [1]_.
+    """Temporal Convolutional Network (TCN) as described in [Bai2018]_.
     Code adapted from https://github.com/locuslab/TCN/blob/master/TCN/tcn.py
+
     Parameters
     ----------
     n_in_chans: int
@@ -31,9 +32,10 @@ class TCN(nn.Module):
         dropout probability
     add_log_softmax: bool
         whether to add a log softmax layer
+
     References
     ----------
-    .. [1] Bai, S., Kolter, J. Z., & Koltun, V. (2018).
+    .. [Bai2018] Bai, S., Kolter, J. Z., & Koltun, V. (2018).
        An empirical evaluation of generic convolutional and recurrent networks
        for sequence modeling.
        arXiv preprint arXiv:1803.01271.
@@ -70,6 +72,13 @@ class TCN(nn.Module):
         self.eval()
 
     def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            Batch of EEG windows of shape (batch_size, n_channels, n_times).
+        """
         x = self.ensuredims(x)
         # x is in format: B x C x T x 1
         (batch_size, _, time_size, _) = x.size()

--- a/braindecode/models/tidnet.py
+++ b/braindecode/models/tidnet.py
@@ -244,6 +244,13 @@ class TIDNet(nn.Module):
         return nn.Sequential(nn.Flatten(start_dim=1), classifier, nn.LogSoftmax(dim=-1))
 
     def forward(self, x):
+        """Forward pass.
+
+        Parameters
+        ----------
+        x: torch.Tensor
+            Batch of EEG windows of shape (batch_size, n_channels, n_times).
+        """
 
         x = self.dscnn(x)
         return self.classify(x)

--- a/braindecode/models/tidnet.py
+++ b/braindecode/models/tidnet.py
@@ -213,7 +213,8 @@ class TIDNet(nn.Module):
     References
     ----------
     .. [TIDNet] Kostas, D. & Rudzicz, F.
-        Thinker invariance: enabling deep neural networks for BCI across more people.
+        Thinker invariance: enabling deep neural networks for BCI across more
+        people.
         J. Neural Eng. 17, 056008 (2020).
         doi: 10.1088/1741-2552/abb7a7.
     """

--- a/braindecode/samplers/ssl.py
+++ b/braindecode/samplers/ssl.py
@@ -12,7 +12,7 @@ from . import RecordingSampler
 
 
 class RelativePositioningSampler(RecordingSampler):
-    """Sample examples for the relative positioning task from [1]_.
+    """Sample examples for the relative positioning task from [Banville2020]_.
 
     Sample examples as tuples of two window indices, with a label indicating
     whether the windows are close or far, as defined by tau_pos and tau_neg.
@@ -40,8 +40,8 @@ class RelativePositioningSampler(RecordingSampler):
 
     References
     ----------
-    .. [1] Banville, H., Chehab, O., Hyvärinen, A., Engemann, D. A., &
-           Gramfort, A. (2020). Uncovering the structure of clinical EEG
+    .. [Banville2020] Banville, H., Chehab, O., Hyvärinen, A., Engemann, D. A.,
+           & Gramfort, A. (2020). Uncovering the structure of clinical EEG
            signals with self-supervised learning.
            arXiv preprint arXiv:2007.16104.
     """

--- a/braindecode/training/losses.py
+++ b/braindecode/training/losses.py
@@ -16,6 +16,15 @@ class CroppedLoss(nn.Module):
         self.loss_function = loss_function
 
     def forward(self, preds, targets):
+        """Forward pass.
+
+        Parameters
+        ----------
+        preds: torch.Tensor
+            Model's prediction with shape (batch_size, n_classes, n_times).
+        targets: torch.Tensor
+            Target labels with shape (batch_size, n_classes, n_times).
+        """
         avg_preds = torch.mean(preds, dim=2)
         avg_preds = avg_preds.squeeze(dim=1)
         return self.loss_function(avg_preds, targets)

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -4,8 +4,34 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-   :special-members: __contains__,__getitem__,__iter__,__len__,__add__,__sub__,__mul__,__div__,__neg__,__hash__
-   :members:
+   {% block methods %}
+
+   {% if methods %}
+   .. rubric:: Methods
+
+   {% for item in methods %}
+   {%- if (item not in inherited_members and (
+           not item.startswith('_') or
+           item in ['__contains__', '__getitem__', '__iter__', '__len__', '__add__',
+                    '__sub__', '__mul__', '__div__', '__neg__', '__hash__'])) %}
+   .. automethod:: {{ item }}
+
+   {%- endif %}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
+
+   {% block attributes %}
+   {% if attributes %}
+   .. rubric:: Attributes
+
+   .. autosummary::
+      :toctree: {{ objname }}
+   {% for item in attributes %}
+      ~{{ name }}.{{ item }}
+   {%- endfor %}
+   {% endif %}
+   {% endblock %}
 
 .. include:: {{fullname}}.examples
 

--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -4,34 +4,31 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+   {#
+      filter out inherited methods (such as the one from torch.nn.Module)
+      and keep the only useful special methods.
+   #}
+   {% set to_display_methods = [] %}
+   {% set include_special_methods = [
+      '__contains__', '__getitem__', '__iter__', '__len__', '__add__',
+      '__sub__', '__mul__', '__div__', '__neg__', '__hash__'
+   ] %}
+   {% for item in methods %}
+      {% if item not in inherited_members and (
+             not item.startswith('_') or item in include_special_methods) %}
+         {% set __  = to_display_methods.append(item) %}
+      {% endif %}
+   {% endfor %}
+   {% if to_display_methods %}
    {% block methods %}
-
-   {% if methods %}
    .. rubric:: Methods
 
-   {% for item in methods %}
-   {%- if (item not in inherited_members and (
-           not item.startswith('_') or
-           item in ['__contains__', '__getitem__', '__iter__', '__len__', '__add__',
-                    '__sub__', '__mul__', '__div__', '__neg__', '__hash__'])) %}
+   {% for item in to_display_methods %}
    .. automethod:: {{ item }}
 
-   {%- endif %}
-   {%- endfor %}
-   {% endif %}
+   {% endfor %}
    {% endblock %}
-
-   {% block attributes %}
-   {% if attributes %}
-   .. rubric:: Attributes
-
-   .. autosummary::
-      :toctree: {{ objname }}
-   {% for item in attributes %}
-      ~{{ name }}.{{ item }}
-   {%- endfor %}
    {% endif %}
-   {% endblock %}
 
 .. include:: {{fullname}}.examples
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,7 @@ def linkcode_resolve(domain, info):
 
 
 autosummary_generate = True
-autodoc_default_options = {'inherited-members': None}
+autodoc_default_options = {'inherited-members': False}
 
 numpydoc_show_class_members = False
 


### PR DESCRIPTION
This PR intends to avoid documenting inherited methods and changes the way the classes are described (see the template).

Questions are:

- do we want to modify this template, in particular the way attributes are documented.
- Are we sure we do not want to document any inherited methods? (it seems doable to only filter out the methods from `torch.nn.Module` for instance if necessary).