### PR TITLE
Add `BIDSDataset`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         run: pip install --upgrade pip
       # Install with MOABB and docs dependencies
       - name: Install with doc dependencies
-        run: pip install -e .[moabb,docs]
+        run: pip install -e .[moabb,docs,bids]
       # Show Braindecode Version
       - run: python -c "import braindecode; print(braindecode.__version__)"
       - name: Create Docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Update pip
       run: python -m pip install --upgrade pip
     - name: Install Braindecode from Current Checkout
-      run: pip install -e .[moabb,tests]
+      run: pip install -e .[moabb,tests,bids]
     # Show Braindecode Version
     - run: python -c "import braindecode; print(braindecode.__version__)"
 

--- a/braindecode/datasets/__init__.py
+++ b/braindecode/datasets/__init__.py
@@ -3,7 +3,7 @@ Loader code for some datasets.
 """
 
 from .base import WindowsDataset, BaseDataset, BaseConcatDataset
-from .bids import BIDSDataset
+from .bids import BIDSDataset, BIDSEpochsDataset
 from .moabb import MOABBDataset, HGD, BNCI2014001
 from .mne import create_from_mne_raw, create_from_mne_epochs
 from .tuh import TUH, TUHAbnormal
@@ -18,6 +18,7 @@ __all__ = [
     "BaseDataset",
     "BaseConcatDataset",
     "BIDSDataset",
+    "BIDSEpochsDataset",
     "MOABBDataset",
     "HGD",
     "BNCI2014001",

--- a/braindecode/datasets/__init__.py
+++ b/braindecode/datasets/__init__.py
@@ -3,6 +3,7 @@ Loader code for some datasets.
 """
 
 from .base import WindowsDataset, BaseDataset, BaseConcatDataset
+from .bids import BIDSDataset
 from .moabb import MOABBDataset, HGD, BNCI2014001
 from .mne import create_from_mne_raw, create_from_mne_epochs
 from .tuh import TUH, TUHAbnormal
@@ -16,6 +17,7 @@ __all__ = [
     "WindowsDataset",
     "BaseDataset",
     "BaseConcatDataset",
+    "BIDSDataset",
     "MOABBDataset",
     "HGD",
     "BNCI2014001",

--- a/braindecode/datasets/bids.py
+++ b/braindecode/datasets/bids.py
@@ -162,7 +162,7 @@ class BIDSDataset(BaseConcatDataset):
         # (argument ignore_json only available in mne-bids>=0.16)
         bids_paths = [
             bids_path for bids_path in bids_paths if bids_path.extension != ".json"
-            ]
+        ]
         all_base_ds = Parallel(n_jobs=self.n_jobs)(
             delayed(self._get_dataset)(bids_path) for bids_path in bids_paths
         )

--- a/braindecode/datasets/bids.py
+++ b/braindecode/datasets/bids.py
@@ -99,11 +99,6 @@ class BIDSDataset(BaseConcatDataset):
         (default), the ``.check`` attribute of the returned
         :class:`mne_bids.BIDSPath` object will be set to ``True`` for paths that
         do conform to BIDS, and to ``False`` for those that don't.
-    ignore_json : bool
-        If ``True``, ignores json files. Defaults to ``False``.
-    ignore_nosub : bool
-        If ``True``, ignores all files that are not of the form ``root/sub-*``.
-        Defaults to ``False``.
     preload : bool
         If True, preload the data. Defaults to False.
     n_jobs : int
@@ -142,8 +137,6 @@ class BIDSDataset(BaseConcatDataset):
     )
     datatypes: str | list[str] | None = "eeg"
     check: bool = False
-    ignore_json: bool = True
-    ignore_nosub: bool = False
     preload: bool = False
     n_jobs: int = 1
 
@@ -164,9 +157,10 @@ class BIDSDataset(BaseConcatDataset):
             extensions=self.extensions,
             datatypes=self.datatypes,
             check=self.check,
-            ignore_json=self.ignore_json,
-            ignore_nosub=self.ignore_nosub,
         )
