### PR TITLE
First commit for python tutorial

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -46,6 +46,7 @@ Enhancements
 - Adding `randomize` parameter to :class:`braindecode.samplers.SequenceSampler` (:gh:`504` by `Théo Gnassounou`_.)
 - Creating new preprocessor objects based on mne's raw/Epochs methods :class:`braindecode.preprocessing.Resample`, :class:`braindecode.preprocessing.DropChannels`, :class:`braindecode.preprocessing.SetEEGReference`, :class:`braindecode.preprocessing.Filter`, :class:`braindecode.preprocessing.Pick`, :class:`braindecode.preprocessing.Crop` (:gh:`500` by `Bruna Lopes`_ and `Bruno Aristimunha`_)
 - Moving :function:`braindecode.models.util.get_output_shape` and :function:`braindecode.models.util.to_dense_prediction_model` to :class:`braindecode.models.base.EEGModuleMixin` (:gh:`514` by `Maciej Śliwowski`_)
+- Adding a pure PyTorch tutorial (:gh:`TODO` by `Remi Delbouys`_)
 
 Bugs
 ~~~~
@@ -224,3 +225,4 @@ Authors
 .. _Sara Sedlar: https://github.com/Sara04
 .. _Bruna Lopes: https://github.com/brunaafl
 .. _Sylvain Chevallier: https://github.com/sylvchev
+.. _Remi Delbouys: https://github.com/remidbs

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -46,7 +46,7 @@ Enhancements
 - Adding `randomize` parameter to :class:`braindecode.samplers.SequenceSampler` (:gh:`504` by `Théo Gnassounou`_.)
 - Creating new preprocessor objects based on mne's raw/Epochs methods :class:`braindecode.preprocessing.Resample`, :class:`braindecode.preprocessing.DropChannels`, :class:`braindecode.preprocessing.SetEEGReference`, :class:`braindecode.preprocessing.Filter`, :class:`braindecode.preprocessing.Pick`, :class:`braindecode.preprocessing.Crop` (:gh:`500` by `Bruna Lopes`_ and `Bruno Aristimunha`_)
 - Moving :function:`braindecode.models.util.get_output_shape` and :function:`braindecode.models.util.to_dense_prediction_model` to :class:`braindecode.models.base.EEGModuleMixin` (:gh:`514` by `Maciej Śliwowski`_)
-- Adding a pure PyTorch tutorial (:gh:`TODO` by `Remi Delbouys`_)
+- Adding a pure PyTorch tutorial (:gh:`523` by `Remi Delbouys`_)
 
 Bugs
 ~~~~

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -46,7 +46,7 @@ Enhancements
 - Adding `randomize` parameter to :class:`braindecode.samplers.SequenceSampler` (:gh:`504` by `Théo Gnassounou`_.)
 - Creating new preprocessor objects based on mne's raw/Epochs methods :class:`braindecode.preprocessing.Resample`, :class:`braindecode.preprocessing.DropChannels`, :class:`braindecode.preprocessing.SetEEGReference`, :class:`braindecode.preprocessing.Filter`, :class:`braindecode.preprocessing.Pick`, :class:`braindecode.preprocessing.Crop` (:gh:`500` by `Bruna Lopes`_ and `Bruno Aristimunha`_)
 - Moving :function:`braindecode.models.util.get_output_shape` and :function:`braindecode.models.util.to_dense_prediction_model` to :class:`braindecode.models.base.EEGModuleMixin` (:gh:`514` by `Maciej Śliwowski`_)
-- Adding a pure PyTorch tutorial (:gh:`523` by `Remi Delbouys`_)
+- Adding a pure PyTorch tutorial (:gh:`523` by `Remi Delbouys`_  and `Bruno Aristimunha`_)
 - Add ``models_dict`` to :mod:`braindecode.models.util` (:gh:`524` by `Pierre Guetschel`_)
 
 Bugs

--- a/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
+++ b/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
@@ -204,9 +204,11 @@ train_set = splitted["session_T"]
 test_set = splitted["session_E"]
 
 ######################################################################
-# Option 1: Pure pytorch training loop
+# Option 1: Pure PyTorch training loop
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
+# .. image:: https://upload.wikimedia.org/wikipedia/commons/9/96/Pytorch_logo.png
+#    :alt: Pytorch logo
 
 
 ######################################################################
@@ -246,9 +248,10 @@ n_epochs = 2
 from tqdm import tqdm
 # Define a method for training one epoch
 
