### PR TITLE
EegModuleMixin extension

### DIFF
--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -165,8 +165,7 @@ class EEGModuleMixin(metaclass=NumpyDocstringInheritanceInitMeta):
         """Input data shape."""
         return (1, self.n_chans, self.n_times)
 
-    @property
-    def output_shape(self) -> Tuple[int]:
+    def get_output_shape(self) -> Tuple[int]:
         """Returns shape of neural network output for batch size equal 1.
 
         Returns

--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -1,4 +1,5 @@
 # Authors: Pierre Guetschel
+#          Maciej Sliwowski
 #
 # License: BSD-3
 

--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -5,6 +5,8 @@
 import warnings
 from typing import Iterable, List, Optional, Dict
 
+import numpy as np
+import torch
 from docstring_inheritance import NumpyDocstringInheritanceInitMeta
 from torchinfo import ModelStatistics, summary
 
@@ -158,6 +160,84 @@ class EEGModuleMixin(metaclass=NumpyDocstringInheritanceInitMeta):
             )
         return self._sfreq
 
+    @property
+    def input_shape(self) -> tuple[int]:
+        """Input data shape."""
+        return (1, self.n_chans, self.n_times)
+
+    @property
+    def output_shape(self) -> tuple[int]:
+        """Returns shape of neural network output for batch size equal 1.
+
+        Returns
+        -------
+        output_shape: tuple[int]
+            shape of the network output for `batch_size==1` (1, ...)
+    """
+        with torch.inference_mode():
+            try:
+                return self.forward(
+                    torch.zeros(
+                        self.input_shape,
+                        dtype=next(self.parameters()).dtype,
+                        device=next(self.parameters()).device
+                    )).shape
+            except RuntimeError as exc:
+                if str(exc).endswith("Output size is too small"):
+                    msg = (
+                        "During model evaluation RuntimeError was thrown showing that at some "
+                        "layer `Output size is too small` (see above in the stacktrace). This "
+                        "could be caused by providing too small `n_times`/`input_window_seconds`. "
+                        "Model may require longer chunks of signal in the input."
+                    )
+                    raise ValueError(msg) from exc
+                raise exc
+
+    def to_dense_prediction_model(self, axis=(2, 3)):
+        """
+        Transform a sequential model with strides to a model that outputs
+        dense predictions by removing the strides and instead inserting dilations.
+        Modifies model in-place.
+
+        Parameters
+        ----------
+        model: torch.nn.Module
+            Model which modules will be modified
+        axis: int or (int,int)
+            Axis to transform (in terms of intermediate output axes)
+            can either be 2, 3, or (2,3).
+
+        Notes
+        -----
+        Does not yet work correctly for average pooling.
+        Prior to version 0.1.7, there had been a bug that could move strides
+        backwards one layer.
+
+        """
+        if not hasattr(axis, "__len__"):
+            axis = [axis]
+        assert all([ax in [2, 3] for ax in axis]), "Only 2 and 3 allowed for axis"
+        axis = np.array(axis) - 2
+        stride_so_far = np.array([1, 1])
+        for module in self.modules():
+            if hasattr(module, "dilation"):
+                assert module.dilation == 1 or (module.dilation == (1, 1)), (
+                    "Dilation should equal 1 before conversion, maybe the model is "
+                    "already converted?"
+                )
+                new_dilation = [1, 1]
+                for ax in axis:
+                    new_dilation[ax] = int(stride_so_far[ax])
+                module.dilation = tuple(new_dilation)
+            if hasattr(module, "stride"):
+                if not hasattr(module.stride, "__len__"):
+                    module.stride = (module.stride, module.stride)
+                stride_so_far *= np.array(module.stride)
+                new_stride = list(module.stride)
+                for ax in axis:
+                    new_stride[ax] = 1
+                module.stride = tuple(new_stride)
+
     def get_torchinfo_statistics(
             self,
             col_names: Optional[Iterable[str]] = (
@@ -191,6 +271,20 @@ class EEGModuleMixin(metaclass=NumpyDocstringInheritanceInitMeta):
             row_settings=row_settings,
             verbose=0,
         )
+
+    def convert_to_regressor(self) -> None:
+        """Convert model to regressor by removing softmax layer, inplace."""
+        to_remove = []
+        for idx, (name, _) in enumerate(self.named_children()):
+            if "softmax" in name:
+                to_remove.append(idx)
+        if len(to_remove) == 0:
+            msg = ("When converting to regressor, no softmax layer found in the layers. Softmax "
+                   "layer may not contain `softmax` in the name or model could have been already "
+                   "converted to a regressor.")
+            warnings.warn(msg, UserWarning)
+        for idx in reversed(to_remove):
+            del self[idx]
 
     def __str__(self) -> str:
         return str(self.get_torchinfo_statistics())

--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -3,7 +3,7 @@
 # License: BSD-3
 
 import warnings
-from typing import Iterable, List, Optional, Dict
+from typing import Dict, Iterable, List, Optional, Tuple
 
 import numpy as np
 import torch
@@ -161,17 +161,17 @@ class EEGModuleMixin(metaclass=NumpyDocstringInheritanceInitMeta):
         return self._sfreq
 
     @property
-    def input_shape(self) -> tuple[int]:
+    def input_shape(self) -> Tuple[int]:
         """Input data shape."""
         return (1, self.n_chans, self.n_times)
 
     @property
-    def output_shape(self) -> tuple[int]:
+    def output_shape(self) -> Tuple[int]:
         """Returns shape of neural network output for batch size equal 1.
 
         Returns
         -------
-        output_shape: tuple[int]
+        output_shape: Tuple[int]
             shape of the network output for `batch_size==1` (1, ...)
     """
         with torch.inference_mode():
@@ -197,7 +197,7 @@ class EEGModuleMixin(metaclass=NumpyDocstringInheritanceInitMeta):
                     raise ValueError(msg) from exc
                 raise exc
 
-    def to_dense_prediction_model(self, axis=(2, 3)):
+    def to_dense_prediction_model(self, axis: Tuple[int] = (2, 3)) -> None:
         """
         Transform a sequential model with strides to a model that outputs
         dense predictions by removing the strides and instead inserting dilations.

--- a/braindecode/models/deep4.py
+++ b/braindecode/models/deep4.py
@@ -4,16 +4,14 @@
 
 from collections import OrderedDict
 
-import numpy as np
+from einops.layers.torch import Rearrange
 from torch import nn
 from torch.nn import init
 from torch.nn.functional import elu
-from einops.layers.torch import Rearrange
 
-from .modules import Expression, AvgPool2dWithConv, Ensure4d, CombinedConv
-from .functions import identity, squeeze_final_output
-from ..util import np_to_th
 from .base import EEGModuleMixin, deprecated_args
