### PR TITLE
Fix incompatibility between augmentations and `skorch.NeuralNet.set_params`

### DIFF
--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -51,7 +51,7 @@ class Transform(torch.nn.Module):
         self.rng = check_random_state(random_state)
 
     def get_params(self, X, y):
-        return tuple()
+        return dict()
 
     def forward(self, X: Tensor, y: Tensor = None) -> Output:
         """General forward pass for an augmentation transform.
@@ -87,7 +87,7 @@ class Transform(torch.nn.Module):
             # Uses the mask to define the output
             out_X[mask, ...], tr_y = self.operation(
                 out_X[mask, ...], out_y[mask],
-                *self.get_params(out_X[mask, ...], out_y[mask])
+                **self.get_params(out_X[mask, ...], out_y[mask])
             )
             # Apply the operation defining the Transform to the whole batch
             if type(tr_y) is tuple:

--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -50,7 +50,7 @@ class Transform(torch.nn.Module):
         self._probability = probability
         self.rng = check_random_state(random_state)
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         return dict()
 
     def forward(self, X: Tensor, y: Tensor = None) -> Output:

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -208,7 +208,7 @@ class ChannelsShuffle(Transform):
         Float setting the probability of applying the operation.
     p_shuffle: float | None, optional
         Float between 0 and 1 setting the probability of including the channel
-        in the set of permutted channels. Defaults to 0.2.
+        in the set of permuted channels. Defaults to 0.2.
     random_state: int | numpy.random.Generator, optional
         Seed to be used to instantiate numpy random number generator instance.
         Used to decide whether or not to transform given the probability
@@ -251,7 +251,7 @@ class ChannelsShuffle(Transform):
             Contains
             * p_shuffle : float
                 Float between 0 and 1 setting the probability of including the
-                channel in the set of permutted channels.
+                channel in the set of permuted channels.
             * random_state : numpy.random.Generator
                 The generator to use.
         """

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -121,12 +121,14 @@ class FTSurrogate(Transform):
 
         Returns
         -------
-        phase_noise_magnitude : float
-            The magnitude of the transformation.
-        rng : numpy.random.Generator
-            The generator to use.
+        params : dict
+            Contains the magnitude of the transformation
+            (phase_noise_magnitude) and the random state.
         """
-        return self.phase_noise_magnitude, self.rng
+        return {
+            "phase_noise_magnitude": self.phase_noise_magnitude,
+            "random_state": self.rng,
+        }
 
 
 class ChannelsDropout(Transform):
@@ -178,13 +180,14 @@ class ChannelsDropout(Transform):
 
         Returns
         -------
-        p_drop : float
-            Float between 0 and 1 setting the probability of dropping each
-            channel.
-        rng : numpy.random.Generator
-            The generator to use.
+        params : dict
+            Contains the probability of dropping each channel (p_drop) and the
+            random state.
         """
-        return self.p_drop, self.rng
+        return {
+            "p_drop": self.p_drop,
+            "random_state": self.rng,
+        }
 
 
 class ChannelsShuffle(Transform):
@@ -237,13 +240,14 @@ class ChannelsShuffle(Transform):
 
         Returns
         -------
-        p_shuffle : float
-            Float between 0 and 1 setting the probability of including the
-            channel in the set of permutted channels.
-        rng : numpy.random.Generator
-            The generator to use.
+        params : dict
+            Contains the probability of including the channel in the set of
+            permutted channels (p_shuffle) and the random state.
         """
-        return self.p_shuffle, self.rng
+        return {
+            "p_shuffle": self.p_shuffle,
+            "random_state": self.rng,
+        }
 
 
 class GaussianNoise(Transform):
@@ -300,12 +304,14 @@ class GaussianNoise(Transform):
 
         Returns
         -------
-        std : float
-            Standard deviation to use for the additive noise.
-        rng : numpy.random.Generator
-            The generator to use.
+        params : dict
+            Contains the standard deviation to use for the additive noise (std)
+            and the random state.
         """
-        return self.std, self.rng
+        return {
+            "std": self.std,
+            "random_state": self.rng,
+        }
 
 
 class ChannelsSymmetry(Transform):
@@ -379,10 +385,10 @@ class ChannelsSymmetry(Transform):
 
         Returns
         -------
