### PR TITLE
Add `"recording"` to `keys` in `RecordingSampler`; docs fix

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -461,7 +461,7 @@ class BaseConcatDataset(ConcatDataset):
             Index of window and target to return. If provided as a list of
             ints, multiple windows and targets will be extracted and
             concatenated. The target output can be modified on the
-            fly by the ``traget_transform`` parameter.
+            fly by the ``target_transform`` parameter.
         """
         if isinstance(idx, Iterable):  # Sample multiple windows
             item = self._get_sequence(idx)

--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -61,8 +61,11 @@ class RecordingSampler(Sampler):
         -------
             See class attributes.
         """
-        keys = [k for k in ["subject", "session", "run", "recording"]
-                if k in self.metadata.columns]
+        keys = [
+            k
+            for k in ["subject", "session", "run", "recording"]
+            if k in self.metadata.columns
+        ]
         if not keys:
             raise ValueError(
                 "metadata must contain at least one of the following columns: "

--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -18,8 +18,8 @@ class RecordingSampler(Sampler):
     Parameters
     ----------
     metadata : pd.DataFrame
-        DataFrame with at least one of {subject, session, run} columns for each
-        window in the BaseConcatDataset to sample examples from. Normally
+        DataFrame with at least one of {subject, session, run, recording} columns
+        for each window in the BaseConcatDataset to sample examples from. Normally
         obtained with `BaseConcatDataset.get_metadata()`. For instance,
         `metadata.head()` might look like this:
 
@@ -61,7 +61,8 @@ class RecordingSampler(Sampler):
         -------
             See class attributes.
         """
-        keys = [k for k in ["subject", "session", "run"] if k in self.metadata.columns]
+        keys = [k for k in ["subject", "session", "run", "recording"]
+                if k in self.metadata.columns]
         if not keys:
             raise ValueError(
                 "metadata must contain at least one of the following columns: "
@@ -115,7 +116,11 @@ class SequenceSampler(RecordingSampler):
     n_windows : int
         Number of consecutive windows in a sequence.
     n_windows_stride : int
-        Number of windows between two consecutive sequences.
+        Number of windows between two consecutive starts of sequences.
+        n_windows_stride=1 is maximal overlap.
+        n_windows_stride=n_windows is minimal overlap.
+        n_windows_stride>n_windows skips (n_windows_stride-n_windows) windows
+        between every consecutive sequence.
     random : bool
         If True, sample sequences randomly. If False, sample sequences in
         order.

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -38,6 +38,7 @@ Enhancements
 - Add ``offset`` arg to :function:`braindecode.preprocessing.preprocess` (:gh:`599` by `Pierre Guetschel`_)
 - Add type hints to preprocessing (:gh:`600` by `Pierre Guetschel`_)
 - Add ``mypy`` type checks to pre-commit and CI (:gh:`606` by `Pierre Guetschel`_)
+- Add `"recording"` to `keys` in `RecordingSampler`; docs fix (:gh:`614` by `John Muradeli`_)
 
 Bugs
 ~~~~


### PR DESCRIPTION
 - Recordings are incorrectly treated as contiguous by `SequenceSampler` due to lack of `groupby` upon `"recording"`. I'm unsure this is the intended fix, but it does work.
 - `plot_sleep_staging_chambon2018` calls `n_windows = n_windows_stride` "maximal overlap", but that doesn't make sense to me, isn't it minimal overlap? Updated docs accordingly.
 - typo fix