### PR TITLE
Enhance model summary page with structured layout, tags, and dropdown filters

### DIFF
--- a/docs/models_summary.rst
+++ b/docs/models_summary.rst
@@ -21,7 +21,7 @@
 .. currentmodule:: braindecode.models
 
 Models Summary
-~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 This page offers a summary of many implemented models. Please note that this list may not be exhaustive. For the definitive and most current list, including detailed class documentation, please consult the :doc:`API documentation <api>`.
 
@@ -31,7 +31,7 @@ We are continually expanding this collection and welcome contributions! If you h
    :alt: Braindecode Models
    :align: center
 
-   Visualization comparing the models based on their total number of parameters (left plot) and the primary experimental they were designed for (right plot).
+   Visualization comparing the models based on their total number of parameters (left plot) and the primary experimental paradigm they were designed for (right plot).
 
 Columns definitions:
     - **Model**: The name of the model.
@@ -52,7 +52,7 @@ Columns definitions:
 The parameter counts shown in the table were calculated using consistent hyperparameters for models within the same paradigm, based largely on Braindecode's default implementation values. These counts provide a relative comparison but may differ from those reported in the original publications due to variations in specific architectural details, input dimensions used in the paper, or calculation methods.
 
 Submit a new model
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 Want to contribute a new model to Braindecode? Great! You can propose a new model by opening an `issue <https://github.com/braindecode/braindecode/issues>`__ (please include a link to the relevant publication or description) or, even better, directly submit your implementation via a `pull request <https://github.com/braindecode/braindecode/pulls>`__. We appreciate your contributions to expanding the library!
 
