### PR TITLE
[WIP} Move stored preds in callbacks to CPU

### DIFF
--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -75,7 +75,8 @@ class EEGClassifier(NeuralNetClassifier):
             if name == 'str':
                 train_cb, valid_cb = self._parse_str_callback(cb)
                 yield train_cb
-                yield valid_cb
+                if self.train_split is not None:
+                    yield valid_cb
             else:
                 yield name, cb, named_by_user
 

--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -179,7 +179,7 @@ class EEGClassifier(NeuralNetClassifier):
         for X, y, i in self.get_iterator(dataset, drop_index=False):
             i_window_in_trials.append(i[0].cpu().numpy())
             i_window_stops.append(i[2].cpu().numpy())
-            preds.append(to_numpy(self.forward(X)))
+            preds.append(to_numpy(self.module.forward(X)))
             window_ys.append(y.cpu().numpy())
         preds = np.concatenate(preds)
         i_window_in_trials = np.concatenate(i_window_in_trials)

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -74,7 +74,8 @@ class EEGRegressor(NeuralNetRegressor):
             if name == 'str':
                 train_cb, valid_cb = self._parse_str_callback(cb)
                 yield train_cb
-                yield valid_cb
+                if self.train_split is not None:
+                    yield valid_cb
             else:
                 yield name, cb, named_by_user
 

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -12,6 +12,7 @@ from skorch.callbacks import EpochTimer, BatchScoring, PrintLog, EpochScoring
 from skorch.classifier import NeuralNet
 from skorch.regressor import NeuralNetRegressor
 from skorch.utils import train_loss_score, valid_loss_score, noop, to_numpy
+import torch
 
 from .training.scoring import (PostEpochTrainScoring,
                                CroppedTrialEpochScoring,
@@ -171,6 +172,7 @@ class EEGRegressor(NeuralNetRegressor):
                 self._last_window_inds_ = None
 
     def predict_with_window_inds_and_ys(self, dataset):
+        self.module.eval()
         preds = []
         i_window_in_trials = []
         i_window_stops = []
@@ -178,7 +180,8 @@ class EEGRegressor(NeuralNetRegressor):
         for X, y, i in self.get_iterator(dataset, drop_index=False):
             i_window_in_trials.append(i[0].cpu().numpy())
             i_window_stops.append(i[2].cpu().numpy())
-            preds.append(to_numpy(self.module.forward(X)))
+            with torch.no_grad():
+                preds.append(to_numpy(self.module.forward(X.to(self.device))))
             window_ys.append(y.cpu().numpy())
         preds = np.concatenate(preds)
         i_window_in_trials = np.concatenate(i_window_in_trials)

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -178,7 +178,7 @@ class EEGRegressor(NeuralNetRegressor):
         for X, y, i in self.get_iterator(dataset, drop_index=False):
             i_window_in_trials.append(i[0].cpu().numpy())
             i_window_stops.append(i[2].cpu().numpy())
-            preds.append(to_numpy(self.forward(X)))
+            preds.append(to_numpy(self.module.forward(X)))
             window_ys.append(y.cpu().numpy())
         preds = np.concatenate(preds)
         i_window_in_trials = np.concatenate(i_window_in_trials)

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -181,7 +181,6 @@ class CroppedTrialEpochScoring(EpochScoring):
                 pred_results['window_ys'] = np.concatenate(
                     [y.cpu().numpy() for y in self.y_trues_])
 
-
             # A new trial starts
             # when the index of the window in trials
             # does not increment by 1
@@ -424,7 +423,7 @@ def predict_trials(module, dataset, return_targets=True):
         trial_labels: np.ndarray
             2-dimensional array (n_trials x n_targets) where the number of
             targets depends on the decoding paradigm and can be either a single
-            value, multiple values, or al sequence.
+            value, multiple values, or a sequence.
     """
     # we have a cropped dataset if there exists at least one trial with more
     # than one compute window

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -157,7 +157,6 @@ class CroppedTrialEpochScoring(EpochScoring):
         if self.use_caching and training == self.on_train:
             self.y_preds_[-1] = self.y_preds_[-1].cpu()
 
-
     def on_epoch_end(self, net, dataset_train, dataset_valid, **kwargs):
         assert self.use_caching
         if not self.crops_to_trials_computed:


### PR DESCRIPTION
EpochScoring with caching by skorch keeps predictions in the GPU memory if model is on GPU. This can cause out of memory problems (it is a known problem: https://github.com/skorch-dev/skorch/issues/509)

This PR should fix that via a workaround on our side. Can you test it @AKiessner ? Basically callbacks should work fine again wrt to GPU memory.

