### PR TITLE
fix joblib usage for NMT dataset

### DIFF
--- a/braindecode/datasets/nmt.py
+++ b/braindecode/datasets/nmt.py
@@ -155,10 +155,8 @@ class NMT(BaseConcatDataset):
             ]
         else:
             base_datasets = Parallel(n_jobs)(
-                delayed(
-                    self._create_dataset(d, target_name, preload)
-                    for recording_id, d in description.iterrows()
-                )
+                delayed(self._create_dataset)(d, target_name, preload)
+                for recording_id, d in description.iterrows()
             )
 
         super().__init__(base_datasets)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -60,6 +60,7 @@ Enhancements
 - Exposing :class:`braindecode.models.EEGITNet` hyper-parameters (:gh:`672` by `Bruno Aristimunha`_)
 - Adding :class:`braindecode.models.SincShallowNet` (:gh:`678` by `Bruno Aristimunha`_ )
 - Adding :class:`braindecode.models.SCCNet` (:gh:`679` by `Bruno Aristimunha`_ )
+- Fix error when using NMT dataset with n_jobs > 1 (:gh:`690` by `Aphel`_)
 
 Bugs
 ~~~~


### PR DESCRIPTION
Currently, when `n_jobs > 1` on the NMT dataset, it will fail with an error:

```
  File "/projects/eeg/venv/lib/python3.11/site-packages/braindecode/datasets/nmt.py", line 157, in __init__
    base_datasets = Parallel(n_jobs)(
                    ^^^^^^^^^^^^^^^^^
  File "/projects/eeg/venv/lib/python3.11/site-packages/joblib/parallel.py", line 1970, in __call__
    iterator = iter(iterable)
               ^^^^^^^^^^^^^^
TypeError: 'function' object is not iterable
```

This PR fixes the invocation of joblib to resolve that bug.