+
 def train_one_epoch(
-        dataloader : DataLoader, model : Module, loss_fn, optimizer,
-        scheduler : LRScheduler, epoch : int, device, print_batch_stats=True
+        dataloader: DataLoader, model: Module, loss_fn, optimizer,
+        scheduler: LRScheduler, epoch: int, device, print_batch_stats=True
 ):
     model.train()  # Set the model to training mode
     train_loss, correct = 0, 0
@@ -287,6 +290,7 @@ def train_one_epoch(
 # Very similarly, the evaluation function loops over the entire dataloader
 # and accumulate the metrics, but doesn't update the model weights.
 
+
 @torch.no_grad()
 def test_model(
     dataloader: DataLoader, model: Module, loss_fn, print_batch_stats=True
@@ -323,9 +327,12 @@ def test_model(
     )
     return test_loss, correct
 
+
 # Define the optimization
-optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
-scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=n_epochs - 1)
+optimizer = torch.optim.AdamW(model.parameters(),
+                              lr=lr, weight_decay=weight_decay)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer,
+                                                       T_max=n_epochs - 1)
 # Define the loss function
 # We used the NNLoss function, which expects log probabilities as input
 # (which is the case for our model output)
@@ -354,8 +361,10 @@ for epoch in range(1, n_epochs + 1):
 
 
 ######################################################################
-# Option 2: Train it with pytorch lightning
+# Option 2: Train it with PyTorch Lightning
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# .. image:: https://upload.wikimedia.org/wikipedia/commons/e/e6/Lightning_Logo_v2.png
+#    :alt: Pytorch Ligthing logo
 
 ######################################################################
 # Alternatively, lightning provides a nice interface around torch modules
@@ -394,6 +403,7 @@ class LitModule(L.LightningModule):
         scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer,
                                                                T_max=n_epochs - 1)
         return [optimizer], [scheduler]
+
 
 # Creating the trainer with max_epochs=2 for demonstration purposes
 trainer = L.Trainer(max_epochs=n_epochs)