+        # Filter out .json files:
+        # (argument ignore_json only available in mne-bids>=0.16)
+        bids_paths = [bids_path for bids_path in bids_paths if bids_path.extension != ".json"]
         all_base_ds = Parallel(n_jobs=self.n_jobs)(
             delayed(self._get_dataset)(bids_path) for bids_path in bids_paths
         )

--- a/braindecode/datasets/bids.py
+++ b/braindecode/datasets/bids.py
@@ -146,12 +146,6 @@ class BIDSDataset(BaseConcatDataset):
     n_jobs: int = 1
 
     def __post_init__(self):
-        from mne_bids import __version__ as mne_bids_version
-
-        assert (
-            mne_bids_version >= "0.16"
-        ), f"mne-bids version must be >= 0.16, got {mne_bids_version}"
-
         bids_paths = mne_bids.find_matching_paths(
             root=self.root,
             subjects=self.subjects,

--- a/braindecode/datasets/bids.py
+++ b/braindecode/datasets/bids.py
@@ -160,7 +160,9 @@ class BIDSDataset(BaseConcatDataset):
         )
         # Filter out .json files:
         # (argument ignore_json only available in mne-bids>=0.16)
-        bids_paths = [bids_path for bids_path in bids_paths if bids_path.extension != ".json"]
+        bids_paths = [
+            bids_path for bids_path in bids_paths if bids_path.extension != ".json"
+            ]
         all_base_ds = Parallel(n_jobs=self.n_jobs)(
             delayed(self._get_dataset)(bids_path) for bids_path in bids_paths
         )

