### PR TITLE
docs: make all navigation entries expandable

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -218,7 +218,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {"collapse_navigation": False, "navigation_depth": 4}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
Makes it possible to browse the sections of other pages without actually opening them, making it easier to get an overview.

How it currently looks (section only expandable/collapsible for current page):

![image](https://user-images.githubusercontent.com/1405370/124741629-33702d00-df1c-11eb-9b2b-7ab34b59cb93.png)

Example from ActivityWatch docs where all sections are expandable:

![image](https://user-images.githubusercontent.com/1405370/124741471-0459bb80-df1c-11eb-8837-c97d0b63f623.png)
