### PR TITLE
fix kernel_size np.int64 dtype in torchinfo

### DIFF
--- a/braindecode/models/usleep.py
+++ b/braindecode/models/usleep.py
@@ -201,7 +201,7 @@ class USleep(EEGModuleMixin, nn.Module):
         del in_chans, n_classes, input_size_s
 
         max_pool_size = 2  # Hardcoded to avoid dimensional errors
-        time_conv_size = np.round(time_conv_size_s * self.sfreq).astype(int)
+        time_conv_size = int(np.round(time_conv_size_s * self.sfreq))
         if time_conv_size % 2 == 0:
             if ensure_odd_conv_size:
                 time_conv_size += 1

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -54,6 +54,7 @@ Bugs
 ~~~~
 - Fix padding's device in :class:`braindecode.models.EEGResNet` (:gh:`451` by `Pierre Guetschel`_)
 - Fix skorch version issue (:gh:`465` by `Marco Zamboni`_)
+- Fix wrong `kernel_size` dtype when running torchinfo in :class:`braindecode.models.USleep` (:gh:`538` by `Maciej Śliwowski`_)
 
 API changes
 ~~~~~~~~~~~


### PR DESCRIPTION
It solves #537 where torchinfo was throwing wrong `kernel_size` type.