### PR TITLE
Fix torch.linalg issue in rotation augmentations

### DIFF
--- a/braindecode/augmentation/functional.py
+++ b/braindecode/augmentation/functional.py
@@ -840,7 +840,6 @@ def _torch_make_interpolation_matrix(pos_from, pos_to, alpha=1e-5):
     try:
         C_inv = torch.linalg.inv(C)
     except torch._C._LinAlgError:
-        print("Had to fallback to pinv for one batch.")
         # There is a stability issue with pinv since torch v1.8.0
         # see https://github.com/pytorch/pytorch/issues/75494
         C_inv = torch.linalg.pinv(C.cpu()).to(device)

--- a/braindecode/augmentation/functional.py
+++ b/braindecode/augmentation/functional.py
@@ -836,7 +836,14 @@ def _torch_make_interpolation_matrix(pos_from, pos_to, alpha=1e-5):
                 torch.ones((1, n_from), device=device),
                 torch.as_tensor([[0]], device=device)])
         ])
-    C_inv = torch.linalg.pinv(C)
+
+    try:
+        C_inv = torch.linalg.inv(C)
+    except torch._C._LinAlgError:
+        print("Had to fallback to pinv for one batch.")
+        # There is a stability issue with pinv since torch v1.8.0
+        # see https://github.com/pytorch/pytorch/issues/75494
+        C_inv = torch.linalg.pinv(C.cpu()).to(device)
 
     interpolation = torch.hstack([
         G_to_from,

--- a/test/unit_tests/augmentation/test_transforms.py
+++ b/test/unit_tests/augmentation/test_transforms.py
@@ -518,6 +518,7 @@ def test_sensors_rotation_functional():
     (SensorsYRotation, 15, False, False),
     (SensorsZRotation, 15, False, False),
     (SensorsZRotation, -15, True, False),
+    (SensorsZRotation, 15, False, True),
 ])
 def test_sensors_rotation_transforms(
     rng_seed,

--- a/test/unit_tests/augmentation/test_transforms.py
+++ b/test/unit_tests/augmentation/test_transforms.py
@@ -518,7 +518,6 @@ def test_sensors_rotation_functional():
     (SensorsYRotation, 15, False, False),
     (SensorsZRotation, 15, False, False),
     (SensorsZRotation, -15, True, False),
-    (SensorsZRotation, 15, False, True),
 ])
 def test_sensors_rotation_transforms(
     rng_seed,


### PR DESCRIPTION
This commit fixes an issue encountered in the implementation of
augmentations using the `sensors_rotation` functional. The latter comes
from a bug that appeared in `torch.linalg.pinv` function since its
reimplementation for v1.8.0 release. The v1.8.0 implementation indeed
led too often in the failing of computation of the pseudo-inverse.
As a results, RandomSensorsRotations augmentations were incorrect at times
and even irreproducible (since pinv fails don't depend on controllable PRNGs).

The fix I propose in this commit follows recommendations in [this torch issue](https://github.com/pytorch/pytorch/issues/75494) and consists in:
1. trying to use regular inverse whenever possible (since the matrix C
   in `_torch_make_interpolation_matrix` is supposed to be invertible
   quite often).
2. falling back to pinv if C is not invertible, but doing the
   computation in cpu (which is more reliable according to the issue
   above).