--- a/braindecode/datasets/bids.py
+++ b/braindecode/datasets/bids.py
@@ -1,0 +1,210 @@
+"""Dataset for loading BIDS.
+
+More information on BIDS (Brain Imaging Data Structure) can be found at https://bids.neuroimaging.io
+"""
+
+# Authors: Pierre Guetschel <pierre.guetschel@gmail.com>
+#
+# License: BSD (3-clause)
+
+from __future__ import annotations
+from typing import Any
+from dataclasses import dataclass, field
+from pathlib import Path
+from joblib import Parallel, delayed
+
+import mne
+import mne_bids
+
+from .base import BaseDataset, BaseConcatDataset, EEGWindowsDataset
+
+
+def _descriptiion_from_bids_path(bids_path: mne_bids.BIDSPath) -> dict[str, Any]:
+    return {
+        "path": bids_path.fpath,
+        "subject": bids_path.subject,
+        "session": bids_path.session,
+        "task": bids_path.task,
+        "acquisition": bids_path.acquisition,
+        "run": bids_path.run,
+        "processing": bids_path.processing,
+        "recording": bids_path.recording,
+        "space": bids_path.space,
+        "split": bids_path.split,
+        "description": bids_path.description,
+        "suffix": bids_path.suffix,
+        "extension": bids_path.extension,
+        "datatype": bids_path.datatype,
+    }
+
+
+@dataclass
+class BIDSDataset(BaseConcatDataset):
+    """Dataset for loading BIDS.
+
+    This class has the same parameters as the :function:`mne_bids.find_matching_paths` function
+    as it will be used to find the files to load. The default parameters were changed.
+
+    More information on BIDS (Brain Imaging Data Structure) can be found at https://bids.neuroimaging.io
+
+    Parameters
+    ----------
+    root : pathlib.Path | str
+        The root of the BIDS path.
+    subjects : str | array-like of str | None
+        The subject ID. Corresponds to "sub".
+    sessions : str | array-like of str | None
+        The acquisition session. Corresponds to "ses".
+    tasks : str | array-like of str | None
+        The experimental task. Corresponds to "task".
+    acquisitions: str | array-like of str | None
+        The acquisition parameters. Corresponds to "acq".
+    runs : str | array-like of str | None
+        The run number. Corresponds to "run".
+    processings : str | array-like of str | None
+        The processing label. Corresponds to "proc".
+    recordings : str | array-like of str | None
+        The recording name. Corresponds to "rec".
+    spaces : str | array-like of str | None
+        The coordinate space for anatomical and sensor location
+        files (e.g., ``*_electrodes.tsv``, ``*_markers.mrk``).
+        Corresponds to "space".
+        Note that valid values for ``space`` must come from a list
+        of BIDS keywords as described in the BIDS specification.
+    splits : str | array-like of str | None
+        The split of the continuous recording file for ``.fif`` data.
+        Corresponds to "split".
+    descriptions : str | array-like of str | None
+        This corresponds to the BIDS entity ``desc``. It is used to provide
+        additional information for derivative data, e.g., preprocessed data
+        may be assigned ``description='cleaned'``.
+    suffixes : str | array-like of str | None
+        The filename suffix. This is the entity after the
+        last ``_`` before the extension. E.g., ``'channels'``.
+        The following filename suffix's are accepted:
+        'meg', 'markers', 'eeg', 'ieeg', 'T1w',
+        'participants', 'scans', 'electrodes', 'coordsystem',
+        'channels', 'events', 'headshape', 'digitizer',
+        'beh', 'physio', 'stim'
+    extensions : str | array-like of str | None
+        The extension of the filename. E.g., ``'.json'``.
+        By default, uses the ones accepted by :function:`mne_bids.read_raw_bids`.
+    datatypes : str | array-like of str | None
+        The BIDS data type, e.g., ``'anat'``, ``'func'``, ``'eeg'``, ``'meg'``,
+        ``'ieeg'``.
+    check : bool
+        If ``True``, only returns paths that conform to BIDS. If ``False``
+        (default), the ``.check`` attribute of the returned
+        :class:`mne_bids.BIDSPath` object will be set to ``True`` for paths that
+        do conform to BIDS, and to ``False`` for those that don't.
+    ignore_json : bool
+        If ``True``, ignores json files. Defaults to ``False``.
+    ignore_nosub : bool
+        If ``True``, ignores all files that are not of the form ``root/sub-*``.
+        Defaults to ``False``.
+    preload : bool
+        If True, preload the data. Defaults to False.
+    n_jobs : int
+        Number of jobs to run in parallel. Defaults to 1.
+    """
+
+    root: Path | str
+    subjects: str | list[str] | None = None
+    sessions: str | list[str] | None = None
+    tasks: str | list[str] | None = None
+    acquisitions: str | list[str] | None = None
+    runs: str | list[str] | None = None
+    processings: str | list[str] | None = None
+    recordings: str | list[str] | None = None
+    spaces: str | list[str] | None = None
+    splits: str | list[str] | None = None
+    descriptions: str | list[str] | None = None
+    suffixes: str | list[str] | None = None
+    extensions: str | list[str] | None = field(
+        default_factory=lambda: [
+            ".con",
+            ".sqd",
+            ".pdf",
+            ".fif",
+            ".ds",
+            ".vhdr",
+            ".set",
+            ".edf",
+            ".bdf",
+            ".EDF",
+            ".snirf",
+            ".cdt",
+            ".mef",
+            ".nwb",
+        ]
+    )
+    datatypes: str | list[str] | None = "eeg"
+    check: bool = False
+    ignore_json: bool = True
+    ignore_nosub: bool = False
+    preload: bool = False
+    n_jobs: int = 1
+
+    def __post_init__(self):
+        from mne_bids import __version__ as mne_bids_version
+
+        assert (
+            mne_bids_version >= "0.16"
+        ), f"mne-bids version must be >= 0.16, got {mne_bids_version}"
+
+        bids_paths = mne_bids.find_matching_paths(
+            root=self.root,
+            subjects=self.subjects,
+            sessions=self.sessions,
+            tasks=self.tasks,
+            acquisitions=self.acquisitions,
+            runs=self.runs,
+            processings=self.processings,
+            recordings=self.recordings,
+            spaces=self.spaces,
+            splits=self.splits,
+            descriptions=self.descriptions,
+            suffixes=self.suffixes,
+            extensions=self.extensions,
+            datatypes=self.datatypes,
+            check=self.check,
+            ignore_json=self.ignore_json,
+            ignore_nosub=self.ignore_nosub,
+        )
+        all_base_ds = Parallel(n_jobs=self.n_jobs)(
+            delayed(self._get_dataset)(bids_path) for bids_path in bids_paths
+        )
+        super().__init__(all_base_ds)
+
+    def _get_dataset(self, bids_path: mne_bids.BIDSPath) -> BaseDataset:
+        description = _descriptiion_from_bids_path(bids_path)
+        raw = mne_bids.read_raw_bids(bids_path, verbose=False)
+        if self.preload:
+            raw.load_data()
+        return BaseDataset(raw, description)
+
+
+class BIDSEpochsDataset(BIDSDataset):
+    """**Experimental** dataset for loading mne.Epochs saved in BIDS.
+
+    Warning: epoched data are not officially supported in BIDS.
+
+    The files must end with ``_epo.fif``.
+
+    This class has the same parameters as :class:`BIDSDataset` except for arguments
+    ``datatypes``, ``extensions`` and ``check`` which are fixed.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            extensions=".fif",
+            datatypes="epo",
+            check=False,
+            **kwargs,
+        )
+
+    def _get_dataset(self, bids_path):
+        description = _descriptiion_from_bids_path(bids_path)
+        epochs = mne.read_epochs(bids_path.fpath)
+        return EEGWindowsDataset(epochs, description)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -61,6 +61,7 @@ Enhancements
 - Adding :class:`braindecode.models.SincShallowNet` (:gh:`678` by `Bruno Aristimunha`_ )
 - Adding :class:`braindecode.models.SCCNet` (:gh:`679` by `Bruno Aristimunha`_ )
 - Fix error when using NMT dataset with n_jobs > 1 (:gh:`690` by `Aphel`_)
+- Add :class:`braindecode.datasets.BIDSDataset` and :class:`braindecode.datasets.BIDSEpochsDataset` plus tutorial (:gh:`701` by `Pierre Guetschel`_ )
 
 Bugs
 ~~~~

--- a/examples/datasets_io/plot_bids_dataset_example.py
+++ b/examples/datasets_io/plot_bids_dataset_example.py
@@ -1,0 +1,37 @@
+"""BIDS Dataset Example
+========================
+
+In this example, we show how to fetch and prepare a BIDS dataset for usage
+with Braindecode.
+"""
+
+# Authors: Pierre Guetschel <pierre.guetschel@gmail.com>
+#
+# License: BSD (3-clause)
+
+from pathlib import Path
+
+import openneuro
+
+from braindecode.datasets import BIDSDataset
+
+
+###############################################################################
+# First, we download a collection of (fake/empty) BIDS datasets.
+
+# import tempfile
+# data_dir = tempfile.mkdtemp()
+data_dir = Path("~/data_local/openneuro/").expanduser()
+dataset_name = "ds004745"  # 200Mb dataset
+dataset_root = data_dir / dataset_name
+
+if not dataset_root.exists():
+    openneuro.download(dataset=dataset_name, target_dir=dataset_root)
+
+###############################################################################
+# Now, loading the dataset is simply a one-line command:
+bids_ds = BIDSDataset(dataset_root)
+
+###############################################################################
+# And we can see that the events of this dataset are set in the ``.annotations`` attribute of the raw data:
+print(bids_ds.datasets[0].raw.annotations)

--- a/examples/datasets_io/plot_bids_dataset_example.py
+++ b/examples/datasets_io/plot_bids_dataset_example.py
@@ -21,7 +21,7 @@ from braindecode.datasets import BIDSDataset
 
 # import tempfile
 # data_dir = tempfile.mkdtemp()
-data_dir = Path("~/data_local/openneuro/").expanduser()
+data_dir = Path("~/mne_data/openneuro/").expanduser()
 dataset_name = "ds004745"  # 200Mb dataset
 dataset_root = data_dir / dataset_name
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ readme = "README.rst"
 requires-python = ">3.9"
 dependencies = [
     'mne', # because of python 3.12
-    'mne_bids>=0.16',
     'numpy',
     'pandas',
     'scipy',
@@ -62,6 +61,7 @@ documentation = "https://braindecode.org/stable/index.html"
 
 [project.optional-dependencies]
 moabb = ["moabb>=1.1.1"]
+bids = ['mne_bids>=0.14']
 tests = [
     'pytest',
     'pytest-cov',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ readme = "README.rst"
 requires-python = ">3.9"
 dependencies = [
     'mne', # because of python 3.12
+    'mne_bids>=0.16',
     'numpy',
     'pandas',
     'scipy',
@@ -79,7 +80,8 @@ docs = [
     'sphinx_design',
     'lightning',
     'seaborn',
-    'pre-commit'
+    'pre-commit',
+    'openneuro-py'
 ]
 
 [build-system]

--- a/test/unit_tests/datasets/test_bids.py
+++ b/test/unit_tests/datasets/test_bids.py
@@ -1,0 +1,58 @@
+# Authors: Pierre Guetschel <pierre.guetschel@gmail.com>
+#
+# License: BSD (3-clause)
+
+import pytest
+
+from moabb.datasets import FakeDataset
+from moabb.paradigms import LeftRightImagery
+from braindecode.datasets import BIDSDataset, BIDSEpochsDataset
+
+
+@pytest.fixture(scope="module")
+def bids_dataset_root(tmpdir_factory):
+    tmp_path = tmpdir_factory.mktemp("bids_root")
+    dataset = FakeDataset(
+        n_subjects=1,
+        n_sessions=1,
+        n_runs=1,
+        stim=True,
+        annotations=True,
+        event_list=["left_hand", "right_hand"],
+    )
+    paradigm = LeftRightImagery()
+    cache_config = dict(
+        save_raw=True,
+        save_epochs=True,
+        save_array=False,
+        use=False,
+        overwrite_raw=False,
+        overwrite_epochs=False,
+        overwrite_array=False,
+        path=tmp_path,
+    )
+    _ = paradigm.get_data(dataset, return_epochs=True, cache_config=cache_config)
+    return (
+        tmp_path
+        / "MNE-BIDS-fake-dataset-imagery-1-1--60--120--lefthand-righthand--c3-cz-c4"
+    )
+
+
+def test_bids_dataset(bids_dataset_root):
+    dataset = BIDSDataset(bids_dataset_root, check=False)
+    assert len(dataset.datasets) == 1
+    assert len(dataset.datasets[0].raw.ch_names) == 3
+    assert len(dataset.datasets[0].raw.annotations) == 60
+    assert set(dataset.datasets[0].raw.annotations.description) == {
+        "left_hand",
+        "right_hand",
+    }
+
+
+def test_bids_epochs_dataset(bids_dataset_root):
+    dataset = BIDSEpochsDataset(bids_dataset_root)
+    assert len(dataset) == 60
+    x, y, _ = dataset[0]
+    assert x.shape[0] == 3
+    assert x.ndim == 2
+    assert y in ["left_hand", "right_hand"]

--- a/test/unit_tests/datasets/test_bids.py
+++ b/test/unit_tests/datasets/test_bids.py
@@ -39,7 +39,7 @@ def bids_dataset_root(tmpdir_factory):
 
 
 def test_bids_dataset(bids_dataset_root):
-    dataset = BIDSDataset(bids_dataset_root, check=False)
+    dataset = BIDSDataset(bids_dataset_root)
     assert len(dataset.datasets) == 1
     assert len(dataset.datasets[0].raw.ch_names) == 3
     assert len(dataset.datasets[0].raw.annotations) == 60


### PR DESCRIPTION
This PR adds the possibility to load any BIDS dataset.

In addition, it adds the possibility to load degenerate BIDS containing `mne.Epochs` data (such as the cache from MOABB), which are not officially supported.