-        permutation : float
-            List of integers defining the new channels order.
+        params : dict
+            Contains just the list of integers defining the new channels order.
         """
-        return (self.permutation,)
+        return {"permutation": self.permutation}
 
 
 class SmoothTimeMask(Transform):
@@ -442,13 +448,13 @@ class SmoothTimeMask(Transform):
 
         Returns
         -------
-        mask_start_per_sample : torch.tensor
-            Tensor of integers containing the position (in last dimension)
-            where to start masking the signal. Should have the same size as the
-            first dimension of X (i.e. one start position per example in the
-            batch).
-        mask_len_samples : int
-            Number of consecutive samples to zero out.
+        params : dict
+            Contains two elements:
+            - a tensor (mask_start_per_sample) of integers representing
+            the position to start masking the signal (has hence the same size
+            as the first dimension of X, i.e. one start position per example in
+            the batch).
+            - the number of consecutive samples to zero out (mask_len_samples).
         """
         seq_length = torch.as_tensor(X.shape[-1], device=X.device)
         mask_len_samples = self.mask_len_samples
@@ -457,7 +463,10 @@ class SmoothTimeMask(Transform):
         mask_start = torch.as_tensor(self.rng.uniform(
             low=0, high=1, size=X.shape[0],
         ), device=X.device) * (seq_length - mask_len_samples)
-        return mask_start, mask_len_samples
+        return {
+            "mask_start_per_sample": mask_start,
+            "mask_len_samples": mask_len_samples,
+        }
 
 
 class BandstopFilter(Transform):
@@ -542,17 +551,11 @@ class BandstopFilter(Transform):
 
         Returns
         -------
