### PR TITLE
update transposition to latest torch convention

### DIFF
--- a/braindecode/augmentation/functional.py
+++ b/braindecode/augmentation/functional.py
@@ -501,8 +501,9 @@ def _frequency_shift(X, fs, f_shift):
     analytical = _analytic_transform(padded)
     if isinstance(f_shift, (float, int, np.ndarray, list)):
         f_shift = torch.as_tensor(f_shift).float()
-    reshaped_f_shift = f_shift.repeat(
-        N_padded, n_channels, 1).T
+    f_shift_stack = f_shift.repeat(N_padded, n_channels, 1)
+    reshaped_f_shift = f_shift_stack.permute(
+        *torch.arange(f_shift_stack.ndim - 1, -1, -1))
     shifted = analytical * torch.exp(2j * np.pi * reshaped_f_shift * t)
     return shifted[..., :N_orig].real.float()
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -43,7 +43,7 @@ Enhancements
 
 Bugs
 ~~~~
-- Removing deprecation warning due to transposition in :func:`braindecode.augmentation.functional._frequency_shift` (:gh:`446` by `Matthieu Terris`_)
+- Removing deprecation warning due to torch transposition in :func:`braindecode.augmentation.functional._frequency_shift` (:gh:`446` by `Matthieu Terris`_)
 
 
 API changes
@@ -187,4 +187,4 @@ Authors
 .. _Ghaith Bouallegue: https://github.com/GhBlg
 .. _Denis A. Engemann: https://github.com/dengemann
 .. _Oskar Størmer: https://github.com/ostormer
-.. _Matthieu Terris:https://github.com/matthieutrs
+.. _Matthieu Terris: https://github.com/matthieutrs

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -43,6 +43,7 @@ Enhancements
 
 Bugs
 ~~~~
+- Removing deprecation warning due to transposition in :func:`braindecode.augmentation.functional._frequency_shift` (:gh:`446` by `Matthieu Terris`_)
 
 
 API changes
@@ -186,3 +187,4 @@ Authors
 .. _Ghaith Bouallegue: https://github.com/GhBlg
 .. _Denis A. Engemann: https://github.com/dengemann
 .. _Oskar Størmer: https://github.com/ostormer
+.. _Matthieu Terris:https://github.com/matthieutrs


### PR DESCRIPTION
Updating a transposition to latest torch convention that was raising a deprecation warning message at each call of the transform and clogging training logs.

The warning was:
```
The use of `x.T` on tensors of dimension other than 2 to reverse their shape is deprecated and it will 
throw an error in a future release. Consider `x.mT` to transpose batches of matrices or 
`x.permute(*torch.arange(x.ndim - 1, -1, -1))` to reverse the dimensions of a tensor.
```

This PR implements precisely the second suggestion. I couldn't find any other use of `.T` in the repo but I'd happily update if you point me to others :)