--- a/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
+++ b/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
@@ -1,0 +1,347 @@
+"""
+Training a Braindecode model in PyTorch
+======================================
+
+This tutorial shows you how to train a Braindecode model with PyTorch. The data
+preparation and model instantiation steps are identical to that of the tutorial
+`How to train, test and tune your model <./plot_how_train_test_and_tune.html>`__
+
+We will use the BCIC IV 2a dataset as a showcase example.
+
+The methods shown can be applied to any standard supervised trial-based decoding setting.
+This tutorial will include additional parts of code like loading and preprocessing,
+defining a model, and other details which are not exclusive to this page (compare
+`Cropped Decoding Tutorial <./plot_bcic_iv_2a_moabb_trial.html>`__). Therefore we
+will not further elaborate on these parts and you can feel free to skip them.
+
+In general, we distinguish between "usual" training and evaluation and hyperparameter search.
+The tutorial is therefore split into two parts, one for the three different training schemes
+and one for the two different hyperparameter tuning methods.
+
+.. contents:: This example covers:
+   :local:
+   :depth: 2
+
+"""
+
+######################################################################
+# Why should I care about model evaluation?
+# -----------------------------------------
+# Short answer: To produce reliable results!
+#
+# In machine learning, we usually follow the scheme of splitting the
+# data into two parts, training and testing sets. It sounds like a
+# simple division, right? But the story does not end here.
+#
+# While developing a ML model you usually have to adjust and tune
+# hyperparameters of your model or pipeline (e.g., number of layers,
+# learning rate, number of epochs). Deep learning models usually have
+# many free parameters; they could be considered complex models with
+# many degrees of freedom. If you kept using the test dataset to
+# evaluate your adjustmentyou would run into data leakage.
+#
+# This means that if you use the test set to adjust the hyperparameters
+# of your model, the model implicitly learns or memorizes the test set.
+# Therefore, the trained model is no longer independent of the test set
+# (even though it was never used for training explicitly!).
+# If you perform any hyperparameter tuning, you need a third split,
+# the so-called validation set.
+#
+# This tutorial shows the three basic schemes for training and evaluating
+# the model as well as two methods to tune your hyperparameters.
+#
+
+######################################################################
+# .. warning::
+#    You might recognize that the accuracy gets better throughout
+#    the experiments of this tutorial. The reason behind that is that
+#    we always use the same model with the same paramters in every
+#    segment to keep the tutorial short and readable. If you do your
+#    own experiments you always have to reinitialize the model before
+#    training.
+#
+
+######################################################################
+# Loading, preprocessing, defining a model, etc.
+# ----------------------------------------------
+#
+
+
+######################################################################
+# Loading
+# ~~~~~~~
+#
+
+from braindecode.datasets import MOABBDataset
+
+subject_id = 3
+dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[subject_id])
+
+######################################################################
+# Preprocessing
+# ~~~~~~~~~~~~~
+#
+
+import numpy as np
+
+from braindecode.preprocessing import (
+    exponential_moving_standardize,
+    preprocess,
+    Preprocessor,
+)
+
+low_cut_hz = 4.0  # low cut frequency for filtering
+high_cut_hz = 38.0  # high cut frequency for filtering
+# Parameters for exponential moving standardization
+factor_new = 1e-3
+init_block_size = 1000
+
+preprocessors = [
+    Preprocessor("pick_types", eeg=True, meg=False, stim=False),  # Keep EEG sensors
+    Preprocessor(
+        lambda data, factor: np.multiply(data, factor),  # Convert from V to uV
+        factor=1e6,
+    ),
+    Preprocessor("filter", l_freq=low_cut_hz, h_freq=high_cut_hz),  # Bandpass filter
+    Preprocessor(
+        exponential_moving_standardize,  # Exponential moving standardization
+        factor_new=factor_new,
+        init_block_size=init_block_size,
+    ),
+]
+
+# Transform the data
+preprocess(dataset, preprocessors, n_jobs=-1)
+
+######################################################################
+# Cut Compute Windows
+# ~~~~~~~~~~~~~~~~~~~
+#
+
+from braindecode.preprocessing import create_windows_from_events
+
+trial_start_offset_seconds = -0.5
+# Extract sampling frequency, check that they are same in all datasets
+sfreq = dataset.datasets[0].raw.info["sfreq"]
+assert all([ds.raw.info["sfreq"] == sfreq for ds in dataset.datasets])
+# Calculate the trial start offset in samples.
+trial_start_offset_samples = int(trial_start_offset_seconds * sfreq)
+
+# Create windows using braindecode function for this. It needs parameters to define how
+# trials should be used.
+windows_dataset = create_windows_from_events(
+    dataset,
+    trial_start_offset_samples=trial_start_offset_samples,
+    trial_stop_offset_samples=0,
+    preload=True,
+)
+
+######################################################################
+# Create model
+# ~~~~~~~~~~~~
+#
+
+import torch
+from braindecode.models import ShallowFBCSPNet
+from braindecode.util import set_random_seeds
+
+cuda = torch.cuda.is_available()  # check if GPU is available, if True chooses to use it
+device = "cuda" if cuda else "cpu"
+if cuda:
+    torch.backends.cudnn.benchmark = True
+seed = 20200220
+set_random_seeds(seed=seed, cuda=cuda)
+
+n_classes = 4
+classes = list(range(n_classes))
+# Extract number of chans and time steps from dataset
+n_channels = windows_dataset[0][0].shape[0]
+input_window_samples = windows_dataset[0][0].shape[1]
+
+model = ShallowFBCSPNet(
+    n_channels,
+    n_classes,
+    input_window_samples=input_window_samples,
+    final_conv_length="auto",
+)
+
+# Display torchinfo table describing the model
+print(model)
+
+# Send model to GPU
+if cuda:
+    model.cuda()
+
+######################################################################
+# How to train and evaluate your model
+# ------------------------------------
+#
+
+######################################################################
+# Split dataset into train and test
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+
+######################################################################
+# We can easily split the dataset using additional info stored in the
+# description attribute, in this case the ``session`` column. We
+# select ``session_T`` for training and ``session_E`` for testing.
+# For other datasets, you might have to choose another column.
+#
+# .. note::
+#    No matter which of the three schemes you use, this initial
+#    two-fold split into train_set and test_set always remains the same.
+#    Remember that you are not allowed to use the test_set during any
+#    stage of training or tuning.
+#
+
+splitted = windows_dataset.split("session")
+train_set = splitted["session_T"]
+test_set = splitted["session_E"]
+
+######################################################################
+# Option 1: Pure pytorch training loop
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+
+
+######################################################################
+# `model` is an instance of `torch.nn.Module`, and can as such be trained
+# using PyTorch optimization capabilities.
+# The following training scheme is simple as the dataset is only
+# split into two distinct sets (``train_set`` and ``test_set``).
+# This scheme uses no separate validation split and should only be
+# used for the final evaluation of the (previously!) found
+# hyperparameters configuration.
+#
+# .. warning::
+#    If you make any use of the ``test_set`` during training
+#    (e.g. by using EarlyStopping) there will be data leakage
+#    which will make the reported generalization capability/decoding
+#    performance of your model less credible.
+#
+# .. warning::
+#    The parameter values showcased here for optimizing the network are
+#    chosen to make this tutorial fast to run and build. Real-world values
+#    would be higher, especially when it comes to batch n_epochs.
+
+from torch.nn import Module
+from torch.optim.lr_scheduler import CosineAnnealingLR, LRScheduler
+from torch.utils.data import DataLoader
+
+lr = 0.0625 * 0.01
+weight_decay = 0
+batch_size = 64
+n_epochs = 2
+
+
+######################################################################
+# The following method runs one training epoch over the dataloader for the
+# given model. It needs a loss function, optimization algorithm, and
+# learning rate updating callback.
+
+def train(
+    dataloader: DataLoader, model: Module, loss_fn, optimizer, scheduler: LRScheduler
+):
+    size = len(dataloader.dataset)
+    n_batches = len(dataloader)
+    model.train()  # declare the model as trainable
+    train_loss, correct = 0, 0
+    for X, y, _ in dataloader:
+        X, y = X.to(device), y.to(device)  # map tensors to their device
+        pred = model(X)
+        loss = loss_fn(pred, y)
+        loss.backward()
+        optimizer.step()  # update the model weights
+        optimizer.zero_grad()
+        train_loss += loss.item()
+        correct += (pred.argmax(1) == y).type(torch.float).sum().item()
+    correct /= size
+    print(
+        f"Train Accuracy: {(100*correct):>0.5f}, Train Loss: {train_loss / n_batches:>8f}, "
+        f"lr: {scheduler.get_last_lr()[0]:<0.4f}",
+        end=", ",
+    )
+
+    # Update the learning rate
+    scheduler.step()
+
+######################################################################
+# Very similarly, the evaluation function loops over the entire dataloader
+# and accumulate the metrics, but doesn't update the model weights.
+
+
+def test(dataloader: DataLoader, model: Module, loss_fn):
+    size = len(dataloader.dataset)
+    n_batches = len(dataloader)
+    model.eval()  # switch to eval mode
+    test_loss, correct = 0, 0
+    with torch.no_grad():  # skip gradient computation as it's not necessary for evaluation
+        for X, y, _ in dataloader:
+            X, y = X.to(device), y.to(device)
+            pred = model(X)
+            test_loss += loss_fn(pred, y).item()
+            correct += (pred.argmax(1) == y).type(torch.float).sum().item()
+    test_loss /= n_batches
+    correct /= size
+    print(f"Test Accuracy: {(100*correct):>0.1f}%, Test loss: {test_loss:>8f} \n")
+
+
+optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=n_epochs - 1)
+loss_fn = torch.nn.NLLLoss()
+
+# train_set and test_set are instances of torch Datasets, and can seamlessly be
+# wrapped in data loaders.
+train_loader = DataLoader(train_set, batch_size=batch_size, shuffle=True)
+test_loader = DataLoader(test_set, batch_size=batch_size)
+
+for t in range(n_epochs):
+    print(f"Epoch {t+1}, ", end="")
+    train(train_loader, model, loss_fn, optimizer, scheduler)
+    test(test_loader, model, loss_fn)
+
+
+######################################################################
+# Option 2: Train it with pytorch lightning
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+######################################################################
+# Alternatively, lightning provides a nice interface around torch modules
+# which integrates the previous logic.
+
+
+import lightning as L
+from torchmetrics.functional import accuracy
+
+
+class LitModule(L.LightningModule):
+    def __init__(self, module):
+        super().__init__()
+        self.module = module
+        self.loss = torch.nn.NLLLoss()
+
+    def training_step(self, batch, batch_idx):
+        x, y, _ = batch
+        y_hat = self.module(x)
+        loss = self.loss(y_hat, y)
+        self.log("train_loss", loss)
+        return loss
+
+    def test_step(self, batch, batch_idx):
+        x, y, _ = batch
+        y_hat = self.module(x)
+        loss = self.loss(y_hat, y)
+        acc = accuracy(y_hat, y, "multiclass", num_classes=4)
+        metrics = {"test_acc": acc, "test_loss": loss}
+        self.log_dict(metrics)
+        return metrics
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=n_epochs - 1)
+        return [optimizer], [scheduler]
+
+trainer = L.Trainer(max_epochs=n_epochs)
+trainer.fit(LitModule(model), DataLoader(train_set, batch_size=batch_size, shuffle=True))
+trainer.test(dataloaders=test_loader)