-        sfreq : float
-            Sampling frequency of the signals to be filtered.
-        bandwidth : float
-            Bandwidth of the filter, i.e. distance between the low and high cut
-            frequencies.
-        freqs_to_notch : array-like | None
-            Array of floats of size ``(batch_size,)`` containing the center of
-            the frequency band to filter out for each sample in the batch.
-            Frequencies should be greater than ``bandwidth/2 + transition`` and
-            lower than ``sfreq/2 - bandwidth/2 - transition`` (where
-            ``transition = 1 Hz``).
+        params : dict
+            Contains the sampling frequency of the signals to be filtered
+            (sfreq), the bandwidth of the filter and an array of floats of size
+            ``(batch_size,)`` containing the center of the frequency band to
+            filter out for each sample in the batch (freqs_to_notch).
         """
         # Prevents transitions from going below 0 and above max_freq
         notched_freqs = self.rng.uniform(
@@ -560,7 +563,11 @@ class BandstopFilter(Transform):
             high=self.max_freq - 1 - 2 * self.bandwidth,
             size=X.shape[0]
         )
-        return self.sfreq, self.bandwidth, notched_freqs
+        return {
+            "sfreq": self.sfreq,
+            "bandwidth": self.bandwidth,
+            "freqs_to_notch": notched_freqs,
+        }
 
 
 class FrequencyShift(Transform):
@@ -612,10 +619,9 @@ class FrequencyShift(Transform):
 
         Returns
         -------
-        delta_freq : float
-            The amplitude of the frequency shift (in Hz).
-        sfreq : float
-            Sampling frequency of the signals to be transformed.
+        params : dict
+            Contains the amplitude of the frequency shift in Hz (delta_freq)
+            and sampling frequency of the signals to be transformed (sfreq).
         """
         u = torch.as_tensor(
             self.rng.uniform(size=X.shape[0]),
@@ -625,7 +631,10 @@ class FrequencyShift(Transform):
         if isinstance(max_delta_freq, torch.Tensor):
             max_delta_freq = max_delta_freq.to(X.device)
         delta_freq = u * 2 * max_delta_freq - max_delta_freq
-        return delta_freq, self.sfreq
+        return {
+            "delta_freq": delta_freq,
+            "sfreq": self.sfreq,
+        }
 
 
 def _get_standard_10_20_positions(raw_or_epoch=None, ordered_ch_names=None):
@@ -743,20 +752,18 @@ class SensorsRotation(Transform):
 
         Returns
         -------
-        sensors_positions_matrix : numpy.ndarray
-            Matrix giving the positions of each sensor in a 3D cartesian
-            coordinate system. Should have shape (3, n_channels), where
-            n_channels is the number of channels.
-        axis : 'x' | 'y' | 'z'
-            Axis around which to rotate.
-        angles : array-like
-            Array of float of shape ``(batch_size,)`` containing the rotation
-            angles (in degrees) for each element of the input batch, sampled
-            uniformly between ``-max_degrees``and ``max_degrees``.
-        spherical_splines : bool
-            Whether to use spherical splines for the interpolation or not. When
-            `False`, standard scipy.interpolate.Rbf (with quadratic kernel)
-            will be used (as in the original paper).
+        params : dict
+            Contains four elements:
+            -  sensors_positions_matrix: matrix giving the positions of each
+            sensor in a 3D cartesian coordinate system. Should have shape
+            (3, n_channels), where n_channels is the number of channels;
+            - axis: axis around which to rotate;
+            - angles: array of float of shape ``(batch_size,)`` containing the
+            rotation angles (in degrees) for each element of the input batch,
+            sampled uniformly between ``-max_degrees``and ``max_degrees``.
+            - spherical_splines: whether to use spherical splines for the
+            interpolation or not. When ``False``, standard scipy.interpolate.Rbf
+            (with quadratic kernel) will be used (as in the original paper).
         """
         u = self.rng.uniform(
             low=0,
@@ -768,12 +775,12 @@ class SensorsRotation(Transform):
             max_degrees = max_degrees.to(X.device)
         random_angles = torch.as_tensor(
             u, device=X.device) * 2 * max_degrees - max_degrees
-        return (
-            self.sensors_positions_matrix,
-            self.axis,
-            random_angles,
-            self.spherical_splines
-        )
+        return {
+            "sensors_positions_matrix": self.sensors_positions_matrix,
+            "axis": self.axis,
+            "angles": random_angles,
+            "spherical_splines": self.spherical_splines
+        }
 
 
 class SensorsZRotation(SensorsRotation):
@@ -994,11 +1001,11 @@ class Mixup(Transform):
 
         Returns
         -------
-        lam : torch.Tensor
-            Values sampled uniformly between 0 and 1 setting the linear
-            interpolation between examples.
-        idx_perm: torch.Tensor
-            Shuffled indices of example that are mixed into original examples.
+        params: dict
+            Contains the values sampled uniformly between 0 and 1 setting the
+            linear interpolation between examples (lam) and the shuffled
+            indices of examples that are mixed into original examples
+            (idx_perm).
         """
         device = X.device
         batch_size, _, _ = X.shape
@@ -1016,4 +1023,7 @@ class Mixup(Transform):
 
         idx_perm = torch.as_tensor(self.rng.permutation(batch_size,))
 
-        return lam, idx_perm
+        return {
+            "lam": lam,
+            "idx_perm": idx_perm,
+        }

--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,5 @@ dependencies:
 - joblib
 - memory_profiler
 - pip:
-  - mne==0.23.0
+  - mne
   - https://github.com/braindecode/braindecode/zipball/master

--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,5 @@ dependencies:
 - joblib
 - memory_profiler
 - pip:
-  - mne
+  - mne==0.23.0
   - https://github.com/braindecode/braindecode/zipball/master

--- a/test/unit_tests/augmentation/conftest.py
+++ b/test/unit_tests/augmentation/conftest.py
@@ -46,7 +46,7 @@ class MockModule(torch.nn.Module):
 
 
 @pytest.fixture
-def mock_clf():
+def augmented_mock_clf():
     return EEGClassifier(
         MockModule(np.random.rand(4, 2)),
         optimizer=optim.Adam,

--- a/test/unit_tests/augmentation/conftest.py
+++ b/test/unit_tests/augmentation/conftest.py
@@ -2,9 +2,16 @@
 #
 # License: BSD (3-clause)
 
+import numpy as np
 import pytest
 import torch
 from sklearn.utils import check_random_state
+from skorch.helper import to_tensor
+from torch import optim
+
+from braindecode.augmentation import AugmentedDataLoader
+from braindecode.augmentation import TimeReverse
+from braindecode.classifier import EEGClassifier
 
 
 def pytest_addoption(parser):
@@ -26,3 +33,24 @@ def random_batch(rng_seed, batch_size=5):
     rng = check_random_state(rng_seed)
     X = torch.from_numpy(rng.random((batch_size, 66, 51))).float().to(device)
     return X, torch.zeros(batch_size)
+
+
+class MockModule(torch.nn.Module):
+    def __init__(self, preds):
+        super().__init__()
+        self.preds = to_tensor(preds, device='cpu')
+        self.linear = torch.nn.Linear(5, 5)
+
+    def forward(self, x):
+        return self.preds
+
+
+@pytest.fixture
+def mock_clf():
+    return EEGClassifier(
+        MockModule(np.random.rand(4, 2)),
+        optimizer=optim.Adam,
+        batch_size=32,
+        iterator_train=AugmentedDataLoader,
+        iterator_train__transforms=TimeReverse(probability=0.5),
+    )

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -2,15 +2,16 @@
 #
 # License: BSD (3-clause)
 
-import pytest
-import numpy as np
-from sklearn.utils import check_random_state
-import torch
 import mne
+import numpy as np
+import pytest
+import torch
+from sklearn.utils import check_random_state
+from skorch.helper import predefined_split
 
-from braindecode.augmentation.base import (
-    Transform, Compose, AugmentedDataLoader
-)
+from braindecode.augmentation.base import AugmentedDataLoader
+from braindecode.augmentation.base import Compose
+from braindecode.augmentation.base import Transform
 from braindecode.datautil import create_from_mne_epochs
 
 
@@ -173,3 +174,13 @@ def test_dataset_with_transform(concat_windows_dataset):
     concat_windows_dataset.transform = transform
     transformed_X = concat_windows_dataset[0][0]
     assert torch.all(transformed_X == factor)
+
+
+def test_set_params(mock_clf, random_batch):
+    mock_clf.set_params(
+        train_split=predefined_split(random_batch)
+    )
+    assert isinstance(
+        mock_clf.train_split,
+        type(predefined_split(random_batch))
+    )

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -176,11 +176,11 @@ def test_dataset_with_transform(concat_windows_dataset):
     assert torch.all(transformed_X == factor)
 
 
-def test_set_params(mock_clf, random_batch):
-    mock_clf.set_params(
+def test_set_params(augmented_mock_clf, random_batch):
+    augmented_mock_clf.set_params(
         train_split=predefined_split(random_batch)
     )
     assert isinstance(
-        mock_clf.train_split,
+        augmented_mock_clf.train_split,
         type(predefined_split(random_batch))
     )

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -29,7 +29,7 @@ class DummyTransform(Transform):
         super().__init__(probability=probability, random_state=random_state)
 
     def get_params(self, X, y):
-        return {"k": self.k,}
+        return {"k": self.k}
 
 
 @pytest.fixture

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -177,6 +177,10 @@ def test_dataset_with_transform(concat_windows_dataset):
 
 
 def test_set_params(augmented_mock_clf, random_batch):
+    """Asserts that changing the parameters of a classifier instantiated with
+    the `AugmentedDataLoader` is possible. Ensures that
+    `braindecode.augmentation` is consistent with `Skorch` API.
+    """
     augmented_mock_clf.set_params(
         train_split=predefined_split(random_batch)
     )

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -29,7 +29,7 @@ class DummyTransform(Transform):
         super().__init__(probability=probability, random_state=random_state)
 
     def get_params(self, X, y):
-        return (self.k,)
+        return {"k": self.k,}
 
 
 @pytest.fixture


### PR DESCRIPTION
Really sorry to open yet another PR @robintibor 😅 
We've realized with @lapaill that braindecode would crash if we instatiate a class inheriting from `skorch.NeuralNet` with an argument based on `Transform` objects and then try to set any other unrelated parameter with the method `set_params`. Indeed, the latter will inspect each attribute of the `NeuralNet` object (even if it was previously defined) and call their `get_params` method when the latter is implemented. The problem is the `Transform` implements such a method (for an unrelated reason) and outputs a tuple instead of a dict, which would make skorch raise an error.

Hence, this PR solves this incompatibility by replacing the tuples by dictionaries for every Transform. It is also cleaner this way I think.