### PR TITLE
fix preprocessing for negative n_jobs

### DIFF
--- a/braindecode/preprocessing/preprocess.py
+++ b/braindecode/preprocessing/preprocess.py
@@ -106,7 +106,8 @@ def preprocess(concat_ds, preprocessors, save_dir=None, overwrite=False,
         the corresponding subdirectories already exist, a ``FileExistsError``
         will be raised.
     n_jobs : int | None
-        Number of jobs for parallel execution.
+        Number of jobs for parallel execution. See `joblib.Parallel` for
+        a more detailed explanation.
 
     Returns
     -------
@@ -125,7 +126,7 @@ def preprocess(concat_ds, preprocessors, save_dir=None, overwrite=False,
         assert hasattr(elem, 'apply'), (
             'Preprocessor object needs an `apply` method.')
 
-    parallel_processing = (n_jobs is not None) and (n_jobs > 1)
+    parallel_processing = (n_jobs is not None) and (n_jobs != 1)
 
     list_of_ds = Parallel(n_jobs=n_jobs)(
         delayed(_preprocess)(

--- a/test/unit_tests/preprocessing/test_mne_preprocessor.py
+++ b/test/unit_tests/preprocessing/test_mne_preprocessor.py
@@ -188,7 +188,7 @@ def test_set_preproc_kwargs_wrong_type(base_concat_ds):
 @pytest.mark.parametrize('kind', ['raw', 'windows'])
 @pytest.mark.parametrize('save', [True, False])
 @pytest.mark.parametrize('overwrite', [True, False])
-@pytest.mark.parametrize('n_jobs', [1, 2, None])
+@pytest.mark.parametrize('n_jobs', [-1, 1, 2, None])
 def test_preprocess_save_dir(base_concat_ds, windows_concat_ds, tmp_path,
                              kind, save, overwrite, n_jobs):
     preproc_kwargs = [

--- a/test/unit_tests/preprocessing/test_preprocess.py
+++ b/test/unit_tests/preprocessing/test_preprocess.py
@@ -300,7 +300,7 @@ def test_set_preproc_kwargs_wrong_type(base_concat_ds):
 @pytest.mark.parametrize('kind', ['raw', 'windows'])
 @pytest.mark.parametrize('save', [True, False])
 @pytest.mark.parametrize('overwrite', [True, False])
-@pytest.mark.parametrize('n_jobs', [1, 2, None])
+@pytest.mark.parametrize('n_jobs', [-1, 1, 2, None])
 def test_preprocess_save_dir(base_concat_ds, windows_concat_ds, tmp_path,
                              kind, save, overwrite, n_jobs):
     preproc_kwargs = [


### PR DESCRIPTION
There was a bug if `n_jobs` was negative, unfortunately introduced in my previous PR. https://github.com/braindecode/braindecode/pull/515/files#diff-58fe27778a3432802bf24c1fb1f014f8f870aaadd9294390a8bd27900295c6b2L136

Should be fixed and tested with this PR.