### PR TITLE
Bump `actions/upload-artifact` to v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
           cd docs
           make html
       - name: Upload HTML Docs as Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: HTML-Docs
           path: ./docs/_build/


### PR DESCRIPTION
The docs job seems to be erroring due to the deprecation of `actions/upload-artifact@v3`: https://github.com/braindecode/braindecode/actions/runs/13089486769/job/36524496412?pr=690

This PR bumps it to v4. I reviewed the migration guide [here](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md): I _think_ it should be fine, but I don't know for sure what the value of `GITHUB_ARTIFACT_URL` is in CircleCI. I've checked the archive of the last successful docs build - it doesn't look like there's any hidden files of concern.

This PR will need a `no changelog` label