### PR TITLE
Fix is_outdated_saved with large files split by mne

### DIFF
--- a/braindecode/datautil/serialization.py
+++ b/braindecode/datautil/serialization.py
@@ -216,7 +216,7 @@ def _is_outdated_saved(path):
     or '-epo.fif' in path (no subdirectories) OR if there are more 'fif' files
     than 'description.json' files."""
     description_files = glob(os.path.join(path, '**/description.json'))
-    fif_files = glob(os.path.join(path, '**/*.fif'))
+    fif_files = glob(os.path.join(path, '**/*-raw.fif')) + glob(os.path.join(path, '**/*-epo.fif'))
     multiple = len(description_files) != len(fif_files)
     kwargs_in_path = any(
         [os.path.exists(os.path.join(path, kwarg_name))


### PR DESCRIPTION
In some cases `_is_outdated_saved` incorrectly recognizes new datasets as saved in the deprecated way. Using `force_new_loading` users can enforce loading with new load function. It should be used  if user is sure about the dataset that it's new.

closes #324 