### PR TITLE
Include summary.csv in package data and update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,7 @@ include README.rst
 include LICENSE.txt
 include NOTICE.txt
 
+include braindecode/models/summary.csv
+
 recursive-include docs *.ipynb *.rst conf.py Makefile
 recursive-exclude docs *checkpoint.ipynb

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,11 @@ match = (?!tests/__init__\.py|fixes).*\.py
 add-ignore = D100,D104,D107,D413
 add-select = D214,D215,D404,D405,D406,D407,D408,D409,D410,D411
 ignore-decorators = ^(copy_.*_doc_to_|on_trait_change|cached_property|deprecated|property|.*setter).*
+
+[metadata]
+
+[options]
+include_package_data = True
+
+[options.package_data]
+* = braindecode/models/summary.csv


### PR DESCRIPTION
 -> models/util.py wants to load models/summary.csv but its not downloaded using pip as it was not included in MANIFEST.in and setup.cfg. 

Now it should be possible to use `pip install git+git@github.com:braindecode/braindecode.git` to install current master branch version again and use it without putting summary.csv there manually. 