### PR TITLE
Add MaskEncoding augmentation

### DIFF
--- a/braindecode/augmentation/__init__.py
+++ b/braindecode/augmentation/__init__.py
@@ -20,6 +20,7 @@ from .transforms import (
     SensorsXRotation,
     Mixup,
     SegmentationReconstruction,
+    MaskEncoding,
 )
 
 from . import functional
@@ -45,5 +46,6 @@ __all__ = [
     "SensorsXRotation",
     "Mixup",
     "SegmentationReconstruction",
+    "MaskEncoding",
     "functional",
 ]

--- a/braindecode/augmentation/functional.py
+++ b/braindecode/augmentation/functional.py
@@ -1043,7 +1043,7 @@ def segmentation_reconstruction(
     return aug_data, y
 
 
-def mask_encoding(X, y, time_start, segment_length, splits):
+def mask_encoding(X, y, time_start, segment_length, n_segments):
     """Replaces a contiguous part (or parts) of all channels by zeros
     (if more than one segment, it may overlap).
 
@@ -1057,11 +1057,11 @@ def mask_encoding(X, y, time_start, segment_length, splits):
          EEG labels for the example or batch.
      time_start : torch.Tensor
          Tensor of integers containing the position (in last dimension) where to
-         start masking the signal. Should have "splits" times the size of the first
-         dimension of X (i.e. "splits" start positions per example in the batch).
+         start masking the signal. Should have "n_segments" times the size of the first
+         dimension of X (i.e. "n_segments" start positions per example in the batch).
      segment_length: int
          Length of each segment to zero out.
-     splits : int
+     n_segments : int
          Number of segments to zero out in each example.
 
      Returns
@@ -1079,7 +1079,7 @@ def mask_encoding(X, y, time_start, segment_length, splits):
      32 (2024): 875-886.
     """
 
-    batch_indices = torch.arange(X.shape[0]).repeat_interleave(splits)
+    batch_indices = torch.arange(X.shape[0]).repeat_interleave(n_segments)
     start_indices = time_start.flatten()
     mask_indices = start_indices[:, None] + torch.arange(segment_length)
 

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -1192,7 +1192,7 @@ class MaskEncoding(Transform):
         Float setting the probability of applying the operation.
     max_mask_ratio: float, optional
         Signal ratio to zero out. Defaults to 0.1.
-    splits : int, optional
+    n_segments : int, optional
         Number of segments to zero out in each example.
         Defaults to 1.
     random_state: int | numpy.random.Generator, optional
@@ -1213,7 +1213,7 @@ class MaskEncoding(Transform):
         self,
         probability,
         max_mask_ratio=0.1,
-        splits=1,
+        n_segments=1,
         random_state=None,
     ):
         super().__init__(
@@ -1221,14 +1221,14 @@ class MaskEncoding(Transform):
             random_state=random_state,
         )
         assert (
-            isinstance(splits, int) and splits > 0
-        ), "splits should be a positive integer."
+            isinstance(n_segments, int) and n_segments > 0
+        ), "n_segments should be a positive integer."
         assert (
             isinstance(max_mask_ratio, (int, float)) and 0 <= max_mask_ratio <= 1
         ), "mask_ratio should be a float between 0 and 1."
 
         self.mask_ratio = max_mask_ratio
