### PR TITLE
Skorch compatibility

### DIFF
--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -3,19 +3,26 @@
 #
 # License: BSD (3-clause)
 
-from numbers import Real
 import warnings
+from numbers import Real
 
 import numpy as np
 import torch
 from mne.channels import make_standard_montage
 
 from .base import Transform
-from .functional import (
-    time_reverse, sign_flip, ft_surrogate, channels_dropout, channels_shuffle,
-    gaussian_noise, channels_permute, smooth_time_mask, bandstop_filter,
-    frequency_shift, sensors_rotation, mixup
-)
+from .functional import bandstop_filter
+from .functional import channels_dropout
+from .functional import channels_permute
+from .functional import channels_shuffle
+from .functional import frequency_shift
+from .functional import ft_surrogate
+from .functional import gaussian_noise
+from .functional import mixup
+from .functional import sensors_rotation
+from .functional import sign_flip
+from .functional import smooth_time_mask
+from .functional import time_reverse
 
 
 class TimeReverse(Transform):
@@ -109,7 +116,7 @@ class FTSurrogate(Transform):
             "phase_noise_magnitude should be between 0 and 1."
         self.phase_noise_magnitude = phase_noise_magnitude
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -172,7 +179,7 @@ class ChannelsDropout(Transform):
         )
         self.p_drop = p_drop
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -237,7 +244,7 @@ class ChannelsShuffle(Transform):
         )
         self.p_shuffle = p_shuffle
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -306,7 +313,7 @@ class GaussianNoise(Transform):
         )
         self.std = std
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -391,7 +398,7 @@ class ChannelsSymmetry(Transform):
             permutation.append(new_position)
         self.permutation = permutation
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -457,7 +464,7 @@ class SmoothTimeMask(Transform):
         ), "mask_len_samples has to be a positive integer"
         self.mask_len_samples = mask_len_samples
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -480,6 +487,10 @@ class SmoothTimeMask(Transform):
             * mask_len_samples : int
                 Number of consecutive samples to zero out.
         """
+        if len(batch) == 0:
+            return super().get_params(*batch)
+        X = batch[0]
+
         seq_length = torch.as_tensor(X.shape[-1], device=X.device)
         mask_len_samples = self.mask_len_samples
         if isinstance(mask_len_samples, torch.Tensor):
@@ -563,7 +574,7 @@ class BandstopFilter(Transform):
         self.max_freq = max_freq
         self.bandwidth = bandwidth
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -591,6 +602,10 @@ class BandstopFilter(Transform):
                 ``sfreq/2 - bandwidth/2 - transition`` (where
                 ``transition = 1 Hz``).
         """
