### PR TITLE
[MRG] Fix predict_trials

### DIFF
--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -319,5 +319,5 @@ class EEGClassifier(NeuralNetClassifier):
             dataset=X,
             return_targets=return_targets,
             batch_size=self.batch_size,
-            num_workers=self.iterator_valid__num_workers,
+            num_workers=clf.get_iterator(X, training=False).loader.num_workers,
         )

--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -319,5 +319,5 @@ class EEGClassifier(NeuralNetClassifier):
             dataset=X,
             return_targets=return_targets,
             batch_size=self.batch_size,
-            num_workers=clf.get_iterator(X, training=False).loader.num_workers,
+            num_workers=self.get_iterator(X, training=False).loader.num_workers,
         )

--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -318,5 +318,6 @@ class EEGClassifier(NeuralNetClassifier):
             module=self.module,
             dataset=X,
             return_targets=return_targets,
+            batch_size=self.batch_size,
             num_workers=self.iterator_valid__num_workers,
         )

--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -318,4 +318,5 @@ class EEGClassifier(NeuralNetClassifier):
             module=self.module,
             dataset=X,
             return_targets=return_targets,
+            num_workers=self.iterator_valid__num_workers,
         )

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -300,6 +300,7 @@ class EEGRegressor(NeuralNetRegressor):
             module=self.module,
             dataset=X,
             return_targets=return_targets,
+            num_workers=self.iterator_valid__num_workers,
         )
 
     def fit(self, X, y, **kwargs):

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -301,7 +301,7 @@ class EEGRegressor(NeuralNetRegressor):
             dataset=X,
             return_targets=return_targets,
             batch_size=self.batch_size,
-            num_workers=self.iterator_valid__num_workers,
+            num_workers=clf.get_iterator(X, training=False).loader.num_workers,
         )
 
     def fit(self, X, y, **kwargs):

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -300,6 +300,7 @@ class EEGRegressor(NeuralNetRegressor):
             module=self.module,
             dataset=X,
             return_targets=return_targets,
+            batch_size=self.batch_size,
             num_workers=self.iterator_valid__num_workers,
         )
 

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -301,7 +301,7 @@ class EEGRegressor(NeuralNetRegressor):
             dataset=X,
             return_targets=return_targets,
             batch_size=self.batch_size,
-            num_workers=clf.get_iterator(X, training=False).loader.num_workers,
+            num_workers=self.get_iterator(X, training=False).loader.num_workers,
         )
 
     def fit(self, X, y, **kwargs):

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -390,7 +390,7 @@ class PostEpochTrainScoring(EpochScoring):
         self._record_score(net.history, current_score)
 
 
-def predict_trials(module, dataset, return_targets=True, num_workers=0):
+def predict_trials(module, dataset, return_targets=True, batch_size=1, num_workers=0):
     """Create trialwise predictions and optionally also return trialwise
     labels from cropped dataset given module.
 
@@ -402,6 +402,8 @@ def predict_trials(module, dataset, return_targets=True, num_workers=0):
         A braindecode dataset to be predicted.
     return_targets: bool
         If True, additionally returns the trial targets.
+    batch_size: int
+        The batch size used to iterate the dataset.
     num_workers: int
         Number of workers used in DataLoader to iterate the dataset.
 
@@ -426,7 +428,7 @@ def predict_trials(module, dataset, return_targets=True, num_workers=0):
                       'window per trial.')
     loader = DataLoader(
         dataset=dataset,
-        batch_size=1,
+        batch_size=batch_size,
         shuffle=False,
         num_workers=num_workers,
     )

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -390,7 +390,7 @@ class PostEpochTrainScoring(EpochScoring):
         self._record_score(net.history, current_score)
 
 
-def predict_trials(module, dataset, return_targets=True):
+def predict_trials(module, dataset, return_targets=True, num_workers=0):
     """Create trialwise predictions and optionally also return trialwise
     labels from cropped dataset given module.
 
@@ -402,6 +402,8 @@ def predict_trials(module, dataset, return_targets=True):
         A braindecode dataset to be predicted.
     return_targets: bool
         If True, additionally returns the trial targets.
+    num_workers: int
+        Number of workers used in DataLoader to iterate the dataset.
 
     Returns
     -------
@@ -426,11 +428,12 @@ def predict_trials(module, dataset, return_targets=True):
         dataset=dataset,
         batch_size=1,
         shuffle=False,
+        num_workers=num_workers,
     )
+    device = next(module.parameters()).device
     all_preds, all_ys, all_inds = [], [], []
     with torch.no_grad():
         for X, y, ind in loader:
-            device = next(module.parameters()).device
             X = X.to(device)
             preds = module(X)
             all_preds.extend(preds.cpu().numpy().astype(np.float32))

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -430,6 +430,8 @@ def predict_trials(module, dataset, return_targets=True):
     all_preds, all_ys, all_inds = [], [], []
     with torch.no_grad():
         for X, y, ind in loader:
+            device = next(module.parameters()).device
+            X = X.to(device)
             preds = module(X)
             all_preds.extend(preds.cpu().numpy().astype(np.float32))
             all_ys.extend(y.cpu().numpy().astype(np.float32))


### PR DESCRIPTION
When the module is on GPU and data is on CPU, `predict_trials` will fail.
In the tests, everything is always on CPU, therefore it did not attract attention.
With this PR always move the data to the device of the module parameters.