### PR TITLE
Be less strict with window sizes exceeding trial

### DIFF
--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -30,7 +30,7 @@ def create_windows_from_events(
         window_size_samples=None, window_stride_samples=None,
         drop_last_window=False, mapping=None, preload=False,
         drop_bad_windows=True, picks=None, reject=None, flat=None,
-        on_missing='error', n_jobs=1):
+        on_missing='error', accepted_bads_ratio=0.1, n_jobs=1):
     """Create windows based on events in mne.Raw.
 
     This function extracts windows of size window_size_samples in the interval
@@ -93,6 +93,12 @@ def create_windows_from_events(
     on_missing: str
         What to do if one or several event ids are not found in the recording.
         Valid keys are ‘error’ | ‘warning’ | ‘ignore’. See mne.Epochs.
+    accepted_bads_ratio: float, optional
+        Acceptable proportion of trials withinconsistent length in a raw. If
+        the number of trials whose length is exceeded by the window size is
+        smaller than this, then only the corresponding trials are dropped, but
+        the computation continues. Otherwise, an error is raised. Defaults to
+        0.1.
     n_jobs: int
         Number of jobs to use to parallelize the windowing.
 
@@ -117,7 +123,7 @@ def create_windows_from_events(
             trial_start_offset_samples, trial_stop_offset_samples,
             window_size_samples, window_stride_samples, drop_last_window,
             mapping, preload, drop_bad_windows, picks, reject, flat,
-            on_missing) for ds in concat_ds.datasets)
+            on_missing, accepted_bads_ratio) for ds in concat_ds.datasets)
     return BaseConcatDataset(list_of_windows_ds)
 
 
@@ -205,7 +211,7 @@ def _create_windows_from_events(
         window_size_samples=None, window_stride_samples=None,
         drop_last_window=False, mapping=None, preload=False,
         drop_bad_windows=True, picks=None, reject=None, flat=None,
-        on_missing='error'):
+        on_missing='error', accepted_bads_ratio=0.1):
     """Create WindowsDataset from BaseDataset based on events.
 
     Parameters
@@ -280,7 +286,7 @@ def _create_windows_from_events(
     i_trials, i_window_in_trials, starts, stops = _compute_window_inds(
         onsets, stops, trial_start_offset_samples,
         trial_stop_offset_samples, window_size_samples,
-        window_stride_samples, drop_last_window)
+        window_stride_samples, drop_last_window, accepted_bads_ratio)
 
     events = [[start, window_size_samples, description[i_trials[i_start]]]
               for i_start, start in enumerate(starts)]
