### PR TITLE
[MRG] Deprecating preprocessing functions zscore and scale

### DIFF
--- a/braindecode/datasets/tuh.py
+++ b/braindecode/datasets/tuh.py
@@ -50,6 +50,7 @@ class TUH(BaseConcatDataset):
         # limit to specified recording ids before doing slow stuff
         if recording_ids is not None:
             descriptions = descriptions[recording_ids]
+
         # create datasets gathering more info about the files touching them
         # reading the raws and potentially preloading the data
         base_datasets = self._create_datasets(

--- a/braindecode/datasets/tuh.py
+++ b/braindecode/datasets/tuh.py
@@ -50,7 +50,6 @@ class TUH(BaseConcatDataset):
         # limit to specified recording ids before doing slow stuff
         if recording_ids is not None:
             descriptions = descriptions[recording_ids]
-
         # create datasets gathering more info about the files touching them
         # reading the raws and potentially preloading the data
         base_datasets = self._create_datasets(

--- a/braindecode/preprocessing/preprocess.py
+++ b/braindecode/preprocessing/preprocess.py
@@ -220,7 +220,6 @@ def exponential_moving_demean(data, factor_new=0.001, init_block_size=None):
     Deman the data point :math:`x_t` at time `t` as:
     :math:`x'_t=(x_t - m_t)`.
 
-
     Parameters
     ----------
     data: np.ndarray (n_channels, n_times)
@@ -265,6 +264,7 @@ def zscore(data):
         If this function is supposed to preprocess continuous data, it should be
         given to raw.apply_function().
     """
+    warn('zscore is deprecated. Use sklearn.preprocessing.scale instead.')
     zscored = data - np.mean(data, keepdims=True, axis=-1)
     zscored = zscored / np.std(zscored, keepdims=True, axis=-1)
     # TODO: the overriding of protected '_data' should be implemented in the
@@ -294,6 +294,7 @@ def scale(data, factor):
         If this function is supposed to preprocess continuous data, it should be
         given to raw.apply_function().
     """
+    warn('scale is deprecated. Use numpy.multiply instead.')
     scaled = np.multiply(data, factor)
     # TODO: the overriding of protected '_data' should be implemented in the
     # TODO: dataset when transforms are applied to windows

--- a/braindecode/preprocessing/preprocess.py
+++ b/braindecode/preprocessing/preprocess.py
@@ -14,6 +14,7 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
+from sklearn.utils import deprecated
 
 
 class Preprocessor(object):
@@ -71,6 +72,7 @@ class Preprocessor(object):
             getattr(raw_or_epochs, self.fn)(**self.kwargs)
 
 
+@deprecated(extra='use Preprocessor with `apply_on_array=False` instead.')
 class MNEPreproc(Preprocessor):
     """Preprocessor for an MNE-raw/epoch.
 
@@ -83,11 +85,10 @@ class MNEPreproc(Preprocessor):
         Keyword arguments will be forwarded to the mne function
     """
     def __init__(self, fn, **kwargs):
-        warn('MNEPreproc is deprecated. Use Preprocessor with '
-             '`apply_on_array=False` instead.')
         super().__init__(fn, apply_on_array=False, **kwargs)
 
 
+@deprecated(extra='use Preprocessor with `apply_on_array=True` instead.')
 class NumpyPreproc(Preprocessor):
     """Preprocessor that directly operates on the underlying numpy array of an mne raw/epoch.
 
@@ -101,8 +102,6 @@ class NumpyPreproc(Preprocessor):
         Keyword arguments will be forwarded to the function
     """
     def __init__(self, fn, channel_wise=False, **kwargs):
-        warn('NumpyPreproc is deprecated. Use Preprocessor with '
-             '`apply_on_array=True` instead.')
         assert callable(fn), 'fn must be callable.'
         super().__init__(fn, apply_on_array=True, channel_wise=channel_wise,
                          **kwargs)
@@ -246,6 +245,7 @@ def exponential_moving_demean(data, factor_new=0.001, init_block_size=None):
     return demeaned.T
 
 
+@deprecated(extra='use sklearn.preprocessing.scale instead.')
 def zscore(data):
     """Zscore normalize continuous or windowed data in-place.
 
@@ -264,7 +264,6 @@ def zscore(data):
         If this function is supposed to preprocess continuous data, it should be
         given to raw.apply_function().
     """
-    warn('zscore is deprecated. Use sklearn.preprocessing.scale instead.')
     zscored = data - np.mean(data, keepdims=True, axis=-1)
     zscored = zscored / np.std(zscored, keepdims=True, axis=-1)
     # TODO: the overriding of protected '_data' should be implemented in the
@@ -274,6 +273,7 @@ def zscore(data):
     return zscored
 
 
+@deprecated(extra='use numpy.multiply instead.')
 def scale(data, factor):
     """Scale continuous or windowed data in-place
 
@@ -294,7 +294,6 @@ def scale(data, factor):
         If this function is supposed to preprocess continuous data, it should be
         given to raw.apply_function().
     """
-    warn('scale is deprecated. Use numpy.multiply instead.')
     scaled = np.multiply(data, factor)
     # TODO: the overriding of protected '_data' should be implemented in the
     # TODO: dataset when transforms are applied to windows

--- a/braindecode/preprocessing/preprocess.py
+++ b/braindecode/preprocessing/preprocess.py
@@ -72,7 +72,8 @@ class Preprocessor(object):
             getattr(raw_or_epochs, self.fn)(**self.kwargs)
 
 
-@deprecated(extra='use Preprocessor with `apply_on_array=False` instead.')
+@deprecated(extra='will be removed in 0.7.0. Use Preprocessor with '
+                  '`apply_on_array=False` instead.')
 class MNEPreproc(Preprocessor):
     """Preprocessor for an MNE-raw/epoch.
 
@@ -88,7 +89,8 @@ class MNEPreproc(Preprocessor):
         super().__init__(fn, apply_on_array=False, **kwargs)
 
 
-@deprecated(extra='use Preprocessor with `apply_on_array=True` instead.')
+@deprecated(extra='will be removed in 0.7.0. Use Preprocessor with '
+                  '`apply_on_array=True` instead.')
 class NumpyPreproc(Preprocessor):
     """Preprocessor that directly operates on the underlying numpy array of an mne raw/epoch.
 
@@ -245,7 +247,8 @@ def exponential_moving_demean(data, factor_new=0.001, init_block_size=None):
     return demeaned.T
 
 
-@deprecated(extra='use sklearn.preprocessing.scale instead.')
+@deprecated(extra='will be removed in 0.7.0. Use sklearn.preprocessing.scale '
+                  'instead.')
 def zscore(data):
     """Zscore normalize continuous or windowed data in-place.
 
@@ -273,7 +276,7 @@ def zscore(data):
     return zscored
 
 
-@deprecated(extra='use numpy.multiply instead.')
+@deprecated(extra='will be removed in 0.7.0. Use numpy.multiply instead.')
 def scale(data, factor):
     """Scale continuous or windowed data in-place
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -24,20 +24,16 @@ Current (0.5.2.dev0)
 Enhancements
 ~~~~~~~~~~~~
 - Adding :class:`braindecode.samplers.SequenceSampler` along with support for returning sequences of windows in :class:`braindecode.datasets.BaseConcatDataset` and an updated sleep staging example to show how to train on sequences of windows (:gh:`263` by `Hubert Banville`_)
-
-Enhancements
-~~~~~~~~~~~~
 - Adding Thinker Invariance Network :class:`braindecode.models.TIDNet` (:gh:`170` by `Ann-Kathrin Kiessner`_, `Dan Wilson`_, `Henrik Bonsmann`_, `Vytautas Jankauskas`_)
 - Adding a confusion matrix plot generator :func:`braindecode.visualization.plot_confusion_matrix` (:gh:`274` by `Ann-Kathrin Kiessner`_, `Dan Wilson`_, `Henrik Bonsmann`_, `Vytautas Jankauskas`_)
-
 - Adding data :ref:`augmentation_api` module (:gh:`254` by `Cedric Rommel`_, `Alex Gramfort`_ and `Thomas Moreau`_)
-
 - Adding Mixup augmentation :class:`braindecode.augmentation.Mixup` (:gh:`254` by `Simon Brandt`_)
 
 API changes
 ~~~~~~~~~~~
 - Removing the default sampling frequency sfreq value in :func:`braindecode.datasets.create_windows_from_events` (:gh:`256` by `Ann-Kathrin Kiessner`_, `Dan Wilson`_, `Henrik Bonsmann`_, `Vytautas Jankauskas`_)
 - Made windowing arguments optional in :func:`braindecode.preprocessing.windowers.create_fixed_length_windows` & :func:`braindecode.preprocessing.windowers.create_windows_from_events` (:gh:`269` by `Ann-Kathrin Kiessner`_, `Dan Wilson`_, `Henrik Bonsmann`_, `Vytautas Jankauskas`_)
+- Deprecating preprocessing functions :func:`braindecode.preprocessing.zscore` and :func:`braindecode.preprocessing.scale` in favour of sklearn's implementation (:gh:`292` by `Hubert Banville`_)
 
 .. _changes_0_5_1:
 

--- a/examples/plot_relative_positioning.py
+++ b/examples/plot_relative_positioning.py
@@ -136,9 +136,9 @@ windows_dataset = create_windows_from_events(
 # We also preprocess the windows by applying channel-wise z-score normalization.
 #
 
-from braindecode.preprocessing.preprocess import zscore
+from sklearn.preprocessing import scale
 
-preprocess(windows_dataset, [Preprocessor(zscore)])
+preprocess(windows_dataset, [Preprocessor(scale, channel_wise=True)])
 
 
 ######################################################################

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -126,9 +126,9 @@ windows_dataset = create_windows_from_events(
 # in each window.
 #
 
-from braindecode.preprocessing.preprocess import zscore
+from sklearn.preprocessing import scale
 
-preprocess(windows_dataset, [Preprocessor(zscore)])
+preprocess(windows_dataset, [Preprocessor(scale, channel_wise=True)])
 
 
 ######################################################################

--- a/test/unit_tests/preprocessing/test_preprocess.py
+++ b/test/unit_tests/preprocessing/test_preprocess.py
@@ -56,10 +56,10 @@ def test_no_raw_or_epochs():
 
 
 def test_deprecated_preprocs(base_concat_ds):
-    msg1 = 'Class MNEPreproc is deprecated; use Preprocessor with ' \
-           '`apply_on_array=False` instead.'
-    msg2 = 'NumpyPreproc is deprecated; use Preprocessor with ' \
-           '`apply_on_array=True` instead.'
+    msg1 = 'Class MNEPreproc is deprecated; will be removed in 0.7.0. Use ' \
+           'Preprocessor with `apply_on_array=False` instead.'
+    msg2 = 'NumpyPreproc is deprecated; will be removed in 0.7.0. Use ' \
+           'Preprocessor with `apply_on_array=True` instead.'
     with pytest.warns(FutureWarning, match=msg1):
         mne_preproc = MNEPreproc('pick_types', eeg=True, meg=False, stim=False)
     factor = 1e6
@@ -117,8 +117,8 @@ def test_preprocess_windows_callable_on_object(windows_concat_ds):
 
 
 def test_zscore_deprecated():
-    msg = 'Function zscore is deprecated; use sklearn.preprocessing.scale '\
-          'instead.'
+    msg = 'Function zscore is deprecated; will be removed in 0.7.0. Use ' \
+          'sklearn.preprocessing.scale instead.'
     with pytest.warns(FutureWarning, match=msg):
         zscore(np.random.rand(2, 2))
 
@@ -162,7 +162,8 @@ def test_zscore_windows(windows_concat_ds):
 
 
 def test_scale_deprecated():
-    msg = 'Function scale is deprecated; use numpy.multiply instead.'
+    msg = 'Function scale is deprecated; will be removed in 0.7.0. Use ' \
+          'numpy.multiply instead.'
     with pytest.warns(FutureWarning, match=msg):
         scale(np.random.rand(2, 2), factor=2)
 

--- a/test/unit_tests/preprocessing/test_preprocess.py
+++ b/test/unit_tests/preprocessing/test_preprocess.py
@@ -116,6 +116,12 @@ def test_preprocess_windows_callable_on_object(windows_concat_ds):
                                rtol=1e-4, atol=1e-4)
 
 
+def test_zscore_deprecated():
+    msg = 'zscore is deprecated. Use sklearn.preprocessing.scale instead.'
+    with pytest.warns(UserWarning, match=msg):
+        zscore(np.random.rand(2, 2))
+
+
 def test_zscore_continuous(base_concat_ds):
     preprocessors = [
         Preprocessor('pick_types', eeg=True, meg=False, stim=False),
@@ -152,6 +158,12 @@ def test_zscore_windows(windows_concat_ds):
         expected = np.ones(shape[:-1])
         np.testing.assert_allclose(
             windowed_data.std(axis=-1), expected, rtol=1e-4, atol=1e-4)
+
+
+def test_scale_deprecated():
+    msg = 'scale is deprecated. Use numpy.multiply instead.'
+    with pytest.warns(UserWarning, match=msg):
+        scale(np.random.rand(2, 2), factor=2)
 
 
 def test_scale_continuous(base_concat_ds):

--- a/test/unit_tests/preprocessing/test_preprocess.py
+++ b/test/unit_tests/preprocessing/test_preprocess.py
@@ -56,14 +56,14 @@ def test_no_raw_or_epochs():
 
 
 def test_deprecated_preprocs(base_concat_ds):
-    msg1 = 'MNEPreproc is deprecated. Use Preprocessor with ' \
+    msg1 = 'Class MNEPreproc is deprecated; use Preprocessor with ' \
            '`apply_on_array=False` instead.'
-    msg2 = 'NumpyPreproc is deprecated. Use Preprocessor with ' \
+    msg2 = 'NumpyPreproc is deprecated; use Preprocessor with ' \
            '`apply_on_array=True` instead.'
-    with pytest.warns(UserWarning, match=msg1):
+    with pytest.warns(FutureWarning, match=msg1):
         mne_preproc = MNEPreproc('pick_types', eeg=True, meg=False, stim=False)
     factor = 1e6
-    with pytest.warns(UserWarning, match=msg2):
+    with pytest.warns(FutureWarning, match=msg2):
         np_preproc = NumpyPreproc(scale, factor=factor)
 
     raw_timepoint = base_concat_ds[0][0][:22]  # only keep EEG channels
@@ -117,8 +117,9 @@ def test_preprocess_windows_callable_on_object(windows_concat_ds):
 
 
 def test_zscore_deprecated():
-    msg = 'zscore is deprecated. Use sklearn.preprocessing.scale instead.'
-    with pytest.warns(UserWarning, match=msg):
+    msg = 'Function zscore is deprecated; use sklearn.preprocessing.scale '\
+          'instead.'
+    with pytest.warns(FutureWarning, match=msg):
         zscore(np.random.rand(2, 2))
 
 
@@ -161,8 +162,8 @@ def test_zscore_windows(windows_concat_ds):
 
 
 def test_scale_deprecated():
-    msg = 'scale is deprecated. Use numpy.multiply instead.'
-    with pytest.warns(UserWarning, match=msg):
+    msg = 'Function scale is deprecated; use numpy.multiply instead.'
+    with pytest.warns(FutureWarning, match=msg):
         scale(np.random.rand(2, 2), factor=2)
 
 


### PR DESCRIPTION
Following discussion in #292, this PR deprecates functions `zscore` and `scale`, which can be replaced by `sklearn.preprocessing.scale` and `np.multiply`, respectively.