### PR TITLE
Get data augmentation to work on single examples

### DIFF
--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -72,9 +72,16 @@ class Transform(torch.nn.Module):
             Transformed labels. Only returned when y is not None.
         """
         X = torch.as_tensor(X).float()
+
+        # check if input has a batch dimension
+        if len(X.shape) < 3:
+            X = X[None, ...]
+
         out_X = X.clone()
         if y is not None:
             y = torch.as_tensor(y)
+            if len(y.shape) == 0:
+                y = y.reshape(1)
             out_y = y.clone()
         else:
             out_y = torch.zeros(X.shape[0])

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -12,7 +12,7 @@ from braindecode.augmentation.base import AugmentedDataLoader
 from braindecode.augmentation.base import Compose
 from braindecode.augmentation.base import Transform
 from braindecode.augmentation.transforms import SmoothTimeMask
-from braindecode.datautil import create_from_mne_epochs
+from braindecode.datasets import create_from_mne_epochs
 
 
 def dummy_k_operation(X, y, k):
@@ -178,3 +178,26 @@ def test_dataset_with_transform(concat_windows_dataset):
     concat_windows_dataset.transform = transform
     transformed_X = concat_windows_dataset[0][0]
     assert torch.all(transformed_X == factor)
+
+
+def test_single_input_aug(concat_windows_dataset):
+    # Create single input without the batch dimension, just (channels, time)
+    X, y, _ = concat_windows_dataset[0]
+    X = X[0]
+    assert len(X.shape) == 2
+
+    # Create dummy data augmentation
+    factor = 10
+    transform = DummyTransform(k=factor, probability=1.)
+
+    # Check that the transformation forward works and outputs an augmented
+    # input with the batch dimension
+    transformed_X = transform(X)
+    assert len(transformed_X.shape) == 3
+    assert transformed_X.shape[0] == 1
+
+    # Same check, when also passing y
+    transformed_X, transformed_y = transform(X, y)
+    assert len(transformed_X.shape) == 3
+    assert len(transformed_y.shape) == 1
+    assert transformed_X.shape[0] == transformed_y.shape[0] == 1


### PR DESCRIPTION
This PR intends to fix issue https://github.com/braindecode/braindecode/issues/477.
It allows to augment single inputs which do not have a batch dimension, just channles and time dimensions.