### PR TITLE
Improved description for `set_random_seeds`

### DIFF
--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -27,7 +27,9 @@ def set_random_seeds(seed, cuda, cudnn_benchmark=None):
     cuda: bool
         Whether to set cuda seed with torch.
     cudnn_benchmark: bool (default=None)
-        Whether pytorch will use cudnn benchmark. When set to True, results may not be reproducible.
+        Whether pytorch will use cudnn benchmark. When set to `None` it will not modify
+        torch.backends.cudnn.benchmark (displays warning in the case of possible lack of
+        reproducibility). When set to True, results may not be reproducible (no warning displayed).
         When set to False it may slow down computations.
 
     Notes

--- a/examples/plot_bcic_iv_2a_moabb_cropped.py
+++ b/examples/plot_bcic_iv_2a_moabb_cropped.py
@@ -151,7 +151,10 @@ if cuda:
     torch.backends.cudnn.benchmark = True
 # Set random seed to be able to roughly reproduce results
 # Note that with cudnn benchmark set to True, GPU indeterminism
-# may still make results substantially different between runs
+# may still make results substantially different between runs.
+# To obtain more consistent results at the cost of increased computation time,
+# you can set `cudnn_benchmark=False` in `set_random_seeds`
+# or remove `torch.backends.cudnn.benchmark = True`
 seed = 20200220
 set_random_seeds(seed=seed, cuda=cuda)
 

--- a/examples/plot_bcic_iv_2a_moabb_trial.py
+++ b/examples/plot_bcic_iv_2a_moabb_trial.py
@@ -158,7 +158,10 @@ if cuda:
     torch.backends.cudnn.benchmark = True
 # Set random seed to be able to roughly reproduce results
 # Note that with cudnn benchmark set to True, GPU indeterminism
-# may still make results substantially different between runs
+# may still make results substantially different between runs.
+# To obtain more consistent results at the cost of increased computation time,
+# you can set `cudnn_benchmark=False` in `set_random_seeds`
+# or remove `torch.backends.cudnn.benchmark = True`
 seed = 20200220
 set_random_seeds(seed=seed, cuda=cuda)
 

--- a/examples/plot_bcic_iv_4_ecog_cropped.py
+++ b/examples/plot_bcic_iv_4_ecog_cropped.py
@@ -183,7 +183,10 @@ if cuda:
     torch.backends.cudnn.benchmark = True
 # Set random seed to be able to roughly reproduce results
 # Note that with cudnn benchmark set to True, GPU indeterminism
-# may still make results substantially different between runs
+# may still make results substantially different between runs.
+# To obtain more consistent results at the cost of increased computation time,
+# you can set `cudnn_benchmark=False` in `set_random_seeds`
+# or remove `torch.backends.cudnn.benchmark = True`
 seed = 20200220
 set_random_seeds(seed=seed, cuda=cuda)
 

--- a/examples/plot_bcic_iv_4_ecog_trial.py
+++ b/examples/plot_bcic_iv_4_ecog_trial.py
@@ -202,7 +202,10 @@ if cuda:
     torch.backends.cudnn.benchmark = True
 # Set random seed to be able to roughly reproduce results
 # Note that with cudnn benchmark set to True, GPU indeterminism
-# may still make results substantially different between runs
+# may still make results substantially different between runs.
+# To obtain more consistent results at the cost of increased computation time,
+# you can set `cudnn_benchmark=False` in `set_random_seeds`
+# or remove `torch.backends.cudnn.benchmark = True`
 seed = 20200220
 set_random_seeds(seed=seed, cuda=cuda)
 

--- a/examples/plot_data_augmentation.py
+++ b/examples/plot_data_augmentation.py
@@ -179,7 +179,10 @@ if cuda:
 
 # Set random seed to be able to roughly reproduce results
 # Note that with cudnn benchmark set to True, GPU indeterminism
-# may still make results substantially different between runs
+# may still make results substantially different between runs.
+# To obtain more consistent results at the cost of increased computation time,
+# you can set `cudnn_benchmark=False` in `set_random_seeds`
+# or remove `torch.backends.cudnn.benchmark = True`
 seed = 20200220
 set_random_seeds(seed=seed, cuda=cuda)
 

--- a/examples/plot_relative_positioning.py
+++ b/examples/plot_relative_positioning.py
@@ -267,7 +267,10 @@ if device == 'cuda':
     torch.backends.cudnn.benchmark = True
 # Set random seed to be able to roughly reproduce results
 # Note that with cudnn benchmark set to True, GPU indeterminism
-# may still make results substantially different between runs
+# may still make results substantially different between runs.
+# To obtain more consistent results at the cost of increased computation time,
+# you can set `cudnn_benchmark=False` in `set_random_seeds`
+# or remove `torch.backends.cudnn.benchmark = True`
 set_random_seeds(seed=random_state, cuda=device == 'cuda')
 
 # Extract number of channels and time steps from dataset

--- a/examples/plot_sleep_staging.py
+++ b/examples/plot_sleep_staging.py
@@ -223,7 +223,10 @@ if cuda:
     torch.backends.cudnn.benchmark = True
 # Set random seed to be able to roughly reproduce results
 # Note that with cudnn benchmark set to True, GPU indeterminism
-# may still make results substantially different between runs
+# may still make results substantially different between runs.
+# To obtain more consistent results at the cost of increased computation time,
+# you can set `cudnn_benchmark=False` in `set_random_seeds`
+# or remove `torch.backends.cudnn.benchmark = True`
 set_random_seeds(seed=random_state, cuda=cuda)
 
 n_classes = 5

--- a/examples/plot_sleep_staging_usleep.py
+++ b/examples/plot_sleep_staging_usleep.py
@@ -197,7 +197,10 @@ if cuda:
     torch.backends.cudnn.benchmark = True
 # Set random seed to be able to roughly reproduce results
 # Note that with cudnn benchmark set to True, GPU indeterminism
-# may still make results substantially different between runs
+# may still make results substantially different between runs.
+# To obtain more consistent results at the cost of increased computation time,
+# you can set `cudnn_benchmark=False` in `set_random_seeds`
+# or remove `torch.backends.cudnn.benchmark = True`
 set_random_seeds(seed=random_state, cuda=cuda)
 
 n_classes = 5


### PR DESCRIPTION
Additional changes after merging #333. It adds description in `set_random_seeds` when `cudnn_benchmark=None` and provides solution in examples how to make results more consistent between runs.