### PR TITLE
[augmentation] fix type hints for Output of Transform.forward

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
       run: python --version
     # Update pip
     - name: Update pip
-      run: pip install --upgrade pip
+      run: python -m pip install --upgrade pip
     - name: Install Braindecode from Current Checkout
       run: pip install -e .[moabb,tests]
     # Show Braindecode Version

--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -25,9 +25,9 @@ Output = Union[
 ]
 # (X, y) -> (X', y') where y' can be a tensor or a tuple of tensors
 Operation = Callable[
-    [torch.Tensor, torch.Tensor], 
+    [torch.Tensor, torch.Tensor],
     Tuple[
-        torch.Tensor, 
+        torch.Tensor,
         Union[torch.Tensor, Tuple[torch.Tensor, ...]]
     ]
 ]

--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -5,7 +5,7 @@
 #          Valentin Iovene <val@too.gy>
 # License: BSD (3-clause)
 
-from typing import List, Tuple, Any, Optional, Union, Callable, TypeAlias
+from typing import List, Tuple, Any, Optional, Union, Callable
 from numbers import Real
 
 from sklearn.utils import check_random_state
@@ -16,12 +16,15 @@ from torch.utils.data._utils.collate import default_collate
 
 from .functional import identity
 
-Batch: TypeAlias = List[Tuple[torch.Tensor, int, Any]]
-Output: TypeAlias = Union[
+Batch = List[Tuple[torch.Tensor, int, Any]]
+Output = Union[
+    # just outputing X
     torch.Tensor,
+    # outputing (X, y) where y can be a tensor or tuple of tensors
     Tuple[torch.Tensor, Union[torch.Tensor, Tuple[torch.Tensor, ...]]]
 ]
-Operation: TypeAlias = Callable[
+# (X, y) -> (X', y') where y' can be a tensor or a tuple of tensors
+Operation = Callable[
     [torch.Tensor, torch.Tensor], 
     Tuple[
         torch.Tensor, 

--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -2,9 +2,10 @@
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Bruno Aristimunha <b.aristimunha@gmail.com>
 #          Martin Wimpff <martin.wimpff@iss.uni-stuttgart.de>
+#          Valentin Iovene <val@too.gy>
 # License: BSD (3-clause)
 
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Optional, Union, Callable
 from numbers import Real
 
 from sklearn.utils import check_random_state
@@ -16,7 +17,10 @@ from torch.utils.data._utils.collate import default_collate
 from .functional import identity
 
 Batch = List[Tuple[torch.Tensor, int, Any]]
-Output = Tuple[torch.Tensor, torch.Tensor]
+Output = Union[
+    torch.Tensor,
+    Tuple[torch.Tensor, Union[torch.Tensor, Tuple[torch.Tensor, ...]]]
+]
 
 
 class Transform(torch.nn.Module):
@@ -36,7 +40,9 @@ class Transform(torch.nn.Module):
         Used to decide whether or not to transform given the probability
         argument. Defaults to None.
     """
-    operation = None
+    operation: Callable[[torch.Tensor, torch.Tensor], Tuple[
+        torch.Tensor, Union[torch.Tensor, Tuple[torch.Tensor, ...]]
+    ]]
 
     def __init__(self, probability=1.0, random_state=None):
         super().__init__()
@@ -54,7 +60,7 @@ class Transform(torch.nn.Module):
     def get_augmentation_params(self, *batch):
         return dict()
 
-    def forward(self, X: Tensor, y: Tensor = None) -> Output:
+    def forward(self, X: Tensor, y: Optional[Tensor] = None) -> Output:
         """General forward pass for an augmentation transform.
 
         Parameters
@@ -87,7 +93,7 @@ class Transform(torch.nn.Module):
             out_y = torch.zeros(out_X.shape[0], device=out_X.device)
 
         # Samples a mask setting for each example whether they should stay
-        # inchanged or not
+        # unchanged or not
         mask = self._get_mask(out_X.shape[0], out_X.device)
         num_valid = mask.sum().long()
 
@@ -98,7 +104,7 @@ class Transform(torch.nn.Module):
                 **self.get_augmentation_params(out_X[mask, ...], out_y[mask])
             )
             # Apply the operation defining the Transform to the whole batch
-            if type(tr_y) is tuple:
+            if isinstance(tr_y, tuple):
                 out_y = tuple(tmp_y[mask] for tmp_y in tr_y)
             else:
                 out_y[mask] = tr_y
@@ -199,8 +205,10 @@ class AugmentedDataLoader(DataLoader):
         elif isinstance(transforms, list):
             self.collated_tr = _make_collateable(Compose(transforms), device=device)
         else:
-            raise TypeError("transforms can be either a Transform object" +
-                            " or a list of Transform objects.")
+            raise TypeError(
+                "transforms can be either a Transform object "
+                "or a list of Transform objects."
+            )
 
         super().__init__(
             dataset,

--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -5,7 +5,7 @@
 #          Valentin Iovene <val@too.gy>
 # License: BSD (3-clause)
 
-from typing import List, Tuple, Any, Optional, Union, Callable
+from typing import List, Tuple, Any, Optional, Union, Callable, TypeAlias
 from numbers import Real
 
 from sklearn.utils import check_random_state
@@ -16,10 +16,17 @@ from torch.utils.data._utils.collate import default_collate
 
 from .functional import identity
 
-Batch = List[Tuple[torch.Tensor, int, Any]]
-Output = Union[
+Batch: TypeAlias = List[Tuple[torch.Tensor, int, Any]]
+Output: TypeAlias = Union[
     torch.Tensor,
     Tuple[torch.Tensor, Union[torch.Tensor, Tuple[torch.Tensor, ...]]]
+]
+Operation: TypeAlias = Callable[
+    [torch.Tensor, torch.Tensor], 
+    Tuple[
+        torch.Tensor, 
+        Union[torch.Tensor, Tuple[torch.Tensor, ...]]
+    ]
 ]
 
 
@@ -40,9 +47,7 @@ class Transform(torch.nn.Module):
         Used to decide whether or not to transform given the probability
         argument. Defaults to None.
     """
-    operation: Callable[[torch.Tensor, torch.Tensor], Tuple[
-        torch.Tensor, Union[torch.Tensor, Tuple[torch.Tensor, ...]]
-    ]]
+    operation: Operation
 
     def __init__(self, probability=1.0, random_state=None):
         super().__init__()

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -56,6 +56,7 @@ Enhancements
 - Standardizing models' last layer names (:gh:`520` by `Bruna Lopes`_ and `Pierre Guetschel`_)
 - Add basic training example with MNE epochs (:gh:`539` by `Pierre Guetschel`_)
 - Log validation accuracy in :class:`braindecode.EEGClassifier` (:gh:`541` by `Pierre Guetschel`_)
+- Better type hints in :mod:`braindecode.augmentation.base` (:gh:`551` by `Valentin Iovene`_)
 
 Bugs
 ~~~~
@@ -238,3 +239,4 @@ Authors
 .. _Bruna Lopes: https://github.com/brunaafl
 .. _Sylvain Chevallier: https://github.com/sylvchev
 .. _Remi Delbouys: https://github.com/remidbs
+.. _Valentin Iovene: https://github.com/tgy


### PR DESCRIPTION
- [x] fix `Output` type annotation, now reflecting that it can return `y` as a
      tuple of `torch.Tensor`
- [x] define new `Operation` type hint, to annotate the `Transform.operation`
      attribute, to better check operation return types
- [x] define `Batch`, `Output` and `Operation` as type aliases
