### PR TITLE
[MRG] Fixing serialization of SleepPhysionet

### DIFF
--- a/braindecode/datasets/sleep_physionet.py
+++ b/braindecode/datasets/sleep_physionet.py
@@ -68,7 +68,7 @@ class SleepPhysionet(BaseConcatDataset):
             'Temp rectal': 'misc',
             'Event marker': 'misc'
         }
-        exclude = ch_mapping.keys() if load_eeg_only else ()
+        exclude = list(ch_mapping.keys()) if load_eeg_only else ()
 
         raw = mne.io.read_raw_edf(raw_fname, preload=preload, exclude=exclude)
         annots = mne.read_annotations(ann_fname)
@@ -89,7 +89,7 @@ class SleepPhysionet(BaseConcatDataset):
         # Rename EEG channels
         ch_names = {
             i: i.replace('EEG ', '') for i in raw.ch_names if 'EEG' in i}
-        mne.rename_channels(raw.info, ch_names)
+        raw.rename_channels(ch_names)
 
         if not load_eeg_only:
             raw.set_channel_types(ch_mapping)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -40,6 +40,7 @@ Enhancements
 Bugs
 ~~~~
 - Correctly computing recording length in :func:`braindecode.preprocessing.windowers.create_fixed_length_windows` in case recording was cropped (:gh:`304` by `Lukas Gemein`_)
+- Fixing :class:`braindecode.datasets.SleepPhysionet` to allow serialization and avoid mismatch in channel names attributes (:gh:`327` by `Hubert Banville`_)
 
 API changes
 ~~~~~~~~~~~

--- a/test/unit_tests/datasets/test_sleep_physionet.py
+++ b/test/unit_tests/datasets/test_sleep_physionet.py
@@ -31,7 +31,7 @@ def test_crop_wake():
 
 def test_serializable():
     """Make sure the object can be pickled. There used to be a bug (<=0.5.1)
-    where the object couldn't be pickled because raw.exlude was a dict_keys
+    where the object couldn't be pickled because raw.exclude was a dict_keys
     object.
     """
     sp = SleepPhysionet(
@@ -42,5 +42,5 @@ def test_serializable():
 def test_ch_names_orig_units_match():
     sp = SleepPhysionet(
         subject_ids=[0], recording_ids=[1], preload=True, load_eeg_only=True)
-    assert all([sp.datasets[0].raw._orig_units.keys() ==
-                set(sp.datasets[0].raw.ch_names) for ds in sp.datasets])
+    assert all([ds.raw._orig_units.keys() == set(ds.raw.ch_names)
+                for ds in sp.datasets])

--- a/test/unit_tests/datasets/test_sleep_physionet.py
+++ b/test/unit_tests/datasets/test_sleep_physionet.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+import pickle
+
 from braindecode.datasets.sleep_physionet import SleepPhysionet
 from braindecode.datasets.base import BaseConcatDataset
 
@@ -25,3 +27,20 @@ def test_crop_wake():
     sfreq = sp.datasets[0].raw.info['sfreq']
     duration_h = len(sp) / (3600 * sfreq)
     assert duration_h < 7 and duration_h > 6
+
+
+def test_serializable():
+    """Make sure the object can be pickled. There used to be a bug (<=0.5.1)
+    where the object couldn't be pickled because raw.exlude was a dict_keys
+    object.
+    """
+    sp = SleepPhysionet(
+        subject_ids=[0], recording_ids=[1], preload=True, load_eeg_only=True)
+    pickle.dumps(sp)
+
+
+def test_ch_names_orig_units_match():
+    sp = SleepPhysionet(
+        subject_ids=[0], recording_ids=[1], preload=True, load_eeg_only=True)
+    assert all([sp.datasets[0].raw._orig_units.keys() ==
+                set(sp.datasets[0].raw.ch_names) for ds in sp.datasets])


### PR DESCRIPTION
This PR fixes two minor bugs with the SleepPhysionet class that I came across with while running some tests for #325. First, the `exclude` attribute of the Raw object was a `dict_keys` object, which prevented the dataset from being serialized. Second, channels were renamed using `mne.rename_channels` instead of using Raw's `rename_channels` method, which led to `.ch_names` and `._orig_units` having different channel names. This created an issue when applying the filterbank preprocessor.