+from .functions import identity, squeeze_final_output
+from .modules import AvgPool2dWithConv, CombinedConv, Ensure4d, Expression
 
 
 class Deep4Net(EEGModuleMixin, nn.Sequential):
@@ -271,16 +269,7 @@ class Deep4Net(EEGModuleMixin, nn.Sequential):
         # self.add_module('drop_classifier', nn.Dropout(p=self.drop_prob))
         self.eval()
         if self.final_conv_length == "auto":
-            out = self(
-                np_to_th(
-                    np.ones(
-                        (1, self.n_chans, self.n_times, 1),
-                        dtype=np.float32,
-                    )
-                )
-            )
-            n_out_time = out.cpu().data.numpy().shape[2]
-            self.final_conv_length = n_out_time
+            self.final_conv_length = self.output_shape[2]
         self.add_module(
             "conv_classifier",
             nn.Conv2d(

--- a/braindecode/models/deep4.py
+++ b/braindecode/models/deep4.py
@@ -269,7 +269,7 @@ class Deep4Net(EEGModuleMixin, nn.Sequential):
         # self.add_module('drop_classifier', nn.Dropout(p=self.drop_prob))
         self.eval()
         if self.final_conv_length == "auto":
-            self.final_conv_length = self.output_shape[2]
+            self.final_conv_length = self.get_output_shape()[2]
         self.add_module(
             "conv_classifier",
             nn.Conv2d(

--- a/braindecode/models/eegnet.py
+++ b/braindecode/models/eegnet.py
@@ -179,7 +179,7 @@ class EEGNetv4(EEGModuleMixin, nn.Sequential):
         self.add_module("pool_2", pool_class(kernel_size=(1, 8), stride=(1, 8)))
         self.add_module("drop_2", nn.Dropout(p=self.drop_prob))
 
-        output_shape = self.output_shape
+        output_shape = self.get_output_shape()
         n_out_virtual_chans = output_shape[2]
 
         if self.final_conv_length == "auto":
@@ -338,7 +338,7 @@ class EEGNetv1(EEGModuleMixin, nn.Sequential):
         self.add_module("pool_3", pool_class(kernel_size=(2, 4), stride=(2, 4)))
         self.add_module("drop_3", nn.Dropout(p=self.drop_prob))
 
-        output_shape = self.output_shape
+        output_shape = self.get_output_shape()
         n_out_virtual_chans = output_shape[2]
 
         if self.final_conv_length == "auto":

--- a/braindecode/models/eegnet.py
+++ b/braindecode/models/eegnet.py
@@ -3,13 +3,13 @@
 # License: BSD (3-clause)
 
 import torch
+from einops.layers.torch import Rearrange
 from torch import nn
 from torch.nn.functional import elu
-from einops.layers.torch import Rearrange
 
 from .base import EEGModuleMixin, deprecated_args
-from .modules import Expression, Ensure4d
 from .functions import squeeze_final_output
+from .modules import Ensure4d, Expression
 
 
 class Conv2dWithConstraint(nn.Conv2d):
@@ -179,16 +179,11 @@ class EEGNetv4(EEGModuleMixin, nn.Sequential):
         self.add_module("pool_2", pool_class(kernel_size=(1, 8), stride=(1, 8)))
         self.add_module("drop_2", nn.Dropout(p=self.drop_prob))
 
-        out = self(
-            torch.ones(
-                (1, self.n_chans, self.n_times, 1),
-                dtype=torch.float32
-            )
-        )
-        n_out_virtual_chans = out.cpu().data.numpy().shape[2]
+        output_shape = self.output_shape
+        n_out_virtual_chans = output_shape[2]
 
         if self.final_conv_length == "auto":
-            n_out_time = out.cpu().data.numpy().shape[3]
+            n_out_time = output_shape[3]
             self.final_conv_length = n_out_time
 
         self.add_module(
@@ -343,16 +338,11 @@ class EEGNetv1(EEGModuleMixin, nn.Sequential):
         self.add_module("pool_3", pool_class(kernel_size=(2, 4), stride=(2, 4)))
         self.add_module("drop_3", nn.Dropout(p=self.drop_prob))
 
-        out = self(
-            torch.ones(
-                (1, self.n_chans, self.n_times, 1),
-                dtype=torch.float32,
-            )
-        )
-        n_out_virtual_chans = out.cpu().data.numpy().shape[2]
+        output_shape = self.output_shape
+        n_out_virtual_chans = output_shape[2]
 
         if self.final_conv_length == "auto":
-            n_out_time = out.cpu().data.numpy().shape[3]
+            n_out_time = output_shape[3]
             self.final_conv_length = n_out_time
 
         self.add_module(
@@ -386,7 +376,7 @@ def _glorot_weight_zero_bias(model):
     """
     for module in model.modules():
         if hasattr(module, "weight"):
-            if not ("BatchNorm" in module.__class__.__name__):
+            if "BatchNorm" not in module.__class__.__name__:
                 nn.init.xavier_uniform_(module.weight, gain=1)
             else:
                 nn.init.constant_(module.weight, 1)

--- a/braindecode/models/shallow_fbcsp.py
+++ b/braindecode/models/shallow_fbcsp.py
@@ -3,15 +3,13 @@
 # License: BSD (3-clause)
 from collections import OrderedDict
 
-import numpy as np
+from einops.layers.torch import Rearrange
 from torch import nn
 from torch.nn import init
-from einops.layers.torch import Rearrange
 
-from ..util import np_to_th
-from .modules import Expression, Ensure4d, CombinedConv
-from .functions import safe_log, square, squeeze_final_output
 from .base import EEGModuleMixin, deprecated_args
+from .functions import safe_log, square, squeeze_final_output
+from .modules import CombinedConv, Ensure4d, Expression
 
 
 class ShallowFBCSPNet(EEGModuleMixin, nn.Sequential):
@@ -171,16 +169,7 @@ class ShallowFBCSPNet(EEGModuleMixin, nn.Sequential):
         self.add_module("drop", nn.Dropout(p=self.drop_prob))
         self.eval()
         if self.final_conv_length == "auto":
-            out = self(
-                np_to_th(
-                    np.ones(
-                        (1, self.n_chans, self.n_times, 1),
-                        dtype=np.float32,
-                    )
-                )
-            )
-            n_out_time = out.cpu().data.numpy().shape[2]
-            self.final_conv_length = n_out_time
+            self.final_conv_length = self.output_shape[2]
         self.add_module(
             "conv_classifier",
             nn.Conv2d(

--- a/braindecode/models/shallow_fbcsp.py
+++ b/braindecode/models/shallow_fbcsp.py
@@ -169,7 +169,7 @@ class ShallowFBCSPNet(EEGModuleMixin, nn.Sequential):
         self.add_module("drop", nn.Dropout(p=self.drop_prob))
         self.eval()
         if self.final_conv_length == "auto":
-            self.final_conv_length = self.output_shape[2]
+            self.final_conv_length = self.get_output_shape()[2]
         self.add_module(
             "conv_classifier",
             nn.Conv2d(

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -6,13 +6,13 @@
 import numpy as np
 import torch
 from scipy.special import log_softmax
+from sklearn.utils import deprecated
 
 
-@np.deprecate(
-    new_name="EEGModuleMixin.to_dense_prediction_model",
-    message=("`to_dense_prediction_model` method should be called directly on the model object that"
-             " should be modified inplace.")
-    )
+@deprecated(
+    "will be removed in version 1.0. Use EEGModuleMixin.to_dense_prediction_model method directly "
+    "on the model object."
+)
 def to_dense_prediction_model(model, axis=(2, 3)):
     """
     Transform a sequential model with strides to a model that outputs
@@ -59,10 +59,10 @@ def to_dense_prediction_model(model, axis=(2, 3)):
             module.stride = tuple(new_stride)
 
 
-@np.deprecate(
-    new_name="EEGModuleMixin.get_output_shape",
-    message=("`get_output_shape` method should be called directly on the model object.")
-    )
+@deprecated(
+    "will be removed in version 1.0. Use EEGModuleMixin.get_output_shape method directly on the "
+    "model object."
+)
 def get_output_shape(model, in_chans, input_window_samples):
     """Returns shape of neural network output for batch size equal 1.
 

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -3,11 +3,16 @@
 #
 # License: BSD (3-clause)
 
-import torch
 import numpy as np
+import torch
 from scipy.special import log_softmax
 
 
+@np.deprecate(
+    new_name="EEGModuleMixin.to_dense_prediction_model",
+    message=("`to_dense_prediction_model` method should be called directly on the model object that"
+             " should be modified inplace.")
+    )
 def to_dense_prediction_model(model, axis=(2, 3)):
     """
     Transform a sequential model with strides to a model that outputs
@@ -54,6 +59,10 @@ def to_dense_prediction_model(model, axis=(2, 3)):
             module.stride = tuple(new_stride)
 
 
+@np.deprecate(
+    new_name="EEGModuleMixin.output_shape",
+    message=("`output_shape` property should be called directly on the model object.")
+    )
 def get_output_shape(model, in_chans, input_window_samples):
     """Returns shape of neural network output for batch size equal 1.
 

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -60,8 +60,8 @@ def to_dense_prediction_model(model, axis=(2, 3)):
 
 
 @np.deprecate(
-    new_name="EEGModuleMixin.output_shape",
-    message=("`output_shape` property should be accessed directly on the model object.")
+    new_name="EEGModuleMixin.get_output_shape",
+    message=("`get_output_shape` method should be called directly on the model object.")
     )
 def get_output_shape(model, in_chans, input_window_samples):
     """Returns shape of neural network output for batch size equal 1.

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -61,7 +61,7 @@ def to_dense_prediction_model(model, axis=(2, 3)):
 
 @np.deprecate(
     new_name="EEGModuleMixin.output_shape",
-    message=("`output_shape` property should be called directly on the model object.")
+    message=("`output_shape` property should be accessed directly on the model object.")
     )
 def get_output_shape(model, in_chans, input_window_samples):
     """Returns shape of neural network output for batch size equal 1.

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -44,6 +44,7 @@ Enhancements
 - Merged temporal and spatial convolutions for Deep4 and ShallowFBCSP (by `Daniel Wilson`_ and `Sara Sedlar`_)
 - Enabling data augmentation of single inputs (with no batch dimension). (:gh:`503` by `Cedric Rommel`_)
 - Adding `randomize` parameter to :class:`braindecode.samplers.SequenceSampler` (:gh:`504` by `Théo Gnassounou`_.)
+- Moving :function:`braindecode.models.util.get_output_shape` and :function:`braindecode.models.util.to_dense_prediction_model` to :class:`braindecode.models.base.EEGModuleMixin` (:gh:`514` by `Maciej Śliwowski`_)
 
 Bugs
 ~~~~

--- a/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
+++ b/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
@@ -198,7 +198,7 @@ if cuda:
 
 from braindecode.models import to_dense_prediction_model
 
-model = to_dense_prediction_model(model)
+to_dense_prediction_model(model)
 
 ######################################################################
 # To know the models’ receptive field, we calculate the shape of model

--- a/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
+++ b/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
@@ -196,14 +196,15 @@ model = new_model
 if cuda:
     model.cuda()
 
-model.to_dense_prediction_model()
+from braindecode.models import to_dense_prediction_model
+
+model = to_dense_prediction_model(model)
 
 ######################################################################
 # To know the models’ receptive field, we calculate the shape of model
 # output for a dummy input.
 
 n_preds_per_input = model.output_shape[2]
-
 
 ######################################################################
 # Cut Compute Windows

--- a/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
+++ b/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
@@ -185,18 +185,19 @@ model = ShallowFBCSPNet(
     final_conv_length=2,
 )
 # We are removing the softmax layer to make it a regression model
-model.convert_to_regressor()
+new_model = torch.nn.Sequential()
+for name, module_ in model.named_children():
+    if "softmax" in name:
+        continue
+    new_model.add_module(name, module_)
+model = new_model
 
 # Send model to GPU
 if cuda:
     model.cuda()
 
-from braindecode.models import to_dense_prediction_model
+model.to_dense_prediction_model()
 
-to_dense_prediction_model(model)
-
-# Display torchinfo table describing the model after conversion to regressor
-print(model)
 ######################################################################
 # To know the models’ receptive field, we calculate the shape of model
 # output for a dummy input.

--- a/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
+++ b/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
@@ -204,7 +204,7 @@ model = to_dense_prediction_model(model)
 # To know the models’ receptive field, we calculate the shape of model
 # output for a dummy input.
 
-n_preds_per_input = model.output_shape[2]
+n_preds_per_input = model.get_output_shape()[2]
 
 ######################################################################
 # Cut Compute Windows

--- a/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
+++ b/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
@@ -196,7 +196,7 @@ model = new_model
 if cuda:
     model.cuda()
 
-from braindecode.models import to_dense_prediction_model
+from braindecode.models import get_output_shape, to_dense_prediction_model
 
 to_dense_prediction_model(model)
 
@@ -204,7 +204,7 @@ to_dense_prediction_model(model)
 # To know the models’ receptive field, we calculate the shape of model
 # output for a dummy input.
 
-n_preds_per_input = model.get_output_shape()[2]
+n_preds_per_input = get_output_shape(model, n_chans, input_window_samples)[2]
 
 ######################################################################
 # Cut Compute Windows

--- a/examples/applied_examples/plot_bcic_iv_4_ecog_trial.py
+++ b/examples/applied_examples/plot_bcic_iv_4_ecog_trial.py
@@ -223,10 +223,12 @@ model = ShallowFBCSPNet(
 )
 
 # We are removing the softmax layer to make it a regression model
-model.convert_to_regressor()
-
-# Display torchinfo table describing the model after conversion to regressor
-print(model)
+new_model = torch.nn.Sequential()
+for name, module_ in model.named_children():
+    if "softmax" in name:
+        continue
+    new_model.add_module(name, module_)
+model = new_model
 
 # Send model to GPU
 if cuda:

--- a/examples/applied_examples/plot_bcic_iv_4_ecog_trial.py
+++ b/examples/applied_examples/plot_bcic_iv_4_ecog_trial.py
@@ -241,7 +241,6 @@ if cuda:
 #
 
 
-from mne import set_log_level
 ######################################################################
 # Now we train the network! EEGRegressor is a Braindecode object
 # responsible for managing the training of neural networks. It inherits
@@ -256,6 +255,7 @@ from mne import set_log_level
 #
 from skorch.callbacks import EpochScoring, LRScheduler
 from skorch.helper import predefined_split
+from mne import set_log_level
 
 from braindecode import EEGRegressor
 

--- a/examples/applied_examples/plot_bcic_iv_4_ecog_trial.py
+++ b/examples/applied_examples/plot_bcic_iv_4_ecog_trial.py
@@ -78,8 +78,9 @@ dataset = BCICompetitionIVDataset4(subject_ids=[subject_id])
 #
 
 
-from braindecode.preprocessing import (
-    exponential_moving_standardize, preprocess, Preprocessor)
+from braindecode.preprocessing import (Preprocessor,
+                                       exponential_moving_standardize,
+                                       preprocess)
 
 low_cut_hz = 1.  # low cut frequency for filtering
 high_cut_hz = 200.  # high cut frequency for filtering, for ECoG higher than for EEG
@@ -193,8 +194,8 @@ train_set = torch.utils.data.Subset(train_set, idx_train)
 # `nn.Module <https://pytorch.org/docs/stable/nn.html#torch.nn.Module>`__.
 
 
-from braindecode.util import set_random_seeds
 from braindecode.models import ShallowFBCSPNet
+from braindecode.util import set_random_seeds
 
 cuda = torch.cuda.is_available()  # check if GPU is available, if True chooses to use it
 device = 'cuda' if cuda else 'cpu'
@@ -222,12 +223,10 @@ model = ShallowFBCSPNet(
 )
 
 # We are removing the softmax layer to make it a regression model
-new_model = torch.nn.Sequential()
-for name, module_ in model.named_children():
-    if "softmax" in name:
-        continue
-    new_model.add_module(name, module_)
-model = new_model
+model.convert_to_regressor()
+
+# Display torchinfo table describing the model after conversion to regressor
+print(model)
 
 # Send model to GPU
 if cuda:
@@ -240,6 +239,7 @@ if cuda:
 #
 
 
+from mne import set_log_level
 ######################################################################
 # Now we train the network! EEGRegressor is a Braindecode object
 # responsible for managing the training of neural networks. It inherits
@@ -252,9 +252,8 @@ if cuda:
 #    encourage you to perform your own hyperparameter and preprocessing optimization using
 #    cross validation on your training data.
 #
-from skorch.callbacks import LRScheduler, EpochScoring
+from skorch.callbacks import EpochScoring, LRScheduler
 from skorch.helper import predefined_split
-from mne import set_log_level
 
 from braindecode import EEGRegressor
 
@@ -323,8 +322,8 @@ y_valid = np.stack([data[1] for data in valid_set])
 #    pipeline which may be not optimal for ECoG.
 #
 import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
 import pandas as pd
+from matplotlib.lines import Line2D
 
 plt.style.use('seaborn')
 fig, axes = plt.subplots(3, 1, figsize=(8, 9))

--- a/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
+++ b/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
@@ -78,9 +78,11 @@ from braindecode.datasets import MOABBDataset
 subject_id = 3
 dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[subject_id])
 
-from braindecode.preprocessing import (
-    exponential_moving_standardize, preprocess, Preprocessor)
 from numpy import multiply
+
+from braindecode.preprocessing import (Preprocessor,
+                                       exponential_moving_standardize,
+                                       preprocess)
 
 low_cut_hz = 4.  # low cut frequency for filtering
 high_cut_hz = 38.  # high cut frequency for filtering
@@ -129,9 +131,9 @@ input_window_samples = 1000
 #
 
 import torch
-from braindecode.util import set_random_seeds
-from braindecode.models import ShallowFBCSPNet
 
+from braindecode.models import ShallowFBCSPNet
+from braindecode.util import set_random_seeds
 
 cuda = torch.cuda.is_available()  # check if GPU is available, if True chooses to use it
 device = 'cuda' if cuda else 'cpu'
@@ -172,7 +174,7 @@ if cuda:
 # crops.
 #
 
-from braindecode.models import to_dense_prediction_model, get_output_shape
+from braindecode.models import to_dense_prediction_model
 
 to_dense_prediction_model(model)
 
@@ -182,7 +184,7 @@ to_dense_prediction_model(model)
 # output for a dummy input.
 #
 
-n_preds_per_input = get_output_shape(model, n_chans, input_window_samples)[2]
+n_preds_per_input = model.output_shape[2]
 
 
 ######################################################################
@@ -295,8 +297,8 @@ clf.fit(train_set, y=None, epochs=n_epochs)
 #
 
 import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
 import pandas as pd
+from matplotlib.lines import Line2D
 
 # Extract loss and accuracy values for plotting from history object
 results_columns = ['train_loss', 'valid_loss', 'train_accuracy', 'valid_accuracy']
@@ -340,6 +342,7 @@ plt.tight_layout()
 #
 
 from sklearn.metrics import confusion_matrix
+
 from braindecode.visualization import plot_confusion_matrix
 
 # generate confusion matrices

--- a/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
+++ b/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
@@ -80,9 +80,11 @@ dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[subject_id])
 
 from numpy import multiply
 
-from braindecode.preprocessing import (Preprocessor,
-                                       exponential_moving_standardize,
-                                       preprocess)
+from braindecode.preprocessing import (
+    Preprocessor,
+    exponential_moving_standardize,
+    preprocess,
+)
 
 low_cut_hz = 4.  # low cut frequency for filtering
 high_cut_hz = 38.  # high cut frequency for filtering
@@ -181,7 +183,7 @@ model.to_dense_prediction_model()
 # output for a dummy input.
 #
 
-n_preds_per_input = model.output_shape[2]
+n_preds_per_input = model.get_output_shape()[2]
 
 
 ######################################################################

--- a/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
+++ b/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
@@ -173,10 +173,7 @@ if cuda:
 # prediction, so we can use it to obtain predictions for all
 # crops.
 #
-
-from braindecode.models import to_dense_prediction_model
-
-to_dense_prediction_model(model)
+model.to_dense_prediction_model()
 
 
 ######################################################################

--- a/examples/model_building/plot_bcic_iv_2a_moabb_trial.py
+++ b/examples/model_building/plot_bcic_iv_2a_moabb_trial.py
@@ -63,9 +63,11 @@ dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[subject_id])
 #    `torchvision <https://pytorch.org/docs/stable/torchvision/index.html>`__.
 #
 
-from braindecode.preprocessing import (
-    exponential_moving_standardize, preprocess, Preprocessor)
 from numpy import multiply
+
+from braindecode.preprocessing import (Preprocessor,
+                                       exponential_moving_standardize,
+                                       preprocess)
 
 low_cut_hz = 4.  # low cut frequency for filtering
 high_cut_hz = 38.  # high cut frequency for filtering
@@ -153,8 +155,10 @@ valid_set = splitted['session_E']
 #
 
 import torch
-from braindecode.util import set_random_seeds
+
 from braindecode.models import ShallowFBCSPNet
+from braindecode.models.util import get_output_shape
+from braindecode.util import set_random_seeds
 
 cuda = torch.cuda.is_available()  # check if GPU is available, if True chooses to use it
 device = 'cuda' if cuda else 'cpu'
@@ -184,6 +188,8 @@ model = ShallowFBCSPNet(
 
 # Display torchinfo table describing the model
 print(model)
+
+get_output_shape(model, n_chans, input_window_samples)
 
 # Send model to GPU
 if cuda:
@@ -215,6 +221,7 @@ from skorch.callbacks import LRScheduler
 from skorch.helper import predefined_split
 
 from braindecode import EEGClassifier
+
 # We found these values to be good for the shallow network:
 lr = 0.0625 * 0.01
 weight_decay = 0
@@ -257,8 +264,8 @@ clf.fit(train_set, y=None, epochs=n_epochs)
 #
 
 import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
 import pandas as pd
+from matplotlib.lines import Line2D
 
 # Extract loss and accuracy values for plotting from history object
 results_columns = ['train_loss', 'valid_loss', 'train_accuracy', 'valid_accuracy']
@@ -306,6 +313,7 @@ plt.tight_layout()
 
 
 from sklearn.metrics import confusion_matrix
+
 from braindecode.visualization import plot_confusion_matrix
 
 # generate confusion matrices

--- a/examples/model_building/plot_bcic_iv_2a_moabb_trial.py
+++ b/examples/model_building/plot_bcic_iv_2a_moabb_trial.py
@@ -157,7 +157,6 @@ valid_set = splitted['session_E']
 import torch
 
 from braindecode.models import ShallowFBCSPNet
-from braindecode.models.util import get_output_shape
 from braindecode.util import set_random_seeds
 
 cuda = torch.cuda.is_available()  # check if GPU is available, if True chooses to use it
@@ -188,8 +187,6 @@ model = ShallowFBCSPNet(
 
 # Display torchinfo table describing the model
 print(model)
-
-get_output_shape(model, n_chans, input_window_samples)
 
 # Send model to GPU
 if cuda:

--- a/examples/model_building/plot_regression.py
+++ b/examples/model_building/plot_regression.py
@@ -166,7 +166,7 @@ from braindecode.models.util import to_dense_prediction_model, get_output_shape
 from braindecode.preprocessing import create_fixed_length_windows
 
 window_size_samples = fake_sfreq * fake_duration // 3
-model = to_dense_prediction_model(model)
+to_dense_prediction_model(model)
 n_preds_per_input = get_output_shape(model, n_fake_chans, window_size_samples)[
     2]
 windows_dataset = create_fixed_length_windows(dataset,

--- a/examples/model_building/plot_regression.py
+++ b/examples/model_building/plot_regression.py
@@ -21,8 +21,9 @@ function from the classifier's output layer and how to train it on a fake regres
 
 import numpy as np
 import pandas as pd
+
+from braindecode.datasets import BaseConcatDataset, BaseDataset
 from braindecode.util import create_mne_dummy_raw
-from braindecode.datasets import BaseDataset, BaseConcatDataset
 
 
 ###################################################################################################
@@ -96,6 +97,9 @@ dataset = fake_regression_dataset(n_fake_recs=n_fake_rec,
                                   fake_duration=fake_duration,
                                   n_fake_targets=n_fake_targets)
 
+import torch
+
+from braindecode.models import Deep4Net, ShallowFBCSPNet
 ###################################################################################################
 # Defining a CNN regression model
 # -------------------------------
@@ -103,29 +107,26 @@ dataset = fake_regression_dataset(n_fake_recs=n_fake_rec,
 # Choosing and defining a CNN classifier, `ShallowFBCSPNet` or `Deep4Net`, introduced in [1]_.
 # To convert a classifier to a regressor, `softmax` function is removed from its output layer.
 from braindecode.util import set_random_seeds
-from braindecode.models import Deep4Net
-from braindecode.models import ShallowFBCSPNet
-import torch
 
 # Choosing a CNN model
 model_name = "shallow"  # 'shallow' or 'deep'
 
 # Defining a CNN model
 if model_name in ["shallow", "Shallow", "ShallowConvNet"]:
-    model_clf = ShallowFBCSPNet(in_chans=n_fake_chans,
-                                n_classes=n_fake_targets,
-                                input_window_samples=fake_sfreq * fake_duration,
-                                n_filters_time=40, n_filters_spat=40,
-                                final_conv_length=35, )
+    model = ShallowFBCSPNet(in_chans=n_fake_chans,
+                            n_classes=n_fake_targets,
+                            input_window_samples=fake_sfreq * fake_duration,
+                            n_filters_time=40, n_filters_spat=40,
+                            final_conv_length=35, )
 elif model_name in ["deep", "Deep", "DeepConvNet"]:
-    model_clf = Deep4Net(in_chans=n_fake_chans, n_classes=n_fake_targets,
-                         input_window_samples=fake_sfreq * fake_duration,
-                         n_filters_time=25, n_filters_spat=25,
-                         stride_before_pool=True,
-                         n_filters_2=n_fake_chans * 2,
-                         n_filters_3=n_fake_chans * 4,
-                         n_filters_4=n_fake_chans * 8,
-                         final_conv_length=1, )
+    model = Deep4Net(in_chans=n_fake_chans, n_classes=n_fake_targets,
+                     input_window_samples=fake_sfreq * fake_duration,
+                     n_filters_time=25, n_filters_spat=25,
+                     stride_before_pool=True,
+                     n_filters_2=n_fake_chans * 2,
+                     n_filters_3=n_fake_chans * 4,
+                     n_filters_4=n_fake_chans * 8,
+                     final_conv_length=1, )
 else:
     raise ValueError(f'{model_name} unknown')
 
@@ -133,15 +134,12 @@ else:
 # Converting a braindecode classifier model to a regressor model
 # ---------------------------------------------------------------
 #
-# Conversion of the CNN classifier into regressor by removing `softmax` function from the last
-# layer
-model_reg = torch.nn.Sequential()
-for name, module_ in model_clf.named_children():
-    if "softmax" in name:
-        continue
-    model_reg.add_module(name, module_)
-model = model_reg
+# Inplace conversion of the CNN classifier into regressor by removing `softmax` function from
+# the last layer
+model.convert_to_regressor()
 
+# Display torchinfo table describing the model after conversion to regressor
+print(model)
 ###################################################################################################
 # Choosing between GPU and CPU processors
 # ---------------------------------------
@@ -161,13 +159,12 @@ if cuda:
 # Data windowing
 # ----------------
 # Windowing data with a sliding window into the epochs of the size `window_size_samples`.
-from braindecode.models.util import to_dense_prediction_model, get_output_shape
+from braindecode.models.util import to_dense_prediction_model
 from braindecode.preprocessing import create_fixed_length_windows
 
 window_size_samples = fake_sfreq * fake_duration // 3
 to_dense_prediction_model(model)
-n_preds_per_input = get_output_shape(model, n_fake_chans, window_size_samples)[
-    2]
+n_preds_per_input = model.output_shape[2]
 windows_dataset = create_fixed_length_windows(dataset,
                                               start_offset_samples=0,
                                               stop_offset_samples=0,
@@ -183,6 +180,9 @@ train_set = splits["train"]
 valid_set = splits["valid"]
 test_set = splits["test"]
 
+from skorch.callbacks import LRScheduler
+from skorch.helper import predefined_split
+
 ###################################################################################################
 # Model training
 # -----------------
@@ -191,8 +191,6 @@ test_set = splits["test"]
 # learning rate scheduler.
 from braindecode import EEGRegressor
 from braindecode.training.losses import CroppedLoss
-from skorch.callbacks import LRScheduler
-from skorch.helper import predefined_split
 
 batch_size = 4
 n_epochs = 3

--- a/examples/model_building/plot_regression.py
+++ b/examples/model_building/plot_regression.py
@@ -159,11 +159,10 @@ if cuda:
 # Data windowing
 # ----------------
 # Windowing data with a sliding window into the epochs of the size `window_size_samples`.
-from braindecode.models.util import to_dense_prediction_model
 from braindecode.preprocessing import create_fixed_length_windows
 
 window_size_samples = fake_sfreq * fake_duration // 3
-to_dense_prediction_model(model)
+model.to_dense_prediction_model()
 n_preds_per_input = model.output_shape[2]
 windows_dataset = create_fixed_length_windows(dataset,
                                               start_offset_samples=0,

--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -88,7 +88,7 @@ def test_cropped_decoding():
         model.cuda()
 
     # Perform forward pass to determine how many outputs per input
-    n_preds_per_input = model.output_shape[2]
+    n_preds_per_input = model.get_output_shape()[2]
 
     train_set = create_from_X_y(X[:60], y[:60],
                                 drop_last_window=False,

--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -15,7 +15,6 @@ from torch import optim
 from braindecode import EEGClassifier
 from braindecode.datasets.xy import create_from_X_y
 from braindecode.models import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model
 from braindecode.training.losses import CroppedLoss
 from braindecode.util import set_random_seeds
 
@@ -83,7 +82,7 @@ def test_cropped_decoding():
         input_window_samples=input_window_samples,
         final_conv_length=12,
     )
-    to_dense_prediction_model(model)
+    model.to_dense_prediction_model()
 
     if cuda:
         model.cuda()

--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -3,10 +3,10 @@
 #
 # License: BSD-3
 import sys
-import pytest
 
 import mne
 import numpy as np
+import pytest
 import torch
 from mne.io import concatenate_raws
 from skorch.helper import predefined_split
@@ -14,9 +14,9 @@ from torch import optim
 
 from braindecode import EEGClassifier
 from braindecode.datasets.xy import create_from_X_y
-from braindecode.training.losses import CroppedLoss
 from braindecode.models import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model, get_output_shape
+from braindecode.models.util import to_dense_prediction_model
+from braindecode.training.losses import CroppedLoss
 from braindecode.util import set_random_seeds
 
 
@@ -89,7 +89,7 @@ def test_cropped_decoding():
         model.cuda()
 
     # Perform forward pass to determine how many outputs per input
-    n_preds_per_input = get_output_shape(model, in_chans, input_window_samples)[2]
+    n_preds_per_input = model.output_shape[2]
 
     train_set = create_from_X_y(X[:60], y[:60],
                                 drop_last_window=False,

--- a/test/acceptance_tests/test_eeg_classifier.py
+++ b/test/acceptance_tests/test_eeg_classifier.py
@@ -4,10 +4,10 @@
 #
 # License: BSD-3
 import sys
-import pytest
 
 import mne
 import numpy as np
+import pytest
 from mne.io import concatenate_raws
 from skorch.helper import predefined_split
 from torch import optim
@@ -15,11 +15,10 @@ from torch.nn.functional import nll_loss
 
 from braindecode.classifier import EEGClassifier
 from braindecode.datasets.xy import create_from_X_y
-from braindecode.training.losses import CroppedLoss
 from braindecode.models import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model
+from braindecode.training.losses import CroppedLoss
 from braindecode.training.scoring import CroppedTrialEpochScoring
-from braindecode.util import set_random_seeds, np_to_th
+from braindecode.util import np_to_th, set_random_seeds
 
 
 def assert_deep_allclose(expected, actual, *args, **kwargs):
@@ -137,7 +136,7 @@ def test_eeg_classifier():
         input_window_samples=input_window_samples,
         final_conv_length=12,
     )
-    to_dense_prediction_model(model)
+    model.to_dense_prediction_model()
 
     if cuda:
         model.cuda()

--- a/test/acceptance_tests/test_variable_length_trials_decoding.py
+++ b/test/acceptance_tests/test_variable_length_trials_decoding.py
@@ -3,21 +3,20 @@
 #
 # License: BSD-3
 import sys
+
+import numpy as np
 import pytest
 import torch
-import numpy as np
-
 from skorch.helper import predefined_split
 
-from braindecode.datasets.tuh import _TUHAbnormalMock
-from braindecode.preprocessing import (
-    preprocess, Preprocessor, create_fixed_length_windows)
-from braindecode.datasets import BaseConcatDataset
-from braindecode.util import set_random_seeds
 from braindecode import EEGClassifier
+from braindecode.datasets import BaseConcatDataset
+from braindecode.datasets.tuh import _TUHAbnormalMock
 from braindecode.models import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model
+from braindecode.preprocessing import (Preprocessor,
+                                       create_fixed_length_windows, preprocess)
 from braindecode.training import CroppedLoss
+from braindecode.util import set_random_seeds
 
 
 @pytest.mark.skipif(sys.version_info != (3, 7), reason="Only for Python 3.7")
@@ -66,7 +65,7 @@ def test_variable_length_trials_cropped_decoding():
         in_chans=x.shape[0],
         n_classes=n_classes,
     )
-    to_dense_prediction_model(model)
+    model.to_dense_prediction_model()
     if cuda:
         model.cuda()
 

--- a/test/unit_tests/models/test_base.py
+++ b/test/unit_tests/models/test_base.py
@@ -221,7 +221,7 @@ def test__str__():
     assert result == str(patch_stats)
 
 
-def test_output_shape():
+def test_get_output_shape():
     n_outputs = 1
     n_chans = 1
     chs_info = [{'ch_name': 'ch1'}],
@@ -237,13 +237,13 @@ def test_output_shape():
         input_window_seconds=input_window_seconds,
         sfreq=sfreq,
     )
-    assert dummy_module.output_shape == (1, 1, 1)
+    assert dummy_module.get_output_shape() == (1, 1, 1)
 
     dummy_module.add_module("linear2", nn.Linear(1, 2))
-    assert dummy_module.output_shape == (1, 1, 2)
+    assert dummy_module.get_output_shape() == (1, 1, 2)
 
 
-def test_raised_runtimeerror_kernel_size_output_shape(dummy_module: DummyModule):
+def test_raised_runtimeerror_kernel_size_get_output_shape(dummy_module: DummyModule):
 
     dummy_module.add_module("too_big_conv", nn.Conv2d(1, 1, kernel_size=(1, 201)))
     err_msg = (
@@ -254,10 +254,10 @@ def test_raised_runtimeerror_kernel_size_output_shape(dummy_module: DummyModule)
         r"in the input than \(1, 1, 200\)."
     )
     with pytest.raises(ValueError, match=err_msg):
-        dummy_module.output_shape
+        dummy_module.get_output_shape()
 
 
-def test_raised_runtimeerror_output_size_output_shape(dummy_module: DummyModule):
+def test_raised_runtimeerror_output_size_get_output_shape(dummy_module: DummyModule):
 
     dummy_module.add_module("good_conv", nn.Conv2d(1, 1, kernel_size=(1, 100)))
     dummy_module.add_module("too_big_pool", nn.AvgPool2d(kernel_size=(1, 200)))
@@ -270,4 +270,4 @@ def test_raised_runtimeerror_output_size_output_shape(dummy_module: DummyModule)
         r"in the input than \(1, 1, 200\)."
     )
     with pytest.raises(ValueError, match=err_msg):
-        dummy_module.output_shape
+        dummy_module.get_output_shape()

--- a/test/unit_tests/models/test_base.py
+++ b/test/unit_tests/models/test_base.py
@@ -27,6 +27,18 @@ class DummyModuleNTime(EEGModuleMixin, nn.Sequential):
         self.add_module('dummy', nn.Linear(self.n_times, 1))
 
 
+@pytest.fixture(scope="function")
+def dummy_module():
+    return DummyModule(
+        n_outputs=1,
+        n_chans=1,
+        ch_names=['ch1'],
+        n_times=200,
+        input_window_seconds=2.,
+        sfreq=100.,
+    )
+
+
 @pytest.mark.parametrize(
     'n_outputs, n_chans, chs_info, n_times, input_window_seconds, sfreq',
     [
@@ -207,3 +219,55 @@ def test__str__():
     patch_method_stats.assert_called_once()
     patch_stats.__str__.assert_called_once()
     assert result == str(patch_stats)
+
+
+def test_output_shape():
+    n_outputs = 1
+    n_chans = 1
+    ch_names = ['ch1']
+    n_times = 200
+    input_window_seconds = 2.
+    sfreq = 100.
+
+    dummy_module = DummyModuleNTime(
+        n_outputs=n_outputs,
+        n_chans=n_chans,
+        ch_names=ch_names,
+        n_times=n_times,
+        input_window_seconds=input_window_seconds,
+        sfreq=sfreq,
+    )
+    assert dummy_module.output_shape == (1, 1, 1)
+
+    dummy_module.add_module("linear2", nn.Linear(1, 2))
+    assert dummy_module.output_shape == (1, 1, 2)
+
+
+def test_raised_runtimeerror_kernel_size_output_shape(dummy_module: DummyModule):
+
+    dummy_module.add_module("too_big_conv", nn.Conv2d(1, 1, kernel_size=(1, 201)))
+    err_msg = (
+        "During model prediction RuntimeError was thrown showing that at some "
+        "layer ` Kernel size can't be greater than actual input size` \(see above "
+        "in the stacktrace\). This could be caused by providing too small "
+        "`n_times`\/`input_window_seconds`. Model may require longer chunks of signal "
+        "in the input than \(1, 1, 200\)."
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        dummy_module.output_shape
+
+
+def test_raised_runtimeerror_output_size_output_shape(dummy_module: DummyModule):
+
+    dummy_module.add_module("good_conv", nn.Conv2d(1, 1, kernel_size=(1, 100)))
+    dummy_module.add_module("too_big_pool", nn.AvgPool2d(kernel_size=(1, 200)))
+
+    err_msg = (
+        "During model prediction RuntimeError was thrown showing that at some "
+        "layer ` Output size is too small` \(see above "
+        "in the stacktrace\). This could be caused by providing too small "
+        "`n_times`\/`input_window_seconds`. Model may require longer chunks of signal "
+        "in the input than \(1, 1, 200\)."
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        dummy_module.output_shape

--- a/test/unit_tests/models/test_base.py
+++ b/test/unit_tests/models/test_base.py
@@ -32,7 +32,7 @@ def dummy_module():
     return DummyModule(
         n_outputs=1,
         n_chans=1,
-        ch_names=['ch1'],
+        chs_info=[{'ch_name': 'ch1'}],
         n_times=200,
         input_window_seconds=2.,
         sfreq=100.,
@@ -224,7 +224,7 @@ def test__str__():
 def test_output_shape():
     n_outputs = 1
     n_chans = 1
-    ch_names = ['ch1']
+    chs_info = [{'ch_name': 'ch1'}],
     n_times = 200
     input_window_seconds = 2.
     sfreq = 100.
@@ -232,7 +232,7 @@ def test_output_shape():
     dummy_module = DummyModuleNTime(
         n_outputs=n_outputs,
         n_chans=n_chans,
-        ch_names=ch_names,
+        chs_info=chs_info,
         n_times=n_times,
         input_window_seconds=input_window_seconds,
         sfreq=sfreq,
@@ -247,11 +247,11 @@ def test_raised_runtimeerror_kernel_size_output_shape(dummy_module: DummyModule)
 
     dummy_module.add_module("too_big_conv", nn.Conv2d(1, 1, kernel_size=(1, 201)))
     err_msg = (
-        "During model prediction RuntimeError was thrown showing that at some "
-        "layer ` Kernel size can't be greater than actual input size` \(see above "
-        "in the stacktrace\). This could be caused by providing too small "
-        "`n_times`\/`input_window_seconds`. Model may require longer chunks of signal "
-        "in the input than \(1, 1, 200\)."
+        r"During model prediction RuntimeError was thrown showing that at some "
+        r"layer ` Kernel size can't be greater than actual input size` \(see above "
+        r"in the stacktrace\). This could be caused by providing too small "
+        r"`n_times`\/`input_window_seconds`. Model may require longer chunks of signal "
+        r"in the input than \(1, 1, 200\)."
     )
     with pytest.raises(ValueError, match=err_msg):
         dummy_module.output_shape
@@ -263,11 +263,11 @@ def test_raised_runtimeerror_output_size_output_shape(dummy_module: DummyModule)
     dummy_module.add_module("too_big_pool", nn.AvgPool2d(kernel_size=(1, 200)))
 
     err_msg = (
-        "During model prediction RuntimeError was thrown showing that at some "
-        "layer ` Output size is too small` \(see above "
-        "in the stacktrace\). This could be caused by providing too small "
-        "`n_times`\/`input_window_seconds`. Model may require longer chunks of signal "
-        "in the input than \(1, 1, 200\)."
+        r"During model prediction RuntimeError was thrown showing that at some "
+        r"layer ` Output size is too small` \(see above "
+        r"in the stacktrace\). This could be caused by providing too small "
+        r"`n_times`\/`input_window_seconds`. Model may require longer chunks of signal "
+        r"in the input than \(1, 1, 200\)."
     )
     with pytest.raises(ValueError, match=err_msg):
         dummy_module.output_shape

--- a/test/unit_tests/training/test_scoring.py
+++ b/test/unit_tests/training/test_scoring.py
@@ -20,7 +20,6 @@ from braindecode.classifier import EEGClassifier
 from braindecode.datasets.moabb import MOABBDataset
 from braindecode.datasets.xy import create_from_X_y
 from braindecode.models import ShallowFBCSPNet
-from braindecode.models.util import to_dense_prediction_model
 from braindecode.preprocessing import create_windows_from_events
 from braindecode.training.scoring import (CroppedTimeSeriesEpochScoring,
                                           CroppedTrialEpochScoring,
@@ -392,7 +391,7 @@ def test_predict_trials():
         in_chans=in_chans,
         n_classes=n_classes,
     )
-    to_dense_prediction_model(model)
+    model.to_dense_prediction_model()
 
     output_shape = model.output_shape
     # the number of samples required to get 1 output

--- a/test/unit_tests/training/test_scoring.py
+++ b/test/unit_tests/training/test_scoring.py
@@ -390,6 +390,7 @@ def test_predict_trials():
     model = ShallowFBCSPNet(
         in_chans=in_chans,
         n_classes=n_classes,
+        n_times=window_size_samples,
     )
     model.to_dense_prediction_model()
 

--- a/test/unit_tests/training/test_scoring.py
+++ b/test/unit_tests/training/test_scoring.py
@@ -21,11 +21,13 @@ from braindecode.datasets.moabb import MOABBDataset
 from braindecode.datasets.xy import create_from_X_y
 from braindecode.models import ShallowFBCSPNet
 from braindecode.preprocessing import create_windows_from_events
-from braindecode.training.scoring import (CroppedTimeSeriesEpochScoring,
-                                          CroppedTrialEpochScoring,
-                                          PostEpochTrainScoring,
-                                          predict_trials,
-                                          trial_preds_from_window_preds)
+from braindecode.training.scoring import (
+    CroppedTimeSeriesEpochScoring,
+    CroppedTrialEpochScoring,
+    PostEpochTrainScoring,
+    predict_trials,
+    trial_preds_from_window_preds,
+)
 from braindecode.util import set_random_seeds
 
 
@@ -394,7 +396,7 @@ def test_predict_trials():
     )
     model.to_dense_prediction_model()
 
-    output_shape = model.output_shape
+    output_shape = model.get_output_shape()
     # the number of samples required to get 1 output
     receptive_field_size = window_size_samples - output_shape[-1] + 1
 

--- a/test/unit_tests/training/test_scoring.py
+++ b/test/unit_tests/training/test_scoring.py
@@ -9,22 +9,25 @@ import numpy as np
 import pytest
 import sklearn.datasets
 import torch
-from sklearn.metrics import f1_score, accuracy_score
+from sklearn.metrics import accuracy_score, f1_score
 from skorch import History
 from skorch.callbacks import Callback
 from skorch.utils import to_numpy, to_tensor
 from torch import optim
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader, Dataset
+
 from braindecode.classifier import EEGClassifier
-from braindecode.datasets.xy import create_from_X_y
-from braindecode.models import ShallowFBCSPNet, get_output_shape
-from braindecode.util import set_random_seeds
-from braindecode.training.scoring import (
-    CroppedTrialEpochScoring, PostEpochTrainScoring, trial_preds_from_window_preds,
-    predict_trials, CroppedTimeSeriesEpochScoring)
 from braindecode.datasets.moabb import MOABBDataset
+from braindecode.datasets.xy import create_from_X_y
+from braindecode.models import ShallowFBCSPNet
 from braindecode.models.util import to_dense_prediction_model
 from braindecode.preprocessing import create_windows_from_events
+from braindecode.training.scoring import (CroppedTimeSeriesEpochScoring,
+                                          CroppedTrialEpochScoring,
+                                          PostEpochTrainScoring,
+                                          predict_trials,
+                                          trial_preds_from_window_preds)
+from braindecode.util import set_random_seeds
 
 
 class MockSkorchNet:
@@ -391,7 +394,7 @@ def test_predict_trials():
     )
     to_dense_prediction_model(model)
 
-    output_shape = get_output_shape(model, in_chans, window_size_samples)
+    output_shape = model.output_shape
     # the number of samples required to get 1 output
     receptive_field_size = window_size_samples - output_shape[-1] + 1
 


### PR DESCRIPTION
Adding `input_shape`, `get_output_shape`, `to_dense_prediction_model`

Deprecating `get_output_shape` and `to_dense_prediction_model`, will be removed in version 1.0.

When we have a proper way of removing logsoftmax we may replace functions with methods everywhere.

Solve #432 with raising error suggesting that input size may be too small.
