### PR TITLE
[MRG] Self-ensembling for sequence-to-sequence models

### DIFF
--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -87,9 +87,9 @@ def _pad_shift_array(x, stride=1):
     Returns
     -------
     np.ndarray :
-        Array of shape (n_rows, n_classes, n_rows + n_windows - 1) where each
-        row is obtained by zero-padding the corresponding row in `x` before and
-        after in the last dimension.
+        Array of shape (n_rows, n_classes, (n_rows - 1) * stride + n_windows)
+        where each row is obtained by zero-padding the corresponding row in `x`
+        before and after in the last dimension.
     """
     if x.ndim != 3:
         raise NotImplementedError(

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -4,6 +4,7 @@
 
 import torch
 import numpy as np
+from scipy.special import log_softmax
 
 
 def to_dense_prediction_model(model, axis=(2, 3)):
@@ -68,3 +69,69 @@ def get_output_shape(model, in_chans, input_window_samples):
         )
         output_shape = model(dummy_input).shape
     return output_shape
+
+
+def _pad_shift_array(x, stride=1):
+    """Zero-pad and shift rows of a 3D array.
+
+    E.g., used to align predictions of corresponding windows in
+    sequence-to-sequence models.
+
+    Parameters
+    ----------
+    x : np.ndarray
+        Array of shape (n_rows, n_classes, n_windows).
+    stride : int
+        Number of non-overlapping elements between two consecutive sequences.
+
+    Returns
+    -------
+    np.ndarray :
+        Array of shape (n_rows, n_classes, n_rows + n_windows - 1) where each
+        row is obtained by zero-padding the corresponding row in `x` before and
+        after in the last dimension.
+    """
+    if x.ndim != 3:
+        raise NotImplementedError(
+            f'x must be of shape (n_rows, n_clases, n_windows), got {x.shape}')
+    x_padded = np.pad(x, ((0, 0), (0, 0), (0, (x.shape[0] - 1) * stride)))
+    orig_strides = x_padded.strides
+    new_strides = (orig_strides[0] - stride * orig_strides[2],
+                   orig_strides[1],
+                   orig_strides[2])
+    return np.lib.stride_tricks.as_strided(x_padded, strides=new_strides)
+
+
+def aggregate_probas(logits, n_windows_stride=1):
+    """Aggregate predicted probabilities with self-ensembling.
+
+    Aggregate window-wise predicted probabilities obtained on overlapping
+    sequences of windows using multiplicative voting as described in
+    [Phan2018]_.
+
+    Parameters
+    ----------
+    logits : np.ndarray
+        Array of shape (n_sequences, n_classes, n_windows) containing the
+        logits (i.e. the raw unnormalized scores for each class) for each
+        window of each sequence.
+    n_windows_stride : int
+        Number of windows between two consecutive sequences. Default is 1
+        (maximally overlapping sequences).
+
+    Returns
+    -------
+    np.ndarray :
+        Array of shape (n_sequences + n_windows - 1, n_classes) containing the
+        aggregated predicted probabilities for each window contained in the
+        input sequences.
+
+    References
+    ----------
+    .. [Phan2018] Phan, H., Andreotti, F., Cooray, N., Chén, O. Y., &
+        De Vos, M. (2018). Joint classification and prediction CNN framework
+        for automatic sleep stage classification. IEEE Transactions on
+        Biomedical Engineering, 66(5), 1285-1296.
+    """
+    log_probas = log_softmax(logits, axis=1)
+    return _pad_shift_array(log_probas, stride=n_windows_stride).sum(axis=0).T

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -88,12 +88,13 @@ def _pad_shift_array(x, stride=1):
     -------
     np.ndarray :
         Array of shape (n_rows, n_classes, (n_rows - 1) * stride + n_windows)
-        where each row is obtained by zero-padding the corresponding row in `x`
-        before and after in the last dimension.
+        where each row is obtained by zero-padding the corresponding row in
+        ``x`` before and after in the last dimension.
     """
     if x.ndim != 3:
         raise NotImplementedError(
-            f'x must be of shape (n_rows, n_clases, n_windows), got {x.shape}')
+            'x must be of shape (n_rows, n_classes, n_windows), got '
+            f'{x.shape}')
     x_padded = np.pad(x, ((0, 0), (0, 0), (0, (x.shape[0] - 1) * stride)))
     orig_strides = x_padded.strides
     new_strides = (orig_strides[0] - stride * orig_strides[2],

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -122,9 +122,9 @@ def aggregate_probas(logits, n_windows_stride=1):
     Returns
     -------
     np.ndarray :
-        Array of shape (n_sequences + n_windows - 1, n_classes) containing the
-        aggregated predicted probabilities for each window contained in the
-        input sequences.
+        Array of shape ((n_rows - 1) * stride + n_windows, n_classes)
+        containing the aggregated predicted probabilities for each window
+        contained in the input sequences.
 
     References
     ----------

--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -95,6 +95,14 @@ class SequenceSampler(RecordingSampler):
         Number of windows between two consecutive sequences.
     random_state : np.random.RandomState | int | None
         Random state.
+
+    Attributes
+    ----------
+    info : pd.DataFrame
+        See RecordingSampler.
+    file_ids : np.ndarray of ints
+        Array of shape (n_sequences,) that indicates from which file each
+        sequence comes from. Useful e.g. to do self-ensembling.
     """
     def __init__(self, metadata, n_windows, n_windows_stride,
                  random_state=None):

--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -102,20 +102,25 @@ class SequenceSampler(RecordingSampler):
 
         self.n_windows = n_windows
         self.n_windows_stride = n_windows_stride
-        self.start_inds = self._compute_seq_start_inds()
+        self.start_inds, self.file_ids = self._compute_seq_start_inds()
 
     def _compute_seq_start_inds(self):
         """Compute sequence start indices.
 
         Returns
         -------
-        np.ndarray
+        np.ndarray :
             Array of shape (n_sequences,) containing the indices of the first
             windows of possible sequences.
+        np.ndarray :
+            Array of shape (n_sequences,) containing the unique file number of
+            each sequence. Useful e.g. to do self-ensembling.
         """
         end_offset = 1 - self.n_windows if self.n_windows > 1 else None
-        return np.concatenate(self.info['index'].apply(
-            lambda x: x[:end_offset:self.n_windows_stride]).values)
+        start_inds = self.info['index'].apply(
+            lambda x: x[:end_offset:self.n_windows_stride]).values
+        file_ids = [[i] * len(inds) for i, inds in enumerate(start_inds)]
+        return np.concatenate(start_inds), np.concatenate(file_ids)
 
     def __len__(self):
         return len(self.start_inds)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -29,6 +29,7 @@ Enhancements
 - Adding data :ref:`augmentation_api` module (:gh:`254` by `Cedric Rommel`_, `Alex Gramfort`_ and `Thomas Moreau`_)
 - Adding Mixup augmentation :class:`braindecode.augmentation.Mixup` (:gh:`254` by `Simon Brandt`_)
 - Adding saving of preprocessing and windowing choices in :func:`braindecode.preprocessing.preprocess`, :func:`braindecode.preprocessing.create_windows_from_events` and :func:`braindecode.preprocessing.create_fixed_length_windows` to datasets to facilitate reproducibility (:gh:`287` by `Lukas Gemein`_)
+- Adding :func:`braindecode.models.util.aggregate_probas` to perform self-ensembling of predictions with sequence-to-sequence models (:gh:`294` by `Hubert Banville`_)
 
 API changes
 ~~~~~~~~~~~

--- a/test/unit_tests/models/test_util.py
+++ b/test/unit_tests/models/test_util.py
@@ -53,9 +53,6 @@ def test_pad_shift_array_not_3d():
 @pytest.mark.parametrize('n_sequences,n_classes,n_windows,stride',
                          [[3, 3, 2, 2], [3, 3, 1, 1], [10, 3, 2, 1]])
 def test_aggregate_probas(n_sequences, n_classes, n_windows, stride):
-    # Aggregation should be done recording-wise, we don't want overlapping
-    # sequences from different recordings...
-
     n_outputs = (n_sequences - 1) * stride + n_windows
     y_true = np.arange(n_outputs) % n_classes
     logits = OneHotEncoder(sparse=False).fit_transform(y_true.reshape(-1, 1))

--- a/test/unit_tests/models/test_util.py
+++ b/test/unit_tests/models/test_util.py
@@ -2,9 +2,13 @@
 #
 # License: BSD (3-clause)
 
+import pytest
+import numpy as np
+from sklearn.preprocessing import OneHotEncoder
 
 from braindecode.models.modules import Expression
-from braindecode.models.util import get_output_shape
+from braindecode.models.util import (
+    get_output_shape, aggregate_probas, _pad_shift_array)
 from torch import nn
 
 
@@ -20,3 +24,46 @@ def test_get_output_shape_2d_model():
         nn.Conv2d(1, 1, (3, 1)))
     out_shape = get_output_shape(model, in_chans=1, input_window_samples=5)
     assert out_shape == (1, 1, 3, 1)
+
+
+@pytest.mark.parametrize('dtype', [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize('n_sequences,n_classes,n_windows,stride',
+                         [[10, 3, 2, 1], [3, 3, 2, 5], [3, 3, 1, 2]])
+def test_pad_shift_array(n_sequences, n_classes, n_windows, stride, dtype):
+    dense_y = np.random.RandomState(33).rand(n_sequences, n_classes, n_windows)
+
+    n_outputs = (n_sequences - 1) * stride + n_windows
+    shifted_y = np.concatenate([
+        np.concatenate((
+            np.zeros((1, n_classes, i * stride)), dense_y[[i]],
+            np.zeros((1, n_classes, n_outputs - n_windows - i * stride))),
+            axis=2)
+        for i in range(n_sequences)], axis=0)
+    shifted_y2 = _pad_shift_array(dense_y, stride=stride)
+
+    assert (shifted_y == shifted_y2).all()
+
+
+def test_pad_shift_array_not_3d():
+    with pytest.raises(NotImplementedError):
+        _pad_shift_array(np.zeros((2, 2)))
+
+
+@pytest.mark.parametrize('n_sequences,n_classes,n_windows,stride',
+                         [[3, 3, 2, 2], [3, 3, 1, 1], [10, 3, 2, 1]])
+def test_aggregate_probas(n_sequences, n_classes, n_windows, stride):
+    # Aggregation should be done recording-wise, we don't want overlapping
+    # sequences from different recordings...
+
+    n_outputs = (n_sequences - 1) * stride + n_windows
+    y_true = np.arange(n_outputs) % n_classes
+    logits = OneHotEncoder(sparse=False).fit_transform(y_true.reshape(-1, 1))
+    logits = np.lib.stride_tricks.sliding_window_view(
+        logits, n_windows, axis=0)[::stride]
+
+    y_pred_probas = aggregate_probas(logits, n_windows_stride=stride)
+
+    assert y_pred_probas.ndim == 2
+    assert y_pred_probas.shape[0] == n_outputs
+    assert y_pred_probas.shape[1] == n_classes
+    assert (y_true == y_pred_probas.argmax(axis=1)).all()

--- a/test/unit_tests/models/test_util.py
+++ b/test/unit_tests/models/test_util.py
@@ -30,7 +30,8 @@ def test_get_output_shape_2d_model():
 @pytest.mark.parametrize('n_sequences,n_classes,n_windows,stride',
                          [[10, 3, 2, 1], [3, 3, 2, 5], [3, 3, 1, 2]])
 def test_pad_shift_array(n_sequences, n_classes, n_windows, stride, dtype):
-    dense_y = np.random.RandomState(33).rand(n_sequences, n_classes, n_windows)
+    dense_y = np.random.RandomState(33).rand(
+        n_sequences, n_classes, n_windows).astype(dtype)
 
     n_outputs = (n_sequences - 1) * stride + n_windows
     shifted_y = np.concatenate([

--- a/test/unit_tests/samplers/test_samplers.py
+++ b/test/unit_tests/samplers/test_samplers.py
@@ -124,6 +124,7 @@ def test_sequence_sampler(windows_ds, n_windows, n_windows_stride):
 
     seq_lens = [(len(ds) - n_windows) // n_windows_stride + 1
                 for ds in windows_ds.datasets]
+    file_ids = np.concatenate([[i] * l for i, l in enumerate(seq_lens)])
     n_seqs = sum(seq_lens)
     assert len(seqs) == n_seqs
     assert len(seqs[0]) == n_windows
@@ -131,3 +132,5 @@ def test_sequence_sampler(windows_ds, n_windows, n_windows_stride):
     for i in range(seq_lens[0] - 1):
         np.testing.assert_array_equal(
             seqs[i][n_windows_stride:], seqs[i + 1][:-n_windows_stride])
+
+    assert (sampler.file_ids == file_ids).all()


### PR DESCRIPTION
This PR introduces a utility function `aggregate_probas` to perform self-ensembling as described in [Phan et al. (2018)](https://ieeexplore.ieee.org/abstract/document/8502139). This works by aggregating the window-wise predictions of a seq2seq model when fed with overlapping sequences. This will be useful e.g. in #282.

To simplify its use, I also added an attribute `file_ids` to `SequenceSampler` so we can easily see which file each sequence comes from. 

In the end, the function can be used in the following way given a seq2seq model `clf` (e.g. an `EEGClassifier` that wraps `USleep`):

```python
y_true = np.array([valid_set[i][1] for i in range(len(valid_set))])
logits = clf.predict_proba(valid_set)
y_pred = np.concatenate(
    [aggregate_probas(logits[valid_sampler.file_ids == id]) 
     for id in np.unique(valid_sampler.file_ids)])
     
# Then, use `y_true` and `y_pred` to measure performance 
``` 

@Tgnassou @agramfort 