### PR TITLE
Removing functions

### DIFF
--- a/braindecode/preprocessing/__init__.py
+++ b/braindecode/preprocessing/__init__.py
@@ -1,4 +1,4 @@
-from .preprocess import (zscore, scale, exponential_moving_demean,
+from .preprocess import (scale, exponential_moving_demean,
                          exponential_moving_standardize, filterbank,
                          preprocess, Preprocessor)
 from .windowers import (create_windows_from_events, create_fixed_length_windows,

--- a/braindecode/preprocessing/preprocess.py
+++ b/braindecode/preprocessing/preprocess.py
@@ -84,45 +84,6 @@ class Preprocessor(object):
             getattr(raw_or_epochs, self.fn)(**self.kwargs)
 
 
-@deprecated(extra='will be removed in 0.7.0. Use Preprocessor with '
-                  '`apply_on_array=False` instead.')
-class MNEPreproc(Preprocessor):
-    """Preprocessor for an MNE-raw/epoch.
-
-    Parameters
-    ----------
-    fn: str or callable
-        if str, the raw/epoch object must have a member function with that name.
-        if callable, directly apply the callable to the mne raw/epoch.
-    kwargs:
-        Keyword arguments will be forwarded to the mne function
-    """
-
-    def __init__(self, fn, **kwargs):
-        super().__init__(fn, apply_on_array=False, **kwargs)
-
-
-@deprecated(extra='will be removed in 0.7.0. Use Preprocessor with '
-                  '`apply_on_array=True` instead.')
-class NumpyPreproc(Preprocessor):
-    """Preprocessor that directly operates on the underlying numpy array of an mne raw/epoch.
-
-    Parameters
-    ----------
-    fn: callable
-        Function that preprocesses the numpy array
-    channel_wise: bool
-        Whether to apply the function channel-wise.
-    kwargs:
-        Keyword arguments will be forwarded to the function
-    """
-
-    def __init__(self, fn, channel_wise=False, **kwargs):
-        assert callable(fn), 'fn must be callable.'
-        super().__init__(fn, apply_on_array=True, channel_wise=channel_wise,
-                         **kwargs)
-
-
 def preprocess(concat_ds, preprocessors, save_dir=None, overwrite=False,
                n_jobs=None):
     """Apply preprocessors to a concat dataset.
@@ -369,35 +330,6 @@ def exponential_moving_demean(data, factor_new=0.001, init_block_size=None):
         )
         demeaned[0:init_block_size] = data[0:init_block_size] - init_mean
     return demeaned.T
-
-
-@deprecated(extra='will be removed in 0.7.0. Use sklearn.preprocessing.scale '
-                  'instead.')
-def zscore(data):
-    """Zscore normalize continuous or windowed data in-place.
-
-    Parameters
-    ----------
-    data: np.ndarray (n_channels, n_times) or (n_windows, n_channels, n_times)
-        continuous or windowed signal
-
-    Returns
-    -------
-    zscored: np.ndarray (n_channels x n_times) or (n_windows x n_channels x
-    n_times)
-        normalized continuous or windowed data
-
-    ..note:
-        If this function is supposed to preprocess continuous data, it should be
-        given to raw.apply_function().
-    """
-    zscored = data - np.mean(data, keepdims=True, axis=-1)
-    zscored = zscored / np.std(zscored, keepdims=True, axis=-1)
-    # TODO: the overriding of protected '_data' should be implemented in the
-    # TODO: dataset when transforms are applied to windows
-    if hasattr(data, '_data'):
-        data._data = zscored
-    return zscored
 
 
 @deprecated(extra='will be removed in 0.7.0. Use numpy.multiply instead.')

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -41,6 +41,7 @@ Bugs
 API changes
 ~~~~~~~~~~~
 - Renaming the method `get_params` to `get_augmentation_params` in augmentation classes. This makes the Transform module compatible with scikit-learn cloning mechanism (:gh:`388` by `Bruno Aristimunha`_ and `Alex Gramfort`_)
+- Removing deprecated functions and classes :func:`braindecode.preprocessing.zscore`, :class:`braindecode.datautil.MNEPreproc` and :class:`braindecode.datautil.NumpyPreproc`  (:gh:`415` by `Bruno Aristimunha`_)
 
 .. _changes_0_6_0:
 


### PR DESCRIPTION
As discussed in issue https://github.com/braindecode/braindecode/issues/412, this PR remove the zscale function, the :class:`braindecode.datautil.MNEPreproc` and :class:`braindecode.datautil.NumpyPreproc` classes.