@@ -87,9 +87,23 @@ Want to contribute a new model to Braindecode? Great! You can propose a new mode
 
         table.column(colIdx).data().each(function (d) {
           if (d) {
-            var plainText = $('<div>').html(d).text();  // Remove HTML tags
-            plainText.split(/[,/]/).forEach(function (tag) {
-              tag = tag.trim();
+            var tags = [];
+            var $temp = $('<div>' + d + '</div>');
+            var $foundTags = $temp.find('.tag');
+
+            if ($foundTags.length > 0) {
+              $foundTags.each(function () {
+                var tag = $(this).text().trim();
+                if (tag) tags.push(tag);
+              });
+            } else {
+              var plainText = $temp.text();
+              tags = plainText.split(/,\s*|\s+/).map(function (tag) {
+                return tag.trim();
+              });
+            }
+
+            tags.forEach(function (tag) {
               if (tag) uniqueTags.add(tag);
             });
           }
@@ -108,7 +122,6 @@ Want to contribute a new model to Braindecode? Great! You can propose a new mode
         $filterContainer.append(select);
       });
 
-      // Clear filters button
       var clearBtn = $('<button>Clear Filters</button>')
         .css({ 'margin-left': '10px', 'padding': '5px 10px', 'cursor': 'pointer' })
         .on('click', function () {

--- a/docs/models_summary.rst
+++ b/docs/models_summary.rst
@@ -1,4 +1,5 @@
 .. _data_summary:
+
 .. raw:: html
 
    <style>
@@ -41,10 +42,14 @@ Columns definitions:
     - **#Parameters**: The approximate total number of trainable parameters in the model, calculated using a consistent configuration (see note below).
 
 .. raw:: html
+
+   <!-- Dropdown filter container -->
+   <div id="custom-filters" style="margin-bottom: 15px;"></div>
+
+.. raw:: html
    :file: generated/models_summary_table.html
 
 The parameter counts shown in the table were calculated using consistent hyperparameters for models within the same paradigm, based largely on Braindecode's default implementation values. These counts provide a relative comparison but may differ from those reported in the original publications due to variations in specific architectural details, input dimensions used in the paper, or calculation methods.
-
 
 Submit a new model
 ~~~~~~~~~~~~~~~~~~~~
@@ -55,14 +60,64 @@ Want to contribute a new model to Braindecode? Great! You can propose a new mode
 
    <script type="text/javascript" src="https://cdn.datatables.net/v/bm/dt-1.13.4/datatables.min.js"></script>
    <script type="text/javascript">
-    $(document).ready(function() {
-     var table = $('.sortable').DataTable({
-       "paging": false,
-       "searching": true,
-       "info": false,
-       language: {
-         "search": "Filter models:"
-       }
-     });
+    $(document).ready(function () {
+      var table = $('.sortable').DataTable({
+        paging: false,
+        searching: true,
+        info: false,
+        language: {
+          search: "Filter models:"
+        }
+      });
+
+      var filterColumns = {
+        1: "Select Paradigm",
+        2: "Choose Model Type",
+        4: "Select Required Hyperparameter"
+      };
+
+      var $filterContainer = $('#custom-filters');
+      var dropdowns = {};
+
+      $.each(filterColumns, function (colIdx, label) {
+        var select = $('<select><option value="" disabled selected>' + label + '</option></select>')
+          .css({ 'margin-right': '10px', 'padding': '5px', 'margin-bottom': '10px' });
+
+        var uniqueTags = new Set();
+
+        table.column(colIdx).data().each(function (d) {
+          if (d) {
+            var plainText = $('<div>').html(d).text();  // Remove HTML tags
+            plainText.split(/[,/]/).forEach(function (tag) {
+              tag = tag.trim();
+              if (tag) uniqueTags.add(tag);
+            });
+          }
+        });
+
+        Array.from(uniqueTags).sort().forEach(function (tag) {
+          select.append('<option value="' + tag + '">' + tag + '</option>');
+        });
+
+        select.on('change', function () {
+          var val = $(this).val();
+          table.column(colIdx).search(val ? val : '', true, false).draw();
+        });
+
+        dropdowns[colIdx] = select;
+        $filterContainer.append(select);
+      });
+
+      // Clear filters button
+      var clearBtn = $('<button>Clear Filters</button>')
+        .css({ 'margin-left': '10px', 'padding': '5px 10px', 'cursor': 'pointer' })
+        .on('click', function () {
+          $.each(dropdowns, function (colIdx, select) {
+            select.prop('selectedIndex', 0);
+            table.column(colIdx).search('').draw();
+          });
+        });
+
+      $filterContainer.append(clearBtn);
     });
    </script>

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -317,3 +317,4 @@ Authors
 .. _Aphel: https://github.com/itsaphel
 .. _Young Truong: https://github.com/dungscout96
 .. _Lucas Heck: https://github.com/lucas-heck
+.. _Ganasekhar Kalla: https://github.com/Ganasekhar-gif

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -22,6 +22,7 @@ Current 0.9 (dev0)
 
 Enhancements
 ~~~~~~~~~~~~
+- Added dropdown menus for selecting `paradigm`, `type`, and `hyperparameters` on the model summary page. (:gh:`718` by `Ganasekhar Kalla`)
 - Adding model page (:gh:`715` by `Lucas Heck`_)
 - Inference of shape for string module when using :class:`skorch.helper.SliceDataset` (:gh:`716` by `Bruno Aristimunha`_)
 - Fix error when using n_njobs > 1 on Windows (:gh:`700` by `Arnaud Delorme`_)


### PR DESCRIPTION
This pull request enhances the models_summary.rst page by introducing a more structured layout and improving interactivity for users. The key improvements include:

✅ Dropdown filters for:
Model Paradigm
Model Type
Required Hyperparameters

Preview of Improved UI with Dropdown Filters and Clear Button:
![Screenshot 2025-04-09 075249](https://github.com/user-attachments/assets/3e698503-1e8d-4db5-b87f-09fffefbf8f3)

✅ Clear button to reset all dropdowns and restore full table view
✅ Improved tag visualization using consistent styling with CSS
✅ More user-friendly layout with a focus on accessibility and clarity
✅ Fixed an issue where the Paradigm filter did not return results due to regex mismatch

Enhances user experience through intuitive navigation of model information
Promotes interactivity and accessibility, helping users filter models based on their needs
Makes the documentation more structured, engaging, and informative, especially for new contributors or researchers

Supports Braindecode’s goal to maintain high-quality, user-friendly documentation
Improves discoverability of models for various EEG paradigms and use-cases

closes #717 