### PR TITLE
[MNT] Fix matplotlib colormaps deprecation

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -47,6 +47,7 @@ Bugs
 - Constraint the version of mne (:gh: 594 by `Bruno Aristimunha`_)
 - Fix type errors (:gh:`606` by `Pierre Guetschel`_)
 - Warn when applying preprocessing steps on a :class:`braindecode.datasets.base.EEGWindowsDataset` (:gh:`607` by `Pierre Guetschel`_)
+- Fix matplotlib colormaps deprecation (:gh:`608` by `Bruno Aristimunha`_)
 
 API changes
 ~~~~~~~~~~~

--- a/examples/advanced_training/plot_relative_positioning.py
+++ b/examples/advanced_training/plot_relative_positioning.py
@@ -477,7 +477,7 @@ print(classification_report(data["test"][1], test_y_pred))
 # of the feature space using a PCA:
 
 from sklearn.decomposition import PCA
-from matplotlib import cm
+from matplotlib import colormaps
 
 X = np.concatenate([v[0] for k, v in data.items()])
 y = np.concatenate([v[1] for k, v in data.items()])
@@ -487,7 +487,7 @@ pca = PCA(n_components=2)
 components = pca.fit_transform(X)
 
 fig, ax = plt.subplots()
-colors = cm.get_cmap("viridis", 5)(range(5))
+colors = colormaps["viridis"](range(5))
 for i, stage in enumerate(["W", "N1", "N2", "N3", "R"]):
     mask = y == i
     ax.scatter(


### PR DESCRIPTION
Matplotlib, since version 3.9, released yesterday, May 17th, does not support `get_cmap` function. They recommend using `colormap[name]` instead.

`colormap` was introduced in matplotlib 3.5 on May 16/11/2021, and since then, they have warned users to change this get_cmap.

The matplotlib warning:

```bash
 MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
  colors = cm.get_cmap("viridis", 5)(range(5))
```
As colormap has been present in matplotlib since 2021, it doesn't affect users or force users to update matplotlib.