--- a/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
+++ b/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
@@ -1,6 +1,6 @@
 """
 Training a Braindecode model in PyTorch
-======================================
+=======================================
 
 This tutorial shows you how to train a Braindecode model with PyTorch. The data
 preparation and model instantiation steps are identical to that of the tutorial
@@ -248,7 +248,7 @@ from tqdm import tqdm
 
 def train_one_epoch(
         dataloader : DataLoader, model : Module, loss_fn, optimizer,
-        scheduler : LRScheduler, epoch, device, print_batch_stats=True
+        scheduler : LRScheduler, epoch : int, device, print_batch_stats=True
 ):
     model.train()  # Set the model to training mode
     train_loss, correct = 0, 0
@@ -389,10 +389,17 @@ class LitModule(L.LightningModule):
         return metrics
 
     def configure_optimizers(self):
-        optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
-        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=n_epochs - 1)
+        optimizer = torch.optim.AdamW(model.parameters(), lr=lr,
+                                      weight_decay=weight_decay)
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(optimizer,
+                                                               T_max=n_epochs - 1)
         return [optimizer], [scheduler]
 
+# Creating the trainer with max_epochs=2 for demonstration purposes
 trainer = L.Trainer(max_epochs=n_epochs)
-trainer.fit(LitModule(model), DataLoader(train_set, batch_size=batch_size, shuffle=True))
+# Create and train the LightningModule
+lit_model = LitModule(model)
+trainer.fit(lit_model, train_loader)
+
+# After training, you can test the model using the test DataLoader
 trainer.test(dataloaders=test_loader)

--- a/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
+++ b/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
@@ -16,10 +16,6 @@ will not further elaborate on these parts and you can feel free to skip them.
 
 The goal of this tutorial is to present braindecode in the PyTorch perpective.
 
-In general, we distinguish between "usual" training and evaluation and hyperparameter search.
-The tutorial is therefore split into two parts, one for the three different training schemes
-and one for the two different hyperparameter tuning methods.
-
 .. contents:: This example covers:
    :local:
    :depth: 2
@@ -229,7 +225,7 @@ test_set = splitted["session_E"]
 # .. warning::
 #    The parameter values showcased here for optimizing the network are
 #    chosen to make this tutorial fast to run and build. Real-world values
-#    would be higher, especially when it comes to batch n_epochs.
+#    would be higher, especially when it comes to n_epochs.
 
 from torch.nn import Module
 from torch.optim.lr_scheduler import LRScheduler
@@ -256,10 +252,8 @@ def train_one_epoch(
     model.train()  # Set the model to training mode
     train_loss, correct = 0, 0
 
-    if print_batch_stats:
-        progress_bar = tqdm(enumerate(dataloader), total=len(dataloader))
-    else:
-        progress_bar = enumerate(dataloader)
+    progress_bar = tqdm(enumerate(dataloader), total=len(dataloader),
+                        disable=not print_batch_stats)
 
     for batch_idx, (X, y, _) in progress_bar:
         X, y = X.to(device), y.to(device)

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
         'moabb': ['moabb'],
         'tests': ['pytest', 'pytest-cov', 'codecov', 'pytest_cases'],
         'docs': ['sphinx_gallery', 'sphinx_rtd_theme', 'pydata_sphinx_theme', 'numpydoc',
-                 'memory_profiler', 'pillow', 'ipython', 'sphinx_design', 'docstring_inheritance'],
+                 'memory_profiler', 'pillow', 'ipython', 'sphinx_design', 'docstring_inheritance',
+                 'lightning'],
     },
     # tests_require = [...]
 


### PR DESCRIPTION
Added a pure torch version of the [train/test tutorial](https://braindecode.org/dev/auto_examples/model_building/plot_how_train_test_and_tune.html#option-2-train-val-test-split).

Most of the data loading and preprocessing is similar, main differences are the two last paragraph showcasing a torch training loop and an equivalent pytorch lightning loop.