+        if len(batch) == 0:
+            return super().get_params(*batch)
+        X = batch[0]
+
         # Prevents transitions from going below 0 and above max_freq
         notched_freqs = self.rng.uniform(
             low=1 + 2 * self.bandwidth,
@@ -641,7 +656,7 @@ class FrequencyShift(Transform):
 
         self.max_delta_freq = max_delta_freq
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -661,6 +676,10 @@ class FrequencyShift(Transform):
             * sfreq : float
                 Sampling frequency of the signals to be transformed.
         """
+        if len(batch) == 0:
+            return super().get_params(*batch)
+        X = batch[0]
+
         u = torch.as_tensor(
             self.rng.uniform(size=X.shape[0]),
             device=X.device
@@ -778,7 +797,7 @@ class SensorsRotation(Transform):
         self.spherical_splines = spherical_splines
         self.max_degrees = max_degrees
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters
@@ -809,6 +828,10 @@ class SensorsRotation(Transform):
                 When ``False``, standard scipy.interpolate.Rbf (with quadratic
                 kernel) will be used (as in the original paper).
         """
+        if len(batch) == 0:
+            return super().get_params(*batch)
+        X = batch[0]
+
         u = self.rng.uniform(
             low=0,
             high=1,
@@ -1033,7 +1056,7 @@ class Mixup(Transform):
         self.alpha = alpha
         self.beta_per_sample = beta_per_sample
 
-    def get_params(self, X, y):
+    def get_params(self, *batch):
         """Return transform parameters.
 
         Parameters

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -514,9 +514,9 @@ class BandstopFilter(Transform):
     ----------
     probability : float
         Float setting the probability of applying the operation.
-    bandwidth : float, optional
+    bandwidth : float
         Bandwidth of the filter, i.e. distance between the low and high cut
-        frequencies. Defaults to 1Hz.
+        frequencies.
     sfreq : float, optional
         Sampling frequency of the signals to be filtered. Defaults to 100 Hz.
     max_freq : float | None, optional

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -1074,6 +1074,7 @@ class Mixup(Transform):
             indices of examples that are mixed into original examples
             (idx_perm).
         """
+        X = batch[0]
         device = X.device
         batch_size, _, _ = X.shape
 

--- a/test/unit_tests/augmentation/conftest.py
+++ b/test/unit_tests/augmentation/conftest.py
@@ -31,7 +31,7 @@ def random_batch(rng_seed, batch_size=5):
     """
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
     rng = check_random_state(rng_seed)
-    X = torch.from_numpy(rng.random((batch_size, 66, 51))).float().to(device)
+    X = torch.from_numpy(rng.random((batch_size, 22, 51))).float().to(device)
     return X, torch.zeros(batch_size)
 
 

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -7,7 +7,6 @@ import numpy as np
 import pytest
 import torch
 from sklearn.utils import check_random_state
-from skorch.helper import predefined_split
 
 from braindecode.augmentation.base import AugmentedDataLoader
 from braindecode.augmentation.base import Compose
@@ -174,17 +173,3 @@ def test_dataset_with_transform(concat_windows_dataset):
     concat_windows_dataset.transform = transform
     transformed_X = concat_windows_dataset[0][0]
     assert torch.all(transformed_X == factor)
-
-
-def test_set_params(augmented_mock_clf, random_batch):
-    """Asserts that changing the parameters of a classifier instantiated with
-    the `AugmentedDataLoader` is possible. Ensures that
-    `braindecode.augmentation` is consistent with `Skorch` API.
-    """
-    augmented_mock_clf.set_params(
-        train_split=predefined_split(random_batch)
-    )
-    assert isinstance(
-        augmented_mock_clf.train_split,
-        type(predefined_split(random_batch))
-    )

--- a/test/unit_tests/augmentation/test_transforms.py
+++ b/test/unit_tests/augmentation/test_transforms.py
@@ -596,9 +596,29 @@ def test_mixup_transform(rng_seed, random_batch, alpha, beta_per_sample):
         assert torch.equal(X_t, X)
 
 
-# TODO: Add the missing spatial domain augmentation to the test. They are not
-# currently tested because they require ch_names, though the random_batch has
-# a number of channels that doesn't match any EEG device structure.
+MONTAGE_10_20 = ['Fz',
+                 'FC3',
+                 'FC1',
+                 'FCz',
+                 'FC2',
+                 'FC4',
+                 'C5',
+                 'C3',
+                 'C1',
+                 'Cz',
+                 'C2',
+                 'C4',
+                 'C6',
+                 'CP3',
+                 'CP1',
+                 'CPz',
+                 'CP2',
+                 'CP4',
+                 'P1',
+                 'Pz',
+                 'P2',
+                 'POz']
+
 
 @ pytest.mark.parametrize("augmentation,kwargs", [
     (IdentityTransform, {"probability": 0.5}),
@@ -610,7 +630,23 @@ def test_mixup_transform(rng_seed, random_batch, alpha, beta_per_sample):
     (GaussianNoise, {"probability": 0.5}),
     (SignFlip, {"probability": 0.5}),
     (SmoothTimeMask, {"probability": 0.5}),
-    (TimeReverse, {"probability": 0.5})
+    (TimeReverse, {"probability": 0.5}),
+    (ChannelsSymmetry, {
+        "probability": 0.5,
+        "ordered_ch_names": MONTAGE_10_20
+    }),
+    (SensorsXRotation, {
+        "probability": 0.5,
+        "ordered_ch_names": MONTAGE_10_20
+    }),
+    (SensorsYRotation, {
+        "probability": 0.5,
+        "ordered_ch_names": MONTAGE_10_20
+    }),
+    (SensorsZRotation, {
+        "probability": 0.5,
+        "ordered_ch_names": MONTAGE_10_20
+    }),
 ]
 )
 def test_set_params(augmented_mock_clf, augmentation, kwargs, random_batch):

--- a/test/unit_tests/augmentation/test_transforms.py
+++ b/test/unit_tests/augmentation/test_transforms.py
@@ -602,7 +602,7 @@ def test_mixup_transform(rng_seed, random_batch, alpha, beta_per_sample):
 
 @ pytest.mark.parametrize("augmentation,kwargs", [
     (IdentityTransform, {"probability": 0.5}),
-    (BandstopFilter, {"probability": 0.5}),
+    (BandstopFilter, {"probability": 0.5, "sfreq": 100}),
     (ChannelsDropout, {"probability": 0.5}),
     (ChannelsShuffle, {"probability": 0.5}),
     (FrequencyShift, {"probability": 0.5, "sfreq": 100}),


### PR DESCRIPTION
It seems that the PR  #356 is incomplete, indeed some methods `get_params` are still not complying to [`skorch` migration guide](https://skorch.readthedocs.io/en/latest/user/FAQ.html#migration-guide). With @cedricrommel, we added in this PR:
 1. A more reliable test that checks the consistency of all augmentations (the reason why the previous test did not address this issue is that it only tested one augmentation). 
 2. Changes in the signature of `get_params` methods for each augmentation. 