### PR TITLE
MTN unpin sckit-learn after skorch release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ dependencies = [
     'matplotlib',
     'h5py',
     'skorch',
-    # TODO: remove this once skorch release
-    'scikit-learn<1.6',
     'torch',
     'torchaudio',
     'einops',


### PR DESCRIPTION
`skorch 1.1.0` got release last week, fixing compat issues with the lastest `scikit-learn`. (skorch-dev/skorch#1088)
This PR removes the pinned version.