### PR TITLE
Check if self._description is None before set_description.

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -280,6 +280,9 @@ class EEGWindowsDataset(BaseDataset):
             dataset description.
         """
         description = _create_description(description)
+        if self._description is None:
+            self._description = description
+            return
         for key, value in description.items():
             # if they key is already in the existing description, drop it
             if key in self._description:
@@ -404,6 +407,9 @@ class WindowsDataset(BaseDataset):
             dataset description.
         """
         description = _create_description(description)
+        if self._description is None:
+            self._description = description
+            return
         for key, value in description.items():
             # if they key is already in the existing description, drop it
             if key in self._description:


### PR DESCRIPTION
The original code does not work when WindowsDataset object is created by **def _create_description**, etc.
The function above creates objects with a NoneType self._description, which causes error when using method **set_description**.