@@ -472,7 +478,7 @@ def _create_windows_from_target_channels(
 
 def _compute_window_inds(
         starts, stops, start_offset, stop_offset, size, stride,
-        drop_last_window, accepted_bads_ratio=0.1):
+        drop_last_window, accepted_bads_ratio):
     """Compute window start and stop indices.
 
     Create window starts from trial onsets (shifted by start_offset) to trial
@@ -495,7 +501,7 @@ def _compute_window_inds(
         Stride between windows.
     drop_last_window: bool
         Toggles of shifting last window within range or dropping last samples.
-    accepted_bads_ratio: float, optional
+    accepted_bads_ratio: float
         Acceptable proportion of bad trials within a raw. If the number of
         trials whose length is exceeded by the window size is smaller than
         this, then only the corresponding trials are dropped, but the

--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -518,8 +518,8 @@ def _compute_window_inds(
             starts = starts[np.logical_not(bads_mask)]
             stops = stops[np.logical_not(bads_mask)]
             warnings.warn(
-                f'Trials {np.where(bads_mask)[0]} are being dropped as the'
-                f'window size {size} exceeds theur duration {min_duration}.')
+                f'Trials {np.where(bads_mask)[0]} are being dropped as the '
+                f'window size ({size}) exceeds their duration {min_duration}.')
         else:
             raise ValueError(f'Window size {size} exceeds trial duration '
                              f'for too many trials {min_duration}.')

--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -522,7 +522,7 @@ def _compute_window_inds(
                 f'window size ({size}) exceeds their duration {min_duration}.')
         else:
             raise ValueError(f'Window size {size} exceeds trial duration '
-                             f'for too many trials {min_duration}.')
+                             f'({min_duration}) for too many trials.')
 
     i_window_in_trials, i_trials, window_starts = [], [], []
     for start_i, (start, stop) in enumerate(zip(starts, stops)):

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -39,6 +39,7 @@ Enhancements
 - Adding :class:`braindecode.models.TimeDistributed` to apply a module on a sequence (:gh:`318` by `Hubert Banville`_)
 - Adding time series targets decoding together with :class:`braindecode.datasets.BCICompetitionIVDataset4` and fingers flexion decoding from ECoG examples (:gh:`261` by `Maciej Śliwowski`_ and `Mohammed Fattouh`_)
 - Make EEGClassifier and EEGRegressor cloneable for scikit-learn :class:`braindecode.augmentation.Mixup` (:gh:`347` by `Lukas Gemein`_, `Robin Tibor Schirrmeister`_, `Maciej Śliwowski`_ and `Alex Gramfort`_)
+- Allow to raise a warning when a few trials are shorter than the windows length, instead of raising an error and stopping all computation. (:gh:`353` by `Cedric Rommel`_)
 
 Bugs
 ~~~~

--- a/test/unit_tests/datautil/test_serialization.py
+++ b/test/unit_tests/datautil/test_serialization.py
@@ -198,7 +198,8 @@ def test_load_save_window_preproc_kwargs(setup_concat_windows_dataset, tmpdir):
                 'drop_last_window': False, 'mapping':  {
                     'feet': 0, 'left_hand': 1, 'right_hand': 2, 'tongue': 3},
                 'preload': False, 'drop_bad_windows': True, 'picks': None,
-                'reject': None, 'flat': None, 'on_missing': 'error'})
+                'reject': None, 'flat': None, 'on_missing': 'error',
+                'accepted_bads_ratio': 0.0})
         ]
         assert ds.window_preproc_kwargs == [
             ('pick_channels', {'ch_names': ['Cz']}),

--- a/test/unit_tests/preprocessing/test_windowers.py
+++ b/test/unit_tests/preprocessing/test_windowers.py
@@ -446,7 +446,8 @@ def test_epochs_kwargs(lazy_loadable_dataset):
                 'window_size_samples': 100, 'window_stride_samples': 100,
                 'drop_last_window': False, 'mapping': {'test': 0}, 'preload': False,
                 'drop_bad_windows': True, 'picks': picks, 'reject': reject,
-                'flat': flat, 'on_missing': on_missing, 'accepted_bads_ratio': 0.1})
+                'flat': flat, 'on_missing': on_missing,
+                'accepted_bads_ratio': 0.0})
         ]
 
     windows = create_fixed_length_windows(

--- a/test/unit_tests/preprocessing/test_windowers.py
+++ b/test/unit_tests/preprocessing/test_windowers.py
@@ -446,7 +446,7 @@ def test_epochs_kwargs(lazy_loadable_dataset):
                 'window_size_samples': 100, 'window_stride_samples': 100,
                 'drop_last_window': False, 'mapping': {'test': 0}, 'preload': False,
                 'drop_bad_windows': True, 'picks': picks, 'reject': reject,
-                'flat': flat, 'on_missing': on_missing})
+                'flat': flat, 'on_missing': on_missing, 'accepted_bads_ratio': 0.1})
         ]
 
     windows = create_fixed_length_windows(
@@ -594,6 +594,8 @@ def test_window_sizes_too_large(concat_ds_targets):
             trial_start_offset_samples=0,
             trial_stop_offset_samples=0,
             drop_last_window=False,
+            accepted_bads_ratio=0.5,
+            on_missing='ignore'
         )
 
 


### PR DESCRIPTION
In PR https://github.com/braindecode/braindecode/pull/304, a new assertion check is added to `_compute_window_inds` (involved in trial-based windowing), to prevent trials which are too short compared to the requested window size. While the check is really useful for robustness, I wonder whether raising an error regardless of the severity of the inconsistency is not too harsh.

To illustrate what I mean, here is my personal example:
After rebasing onto braindecode/master, I encountered errors when loading the MASS dataset that I have been using for a while now. Probably due to `mne.resample` issues, it happened that one trial of one recording out of 64 had a slight misalignment, making its size be 3839 instead of 3840 (window size). And because of this, the whole dataset could not be loaded. So the first thing I did was find out what raw was causing the problem, what trial, go to the data saved locally, fix it, etc... But then I though that maybe this might happen quite often to other users as well and that warning the users (as it was done before PR https://github.com/braindecode/braindecode/pull/304) and just dropping the bad trial instead of raising an error and stopping all computation might be a good alternative.

What do you think?