### PR TITLE
MOABB as an extra dependency

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -15,12 +15,6 @@ Installing the PyTorch library depends on the architecture and operational syste
 Given this complexity, we recommend that you go directly to the ``pytorch``
 page and follow the instructions in http://pytorch.org/. You don't need to install torchvision.
 
-To install moabb, run in your terminal:
-
-.. code-block:: console
-
-   $ pip install moabb
-
 Installing the braindecode with pip
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 After preparing the environment for braindecode, you can install via :code:`pip`:
@@ -36,6 +30,20 @@ alternatively, you can install the latest version of braindecode via pip:
 
   pip install -U https://api.github.com/repos/braindecode/braindecode/zipball/master
 
+If you want to use MOABB datasets utilities you can add it as an extra when installing braindecode:
+
+.. code-block:: console
+
+   $ pip install braindecode[moabb]
+
+or
+
+.. code-block:: console
+
+  pip install -U https://api.github.com/repos/braindecode/braindecode/zipball/master#egg=braindecode[moabb]
+
+
+If you are using other installation methods
 
 Installing Braindecode with conda
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -52,4 +60,9 @@ This might help depending on how you are managing other libraries.
 This will create a new ``conda`` environment called ``braindecode`` (you can adjust
 this by passing a different name via ``--name``).
 
+If you want to use MOABB dataset utilities in this case you need to install the ``moabb`` package separately:
+
+.. code-block:: console
+
+   $ pip install moabb
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -23,6 +23,8 @@ Current 0.8 (dev0)
 Enhancements
 ~~~~~~~~~~~~
 
+- Have moabb as an extra dependency (:gh:`467` by `Marco Zamboni`_)
+
 Bugs
 ~~~~
 - Fix padding's device in :class:`braindecode.models.EEGResNet` (:gh:`451` by `Pierre Guetschel`_)

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setup(
     license='BSD 3-Clause',
 
     install_requires=['mne', 'numpy', 'pandas', 'scipy', 'matplotlib', 'h5py', 'skorch'],
+    extras_require={
+        'moabb': ["moabb"]
+    },
     # tests_require = [...]
 
     # See https://PyPI.python.org/PyPI?%3Aaction=list_classifiers


### PR DESCRIPTION
Let users install braindecode with moabb support by running:
```sh
pip install braindecode[moabb]
```
instead of
```sh
pip install braindecode
pip install moabb
```