-        self.splits = splits
+        self.n_segments = n_segments
 
     def get_augmentation_params(self, *batch):
         """Return transform parameters.
@@ -1250,19 +1250,19 @@ class MaskEncoding(Transform):
 
         batch_size, _, n_times = X.shape
 
-        segment_length = int((n_times * self.mask_ratio) / self.splits)
+        segment_length = int((n_times * self.mask_ratio) / self.n_segments)
 
         assert (
             segment_length >= 1
-        ), "splits should be a positive integer not higher than (max_mask_ratio * window size)."
+        ), "n_segments should be a positive integer not higher than (max_mask_ratio * window size)."
 
         time_start = self.rng.randint(
-            0, n_times - segment_length, (batch_size, self.splits)
+            0, n_times - segment_length, (batch_size, self.n_segments)
         )
         time_start = torch.from_numpy(time_start)
 
         return {
             "time_start": time_start,
             "segment_length": segment_length,
-            "splits": self.splits,
+            "n_segments": self.n_segments,
         }

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -26,6 +26,7 @@ from .functional import sign_flip
 from .functional import smooth_time_mask
 from .functional import time_reverse
 from .functional import segmentation_reconstruction
+from .functional import mask_encoding
 
 
 class TimeReverse(Transform):
@@ -1176,4 +1177,92 @@ class SegmentationReconstruction(Transform):
             "data_classes": data_classes,
             "rand_indices": rand_indices,
             "idx_shuffle": idx_shuffle,
+        }
+
+
+class MaskEncoding(Transform):
+    """Replaces randomly chosen contiguous part (or parts) of all channels by
+    zeros (if more than one segment, it may overlap).
+
+    Implementation based on [1]_
+
+    Parameters
+    ----------
+    probability : float
+        Float setting the probability of applying the operation.
+    max_mask_ratio: float, optional
+        Signal ratio to zero out. Defaults to 0.1.
+    splits : int, optional
+        Number of segments to zero out in each example.
+        Defaults to 1.
+    random_state: int | numpy.random.Generator, optional
+        Seed to be used to instantiate numpy random number generator instance.
+        Defaults to None.
+
+    References
+    ----------
+    .. [1] Ding, Wenlong, et al. "A Novel Data Augmentation Approach
+    Using Mask Encoding for Deep Learning-Based Asynchronous SSVEP-BCI."
+    IEEE Transactions on Neural Systems and Rehabilitation Engineering
+    32 (2024): 875-886.
+    """
+
+    operation = staticmethod(mask_encoding)  # type: ignore[assignment]
+
+    def __init__(
+        self,
+        probability,
+        max_mask_ratio=0.1,
+        splits=1,
+        random_state=None,
+    ):
+        super().__init__(
+            probability=probability,
+            random_state=random_state,
+        )
+        assert (
+            isinstance(splits, int) and splits > 0
+        ), "splits should be a positive integer."
+        assert (
+            isinstance(max_mask_ratio, (int, float)) and 0 <= max_mask_ratio <= 1
+        ), "mask_ratio should be a float between 0 and 1."
+
+        self.mask_ratio = max_mask_ratio
+        self.splits = splits
+
+    def get_augmentation_params(self, *batch):
+        """Return transform parameters.
+
+        Parameters
+        ----------
+        X : tensor.Tensor
+            The data.
+        y : tensor.Tensor
+            The labels.
+        Returns
+        -------
+        params : dict
+            Contains ...
+        """
+        if len(batch) == 0:
+            return super().get_augmentation_params(*batch)
+        X = batch[0]
+
+        batch_size, _, n_times = X.shape
+
+        segment_length = int((n_times * self.mask_ratio) / self.splits)
+
+        assert (
+            segment_length >= 1
+        ), "splits should be a positive integer not higher than (max_mask_ratio * window size)."
+
+        time_start = self.rng.randint(
+            0, n_times - segment_length, (batch_size, self.splits)
+        )
+        time_start = torch.from_numpy(time_start)
+
+        return {
+            "time_start": time_start,
+            "segment_length": segment_length,
+            "splits": self.splits,
         }

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -221,6 +221,7 @@ Augmentation
     SensorsXRotation
     Mixup
     SegmentationReconstruction
+    MaskEncoding
 
     functional.identity
     functional.time_reverse
@@ -236,6 +237,7 @@ Augmentation
     functional.sensors_rotation
     functional.mixup
     functional.segmentation_reconstruction
+    functional.mask_encoding
 
 
 Utils

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -43,6 +43,7 @@ Enhancements
 - Add two models :class:`braindecode.models.ContraWR` and :class:`braindecode.models.SPARCNet` (:gh:`611` by `Bruno Aristimunha`_)
 - Optimize the CI by executing only the last commit (:gh:`612` by `Bruno Aristimunha`_)
 - Add experimental `lazy_metadata` parameter to :function:`braindecode.preprocessing.create_fixed_length_windows` (:gh:`597` by `Pierre Guetschel`_)
+- Add MaskEncoding augmentation :class:`braindecode.augmentation.MaskEncoding` (:gh:`631` by `Gustavo Rodrigues`_)
 
 Bugs
 ~~~~

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -38,7 +38,7 @@ def dummy_transform():
     return DummyTransform()
 
 
-def common_tranform_assertions(
+def common_transform_assertions(
         input_batch,
         output_batch,
         expected_X=None,
@@ -101,7 +101,7 @@ def test_transform_composition(random_batch, k1, k2, expected, p1, p2):
     concat_transform = Compose([dummy_transform1, dummy_transform2])
     expected_tensor = torch.ones(X.shape, device=X.device) * expected
 
-    common_tranform_assertions(random_batch, concat_transform(X, y), expected_tensor)
+    common_transform_assertions(random_batch, concat_transform(X, y), expected_tensor)
 
 
 def test_transform_proba_exception(rng_seed, dummy_transform):

--- a/test/unit_tests/augmentation/test_transforms.py
+++ b/test/unit_tests/augmentation/test_transforms.py
@@ -692,7 +692,7 @@ def test_segmentation_rec_with_large_n_segments(time_aranged_batch):
 
 
 @pytest.mark.parametrize(
-    "max_mask_ratio, splits, fail",
+    "max_mask_ratio, n_segments, fail",
     [
         (3, 1, True),
         (0, 1, True),
@@ -705,19 +705,19 @@ def test_segmentation_rec_with_large_n_segments(time_aranged_batch):
 def test_mask_encoding_transform(
         rng_seed,
         max_mask_ratio,
-        splits,
+        n_segments,
         fail,
 ):
     if fail:
         with pytest.raises(AssertionError):
             # Check max_mask_ratio cannot be outside interval [0,1] and
-            # splits must be a positive integer
+            # n_segments must be a positive integer
             transform = MaskEncoding(
                 1.0, max_mask_ratio=max_mask_ratio,
-                splits=splits,
+                n_segments=n_segments,
                 random_state=rng_seed,
             )
-            # Check splits cannot be higher than (max_mask_ratio * window_size)
+            # Check n_segments cannot be higher than (max_mask_ratio * window_size)
             ones_batch = ones_and_zeros_batch()
             common_transform_assertions(
                 ones_batch, transform(*ones_batch)
@@ -726,7 +726,7 @@ def test_mask_encoding_transform(
         ones_batch = ones_and_zeros_batch()
         transform = MaskEncoding(
             1.0, max_mask_ratio=max_mask_ratio,
-            splits=splits, random_state=rng_seed,
+            n_segments=n_segments, random_state=rng_seed,
         )
 
         transformed_batch = transform(*ones_batch)
@@ -739,7 +739,7 @@ def test_mask_encoding_transform(
         transformed_X = transformed_batch[0]
         _, _, n_times = transformed_X.shape
 
-        segment_length = int((n_times * max_mask_ratio) / splits)
+        segment_length = int((n_times * max_mask_ratio) / n_segments)
         for sample in transformed_X:
             # check that the number of zeros in the masked matrix is at least
             # segment_length

--- a/test/unit_tests/augmentation/test_transforms.py
+++ b/test/unit_tests/augmentation/test_transforms.py
@@ -2,7 +2,7 @@
 #          Gustavo Rodrigues <gustavenrique01@gmail.com>
 #
 # License: BSD (3-clause)
-from test.unit_tests.augmentation.test_base import common_tranform_assertions
+from test.unit_tests.augmentation.test_base import common_transform_assertions
 from test.dataset import concat_windows_dataset, concat_ds_targets
 
 import numpy as np
@@ -79,7 +79,7 @@ def test_time_reverse_transform(time_aranged_batch, probability):
             .float()
         )
 
-    common_tranform_assertions(
+    common_transform_assertions(
         time_aranged_batch, flip_transform(*time_aranged_batch), expected_tensor
     )
 
@@ -99,7 +99,7 @@ def test_sign_flip_transform(time_aranged_batch, probability):
             .float()
         )
 
-    common_tranform_assertions(
+    common_transform_assertions(
         time_aranged_batch, sign_flip_transform(*time_aranged_batch), expected_tensor
     )
 
@@ -137,7 +137,7 @@ def test_ft_surrogate_transforms(
         phase_noise_magnitude=phase_noise_magnitude,
         channel_indep=channel_indep,
     )
-    common_tranform_assertions(
+    common_transform_assertions(
         random_batch,
         transform(*random_batch),
         diff_param=phase_noise_magnitude if diff else None,
@@ -175,7 +175,7 @@ def test_channels_dropout_transform(rng_seed, p_drop, diff):
     transform = ChannelsDropout(1, p_drop=p_drop, random_state=rng_seed)
     new_batch = transform(*ones_batch)
     tr_X, _ = new_batch
-    common_tranform_assertions(ones_batch, new_batch, diff_param=p_drop if diff else None)
+    common_transform_assertions(ones_batch, new_batch, diff_param=p_drop if diff else None)
     zeros_mask = np.all(tr_X.detach().cpu().numpy() <= 1e-3, axis=-1)
     average_nb_of_zero_rows = np.mean(np.sum(zeros_mask.astype(int), axis=-1))
     proportion_of_zeros = transform.p_drop
@@ -194,7 +194,7 @@ def test_channels_shuffle_transform(rng_seed, ch_aranged_batch, p_shuffle):
     transform = ChannelsShuffle(1, p_shuffle=p_shuffle, random_state=rng_seed)
     new_batch = transform(*ch_aranged_batch)
     tr_X, _ = new_batch
-    common_tranform_assertions(ch_aranged_batch, new_batch)
+    common_transform_assertions(ch_aranged_batch, new_batch)
     # test that rows (channels) are conserved
     assert all([torch.equal(tr_X[0, :, 0], tr_X[0, :, i]) for i in range(tr_X.shape[2])])
     # test that rows (channels) have been shuffled
@@ -227,7 +227,7 @@ def test_gaussian_noise_transform(rng_seed, probability, diff):
     transform = GaussianNoise(probability, std=std, random_state=rng_seed)
     new_batch = transform(*ones_batch)
     tr_X, _ = new_batch
-    common_tranform_assertions(ones_batch, new_batch, diff_param=std if diff else None)
+    common_transform_assertions(ones_batch, new_batch, diff_param=std if diff else None)
 
     if probability == 1.0:
         # check that the values of X changed, but the rows and cols means are
@@ -302,7 +302,7 @@ def test_channels_symmetry_transform(probability):
 
     ordered_batch = (X, torch.zeros(batch_size))
 
-    common_tranform_assertions(ordered_batch, transform(*ordered_batch), expected_tensor)
+    common_transform_assertions(ordered_batch, transform(*ordered_batch), expected_tensor)
 
 
 @pytest.mark.parametrize(
@@ -336,7 +336,7 @@ def test_smooth_time_mask_transform(
             1.0, mask_len_samples=mask_len_samples, random_state=rng_seed
         )
         transformed_batch = transform(*ones_batch)
-        common_tranform_assertions(
+        common_transform_assertions(
             ones_batch, transformed_batch, diff_param=mask_len_samples if diff else None
         )
 
@@ -377,7 +377,7 @@ def test_bandstop_filter_transform(rng_seed, random_batch, bandwidth, fail):
         )
 
         transformed_batch = transform(*random_batch)
-        common_tranform_assertions(random_batch, transformed_batch)
+        common_transform_assertions(random_batch, transformed_batch)
 
         if transform.bandwidth > 0:
             # Transform white noise
@@ -458,7 +458,7 @@ def test_frequency_shift_transform(
     )
 
     transformed_batch = transform(*random_batch)
-    common_tranform_assertions(
+    common_transform_assertions(
         random_batch, transformed_batch, diff_param=max_shift if diff else None
     )
 
@@ -576,7 +576,7 @@ def test_sensors_rotation_transforms(
             random_state=rng_seed,
         )
         transformed_batch = transform(*cropped_random_batch)
-        common_tranform_assertions(
+        common_transform_assertions(
             cropped_random_batch,
             transformed_batch,
             diff_param=max_degrees if diff else None,
@@ -674,7 +674,7 @@ def test_segmentation_reconstruction_transform(
         probability=1.0,
         n_segments=n_segments,
     )
-    common_tranform_assertions(
+    common_transform_assertions(
         time_aranged_batch, transform(*time_aranged_batch), X
     )
 
@@ -686,7 +686,7 @@ def test_segmentation_rec_with_large_n_segments(time_aranged_batch):
         n_segments=100,
     )
     with pytest.raises(ValueError):
-        common_tranform_assertions(
+        common_transform_assertions(
             time_aranged_batch, transform(*time_aranged_batch), X
         )
 
@@ -719,7 +719,7 @@ def test_mask_encoding_transform(
             )
             # Check splits cannot be higher than (max_mask_ratio * window_size)
             ones_batch = ones_and_zeros_batch()
-            common_tranform_assertions(
+            common_transform_assertions(
                 ones_batch, transform(*ones_batch)
             )
     else:
@@ -730,7 +730,7 @@ def test_mask_encoding_transform(
         )
 
         transformed_batch = transform(*ones_batch)
-        common_tranform_assertions(
+        common_transform_assertions(
             ones_batch, transformed_batch
         )
 


### PR DESCRIPTION
Hi, I've implemented another data augmentation class called MaskEncoding. 

The idea is similar to SmoothTimeMask but there is no smoothing of the masking. In addition, the masking can be divided into parts and spread across the signal (these parts can overlap, and I chose to leave it this way). This implementation was initially based on [this article](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=10439237), and I modified it as I saw appropriate.

Adresses #628 