### PR TITLE
Distributed samplers for recording and relative positioning sampling

### DIFF
--- a/braindecode/samplers/__init__.py
+++ b/braindecode/samplers/__init__.py
@@ -1,7 +1,7 @@
 """Classes to sample examples."""
 
 from .base import RecordingSampler, SequenceSampler, BalancedSequenceSampler, DistributedRecordingSampler
-from .ssl import RelativePositioningSampler
+from .ssl import RelativePositioningSampler, DistributedRelativePositioningSampler
 
 __all__ = [
     "RecordingSampler",
@@ -9,4 +9,5 @@ __all__ = [
     "BalancedSequenceSampler",
     "RelativePositioningSampler",
     "DistributedRecordingSampler",
+    "DistributedRelativePositioningSampler",
 ]

--- a/braindecode/samplers/__init__.py
+++ b/braindecode/samplers/__init__.py
@@ -1,6 +1,11 @@
 """Classes to sample examples."""
 
-from .base import RecordingSampler, SequenceSampler, BalancedSequenceSampler, DistributedRecordingSampler
+from .base import (
+    RecordingSampler,
+    SequenceSampler,
+    BalancedSequenceSampler,
+    DistributedRecordingSampler,
+)
 from .ssl import RelativePositioningSampler, DistributedRelativePositioningSampler
 
 __all__ = [

--- a/braindecode/samplers/__init__.py
+++ b/braindecode/samplers/__init__.py
@@ -1,6 +1,6 @@
 """Classes to sample examples."""
 
-from .base import RecordingSampler, SequenceSampler, BalancedSequenceSampler
+from .base import RecordingSampler, SequenceSampler, BalancedSequenceSampler, DistributedRecordingSampler
 from .ssl import RelativePositioningSampler
 
 __all__ = [
@@ -8,4 +8,5 @@ __all__ = [
     "SequenceSampler",
     "BalancedSequenceSampler",
     "RelativePositioningSampler",
+    "DistributedRecordingSampler",
 ]

--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -113,6 +113,7 @@ class RecordingSampler(Sampler):
     def n_recordings(self):
         return self.info.shape[0]
 
+
 class DistributedRecordingSampler(DistributedSampler):
     """Base sampler simplifying sampling from recordings in distributed setting.
 
@@ -146,11 +147,12 @@ class DistributedRecordingSampler(DistributedSampler):
         Additional keyword arguments to pass to torch DistributedSampler.
         See https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler
     """
+
     def __init__(
-            self, 
-            metadata,
-            random_state=None,
-            **kwargs,
+        self,
+        metadata,
+        random_state=None,
+        **kwargs,
     ):
         self.metadata = metadata
         self.info = self._init_info(metadata)
@@ -203,15 +205,6 @@ class DistributedRecordingSampler(DistributedSampler):
         return self.rng.choice(list(super().__iter__()))
 
     def sample_window(self, rec_ind=None):
-        """Return a specific window.
-        """
-        # XXX docstring missing
-        if rec_ind is None:
-            rec_ind = self.sample_recording()
-        win_ind = self.rng.choice(self.info.iloc[rec_ind]['index'])
-        return win_ind, rec_ind
-
-    def sample_window(self, rec_ind=None):
         """Return a specific window."""
         # XXX docstring missing
         if rec_ind is None:
@@ -222,6 +215,7 @@ class DistributedRecordingSampler(DistributedSampler):
     @property
     def n_recordings(self):
         return super().__len__()
+
 
 class SequenceSampler(RecordingSampler):
     """Sample sequences of consecutive windows.

--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -146,12 +146,13 @@ class DistributedRecordingSampler(DistributedSampler):
             self, 
             metadata,
             random_state=None,
+            shuffle=None,
     ):
         self.metadata = metadata
         self.info = self._init_info(metadata)
         self.rng = check_random_state(random_state)
         # send information to DistributedSampler parent to handle data splitting among workers
-        super().__init__(self.info, random_state)
+        super().__init__(self.info, shuffle=shuffle)
          # super iter should contain only indices of datasets specific to the current process
         self._iterator = list(super().__iter__())
 
@@ -223,7 +224,7 @@ class DistributedRecordingSampler(DistributedSampler):
 
     @property
     def n_recordings(self):
-        return self.__len__()
+        return len(self._iterator)
 
 class SequenceSampler(RecordingSampler):
     """Sample sequences of consecutive windows.

--- a/braindecode/samplers/ssl.py
+++ b/braindecode/samplers/ssl.py
@@ -230,6 +230,6 @@ class DistributedRelativePositioningSampler(DistributedRecordingSampler):
                 yield self.examples[i]
             else:
                 yield self._sample_pair()
-
+                
     def __len__(self):
         return self.n_examples

--- a/braindecode/samplers/ssl.py
+++ b/braindecode/samplers/ssl.py
@@ -8,6 +8,7 @@ Self-supervised learning samplers.
 # License: BSD (3-clause)
 
 import numpy as np
+import warnings
 
 from . import RecordingSampler, DistributedRecordingSampler
 import torch.distributed as dist
@@ -184,8 +185,10 @@ class DistributedRelativePositioningSampler(DistributedRecordingSampler):
         self.same_rec_neg = same_rec_neg
 
         self.n_examples = n_examples // self.info.shape[0] * self.n_recordings
-        print(f"Rank {dist.get_rank()} - Number of datasets:", self.n_recordings)
-        print(f"Rank {dist.get_rank()} - Number of samples:", self.n_examples)
+        warnings.warn(
+            f"Rank {dist.get_rank()} - Number of datasets:", self.n_recordings
+        )
+        warnings.warn(f"Rank {dist.get_rank()} - Number of samples:", self.n_examples)
 
         if not same_rec_neg and self.n_recordings < 2:
             raise ValueError(

--- a/braindecode/samplers/ssl.py
+++ b/braindecode/samplers/ssl.py
@@ -112,13 +112,17 @@ class RelativePositioningSampler(RecordingSampler):
         return self
 
     def __iter__(self):
-        """Iterate over pairs.
+        """
+        Iterate over pairs.
 
         Yields
         ------
-            (int): position of the first window in the dataset.
-            (int): position of the second window in the dataset.
-            (float): 0 for negative pair, 1 for positive pair.
+        int
+            Position of the first window in the dataset.
+        int
+            Position of the second window in the dataset.
+        float
+            0 for a negative pair, 1 for a positive pair.
         """
         for i in range(self.n_examples):
             if hasattr(self, "examples"):
@@ -131,7 +135,7 @@ class RelativePositioningSampler(RecordingSampler):
 
 
 class DistributedRelativePositioningSampler(DistributedRecordingSampler):
-    """Sample examples for the relative positioning task from [Banville2020]_. in distributed mode.
+    """Sample examples for the relative positioning task from [Banville2020]_ in distributed mode.
 
     Sample examples as tuples of two window indices, with a label indicating
     whether the windows are close or far, as defined by tau_pos and tau_neg.
@@ -159,6 +163,7 @@ class DistributedRelativePositioningSampler(DistributedRecordingSampler):
     kwargs: dict
         Additional keyword arguments to pass to torch DistributedSampler.
         See https://pytorch.org/docs/stable/data.html#torch.utils.data.distributed.DistributedSampler
+
     References
     ----------
     .. [Banville2020] Banville, H., Chehab, O., Hyvärinen, A., Engemann, D. A.,
@@ -188,7 +193,7 @@ class DistributedRelativePositioningSampler(DistributedRecordingSampler):
         warnings.warn(
             f"Rank {dist.get_rank()} - Number of datasets:", self.n_recordings
         )
-        warnings.warn(f"Rank {dist.get_rank()} - Number of samples:", self.n_examples)
+        warnings.warn(f"Rank {dist.get_rank()} - Number of samples: {self.n_examples}")
 
         if not same_rec_neg and self.n_recordings < 2:
             raise ValueError(
@@ -235,13 +240,17 @@ class DistributedRelativePositioningSampler(DistributedRecordingSampler):
         return self
 
     def __iter__(self):
-        """Iterate over pairs.
+        """
+        Iterate over pairs.
 
         Yields
         ------
-            (int): position of the first window in the dataset.
-            (int): position of the second window in the dataset.
-            (float): 0 for negative pair, 1 for positive pair.
+        int
+            Position of the first window in the dataset.
+        int
+            Position of the second window in the dataset.
+        float
+            0 for a negative pair, 1 for a positive pair.
         """
         for i in range(self.n_examples):
             if hasattr(self, "examples"):

--- a/braindecode/samplers/ssl.py
+++ b/braindecode/samplers/ssl.py
@@ -191,7 +191,7 @@ class DistributedRelativePositioningSampler(DistributedRecordingSampler):
 
         self.n_examples = n_examples // self.info.shape[0] * self.n_recordings
         warnings.warn(
-            f"Rank {dist.get_rank()} - Number of datasets:", self.n_recordings
+            f"Rank {dist.get_rank()} - Number of datasets: {self.n_recordings}"
         )
         warnings.warn(f"Rank {dist.get_rank()} - Number of samples: {self.n_examples}")
 

--- a/braindecode/samplers/ssl.py
+++ b/braindecode/samplers/ssl.py
@@ -8,7 +8,8 @@ Self-supervised learning samplers.
 
 import numpy as np
 
-from . import RecordingSampler
+from . import RecordingSampler, DistributedRecordingSampler
+import torch.distributed as dist
 
 
 class RelativePositioningSampler(RecordingSampler):
@@ -119,6 +120,113 @@ class RelativePositioningSampler(RecordingSampler):
         """
         for i in range(self.n_examples):
             if hasattr(self, "examples"):
+                yield self.examples[i]
+            else:
+                yield self._sample_pair()
+
+    def __len__(self):
+        return self.n_examples
+
+class DistributedRelativePositioningSampler(DistributedRecordingSampler):
+    """Sample examples for the relative positioning task from [Banville2020]_.
+
+    Sample examples as tuples of two window indices, with a label indicating
+    whether the windows are close or far, as defined by tau_pos and tau_neg.
+
+    Parameters
+    ----------
+    metadata : pd.DataFrame
+        See RecordingSampler.
+    tau_pos : int
+        Size of the positive context, in samples. A positive pair contains two
+        windows x1 and x2 which are separated by at most `tau_pos` samples.
+    tau_neg : int
+        Size of the negative context, in samples. A negative pair contains two
+        windows x1 and x2 which are separated by at least `tau_neg` samples and
+        at most `tau_max` samples. Ignored if `same_rec_neg` is False.
+    n_examples : int
+        Number of pairs to extract.
+    tau_max : int | None
+        See `tau_neg`.
+    same_rec_neg : bool
+        If True, sample negative pairs from within the same recording. If
+        False, sample negative pairs from two different recordings.
+    random_state : None | np.RandomState | int
+        Random state.
+
+    References
+    ----------
+    .. [Banville2020] Banville, H., Chehab, O., Hyvärinen, A., Engemann, D. A.,
+           & Gramfort, A. (2020). Uncovering the structure of clinical EEG
+           signals with self-supervised learning.
+           arXiv preprint arXiv:2007.16104.
+    """
+    def __init__(self, metadata, tau_pos, tau_neg, n_samples_per_dataset, 
+                 tau_max=None, same_rec_neg=True, random_state=None, shuffle=True):
+        super().__init__(metadata, random_state=random_state, shuffle=shuffle)
+        self.tau_pos = tau_pos
+        self.tau_neg = tau_neg
+        self.tau_max = np.inf if tau_max is None else tau_max
+        self.same_rec_neg = same_rec_neg
+        if not same_rec_neg and self.n_recordings < 2:
+            raise ValueError('More than one recording must be available when '
+                             'using across-recording negative sampling.')
+
+        self.n_examples = n_samples_per_dataset * len(self._iterator)
+        print(f"rank {dist.get_rank()} - Number of datasets:", len(self._iterator))
+        print(f"rank {dist.get_rank()} - Number of samples:", self.n_examples) 
+
+    def _sample_pair(self):
+        """Sample a pair of two windows.
+        """
+        # Sample first window
+        win_ind1, rec_ind1 = self.sample_window()
+        ts1 = self.metadata.iloc[win_ind1]['i_start_in_trial']
+        ts = self.info.iloc[rec_ind1]['i_start_in_trial']
+
+        # Decide whether the pair will be positive or negative
+        pair_type = self.rng.binomial(1, 0.5)
+        win_ind2 = None
+        if pair_type == 0:  # Negative example
+            if self.same_rec_neg:
+                mask = (
+                    ((ts <= ts1 - self.tau_neg) & (ts >= ts1 - self.tau_max)) |
+                    ((ts >= ts1 + self.tau_neg) & (ts <= ts1 + self.tau_max))
+                )
+            else:
+                rec_ind2 = rec_ind1
+                while rec_ind2 == rec_ind1:
+                    win_ind2, rec_ind2 = self.sample_window()
+        elif pair_type == 1:  # Positive example
+            mask = (ts >= ts1 - self.tau_pos) & (ts <= ts1 + self.tau_pos)
+
+        if win_ind2 is None:
+            mask[ts == ts1] = False  # same window cannot be sampled twice
+            if sum(mask) == 0:
+                raise NotImplementedError
+            win_ind2 = self.rng.choice(self.info.iloc[rec_ind1]['index'][mask])
+
+        return win_ind1, win_ind2, float(pair_type)
+
+    def presample(self):
+        """Presample examples.
+
+        Once presampled, the examples are the same from one epoch to another.
+        """
+        self.examples = [self._sample_pair() for _ in range(self.n_examples)]
+        return self
+
+    def __iter__(self):
+        """Iterate over pairs.
+
+        Yields
+        ------
+            (int): position of the first window in the dataset.
+            (int): position of the second window in the dataset.
+            (float): 0 for negative pair, 1 for positive pair.
+        """
+        for i in range(self.n_examples):
+            if hasattr(self, 'examples'):
                 yield self.examples[i]
             else:
                 yield self._sample_pair()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -199,8 +199,10 @@ Samplers
    :toctree: generated/
 
    RecordingSampler
+   DistributedRecordingSampler
    SequenceSampler
    RelativePositioningSampler
+   DistributedRelativePositioningSampler
    BalancedSequenceSampler
 
 .. _augmentation_api:

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -61,6 +61,7 @@ Enhancements
 - Adding :class:`braindecode.models.SincShallowNet` (:gh:`678` by `Bruno Aristimunha`_ )
 - Adding :class:`braindecode.models.SCCNet` (:gh:`679` by `Bruno Aristimunha`_ )
 - Fix error when using NMT dataset with n_jobs > 1 (:gh:`690` by `Aphel`_)
+- Adding support for distributed samplers (:gh:`695` by `Young Truong`_)
 
 Bugs
 ~~~~
@@ -303,3 +304,4 @@ Authors
 .. _John Muradeli: https://github.com/OverLordGoldDragon/
 .. _Gustavo Rodrigues: https://github.com/gustavohenriquesr
 .. _Aphel: https://github.com/itsaphel
+.. _Young Truong: https://github.com/dungscout96

--- a/test/unit_tests/datautil/test_serialization.py
+++ b/test/unit_tests/datautil/test_serialization.py
@@ -308,6 +308,7 @@ def test_load_concat_raw_dataset_parallel(setup_concat_raw_dataset, tmpdir):
         loaded_concat_raw_dataset = load_concat_dataset(
             path=tmpdir, preload=False, n_jobs=2
         )
+        warnings.warn("", UserWarning)
         assert len(raised_warnings) >= 0
     assert len(concat_raw_dataset) == len(loaded_concat_raw_dataset)
     assert len(concat_raw_dataset.datasets) == len(

--- a/test/unit_tests/samplers/test_samplers.py
+++ b/test/unit_tests/samplers/test_samplers.py
@@ -140,6 +140,9 @@ def dist_sampler_init_process(rank, world_size, windows_ds):
     # Cleanup
     dist.destroy_process_group()
 
+
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason="Not supported on Windows because of use_libuv compatibility")
 def test_distributed_recording_sampler(windows_ds):
     world_size = 1  # Test single process - no dataset splitting
     mp.spawn(dist_sampler_init_process, args=(world_size,windows_ds), nprocs=world_size, join=True)

--- a/test/unit_tests/samplers/test_samplers.py
+++ b/test/unit_tests/samplers/test_samplers.py
@@ -8,6 +8,7 @@ Test for samplers.
 # License: BSD (3-clause)
 
 import bisect
+import platform
 
 import pytest
 import numpy as np
@@ -255,6 +256,9 @@ def distributed_relative_positioning_sampler_init_process(rank, world_size, wind
         assert all(pairs_df.loc[pairs_df["y"] == 1, "same_rec"] == True)  # noqa: E712
     assert abs(np.diff(pairs_df["y"].value_counts())) < 20
 
+
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason="Not supported on Windows because of use_libuv compatibility")
 @pytest.mark.parametrize("same_rec_neg", [True, False])
 def test_distributed_relative_positioning_sampler(windows_ds, same_rec_neg):
     world_size = 1

--- a/test/unit_tests/samplers/test_samplers.py
+++ b/test/unit_tests/samplers/test_samplers.py
@@ -100,7 +100,7 @@ def test_recording_sampler(windows_ds):
 def dist_sampler_init_process(rank, world_size, windows_ds):
     """Initialize the process group for multi-CPU training."""
     dist.init_process_group(
-        backend="gloo", 
+        backend="gloo",
         init_method="tcp://127.0.0.1:29500",  # Localhost for single machine
         rank=rank,
         world_size=world_size
@@ -111,7 +111,7 @@ def dist_sampler_init_process(rank, world_size, windows_ds):
     if world_size == 1:
         sampler_single = RecordingSampler(windows_ds.get_metadata(), random_state=87)
         assert sampler.n_recordings == windows_ds.description.shape[0] == sampler_single.n_recordings
-    assert len(sampler.dataset) == windows_ds.description.shape[0] 
+    assert len(sampler.dataset) == windows_ds.description.shape[0]
     assert sampler.n_recordings <= windows_ds.description.shape[0] // world_size
     print(f"Rank {rank} has {sampler.n_recordings} datasets after splitting")
 
@@ -209,13 +209,13 @@ def test_relative_positioning_sampler_presample(windows_ds):
 
 def distributed_relative_positioning_sampler_init_process(rank, world_size, windows_ds, same_rec_neg):
     dist.init_process_group(
-        backend="gloo", 
+        backend="gloo",
         init_method="tcp://127.0.0.1:29500",  # Localhost for single machine
         rank=rank,
         world_size=world_size
     )
     print(f"Process {rank} initialized")
-    
+
     tau_pos, tau_neg = 2000, 3000
     n_examples = 100
     sampler = DistributedRelativePositioningSampler(
@@ -256,7 +256,7 @@ def distributed_relative_positioning_sampler_init_process(rank, world_size, wind
 
 @pytest.mark.parametrize("same_rec_neg", [True, False])
 def test_distributed_relative_positioning_sampler(windows_ds, same_rec_neg):
-    world_size = 1  
+    world_size = 1
     mp.spawn(distributed_relative_positioning_sampler_init_process, args=(world_size, windows_ds, same_rec_neg), nprocs=world_size, join=True)
 
 @pytest.mark.parametrize("n_windows,n_windows_stride", [[10, 5], [10, 100], [1, 1]])

--- a/test/unit_tests/samplers/test_samplers.py
+++ b/test/unit_tests/samplers/test_samplers.py
@@ -145,6 +145,7 @@ def test_distributed_recording_sampler(windows_ds):
     world_size = 3  # Test multiple processes - dataset splitting
     mp.spawn(dist_sampler_init_process, args=(world_size,windows_ds), nprocs=world_size, join=True)
 
+
 @pytest.mark.parametrize("same_rec_neg", [True, False])
 def test_relative_positioning_sampler(windows_ds, same_rec_neg):
     tau_pos, tau_neg = 2000, 3000


### PR DESCRIPTION
Adding support for distributed sampling by creating new classes `DistributedRecordingSampler` (which subclass `torch.utils.data.distributed.DistributedSampler`), and `DistributedRelativePositioningSampler` which subclass the recording sampler. The split into two classes for distributed vs non-distributed cases is not ideal but torch's distributed sampler doesn't take another torch.utils.data.sampler as input and only takes a Dataset (reference [source code](https://github.com/pytorch/pytorch/blob/main/torch/utils/data/distributed.py)). But maybe there's a better way to consolidate them.