### PR TITLE
[FIX] Making the MOABB dataset work with BIDS cache

### DIFF
--- a/braindecode/datasets/moabb.py
+++ b/braindecode/datasets/moabb.py
@@ -56,8 +56,13 @@ def _fetch_and_unpack_moabb_data(dataset, subject_ids=None, dataset_load_kwargs=
 
 
 def _annotations_from_moabb_stim_channel(raw, dataset):
-    # find events from stim channel
-    events = mne.find_events(raw)
+    # find events from the stim channel
+    stim_channels = mne.utils._get_stim_channel(None, raw.info, raise_error=False)
+    if len(stim_channels) > 0:
+        # returns an empty array if none found
+        events = mne.find_events(raw, shortest_event=0, verbose=False)
+    else:
+        events, _ = mne.events_from_annotations(raw, verbose=False)
 
     # get annotations from events
     event_desc = {k: v for v, k in dataset.event_id.items()}
@@ -141,7 +146,7 @@ class MOABBDataset(BaseConcatDataset):
         dataset_load_kwargs: dict[str, Any] | None = None,
     ):
         # soft dependency on moabb
-        from moabb import __version__ as moabb_version
+        from moabb import __version__ as moabb_version  # type: ignore[attr-defined]
 
         if moabb_version == "1.0.0":
             warnings.warn(

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -75,7 +75,7 @@ Bugs
 - Deprecate moabb version 1.0.0 because of incorrect epoching (:gh:`627` by `Pierre Guetschel`_)
 - Fixing tutorial benchmark lazy eager loagin (:gh:`` by `Bruno Aristimunha`_ and `Aphel`_)
 - Improve doc build's time with better caching (:gh:`693` by `Thomas Moreau`_)
-- Fixing the MOABBDataset to work with the cache (:gh:`XXX` by `Bruno Aristimunha`_)
+- Fixing the MOABBDataset to work with the cache (:gh:`694` by `Bruno Aristimunha`_)
 
 API changes
 ~~~~~~~~~~~

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -75,6 +75,7 @@ Bugs
 - Deprecate moabb version 1.0.0 because of incorrect epoching (:gh:`627` by `Pierre Guetschel`_)
 - Fixing tutorial benchmark lazy eager loagin (:gh:`` by `Bruno Aristimunha`_ and `Aphel`_)
 - Improve doc build's time with better caching (:gh:`693` by `Thomas Moreau`_)
+- Fixing the MOABBDataset to work with the cache (:gh:`XXX` by `Bruno Aristimunha`_)
 
 API changes
 ~~~~~~~~~~~


### PR DESCRIPTION
Code to test:
```python
from braindecode.datasets import MOABBDataset
from braindecode.preprocessing import create_windows_from_events
cache_config = dict(
    use=True,
    path="~/mne_data",
    save_raw=True,
    save_epochs=False,
    save_array=False,
    overwrite_raw=False,
    overwrite_epochs=False,
    overwrite_array=False,
)

dataset = MOABBDataset("AlexMI", subject_ids=[1], dataset_load_kwargs={'cache_config': cache_config})

windows = create_windows_from_events(dataset)
```

