### PR TITLE
DOC: Fixing broken links and warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,7 +224,6 @@ intersphinx_mapping = {
     "mne": ("http://mne.tools/stable", None),
     "skorch": ("https://skorch.readthedocs.io/en/stable/", None),
     "torch": ("https://pytorch.org/docs/stable/", None),
-    "braindecode": ("https://braindecode.org/", None),
 }
 
 sphinx_gallery_conf = {
@@ -250,10 +249,8 @@ sphinx_gallery_conf = {
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-import sphinx_rtd_theme  # noqa
 
 html_theme = "pydata_sphinx_theme"
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 switcher_version_match = "dev" if release.endswith("dev0") else version
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/help.rst
+++ b/docs/help.rst
@@ -9,7 +9,7 @@ Frequently Asked Questions (FAQ)
 
 How do I cite Braindecode?
 --------------------------
-See  :ref:`cite`.
+See :doc:`cite`.
 
 Help! I can't get Python and Braindecode working!
 -------------------------------------------------
@@ -25,7 +25,7 @@ tell whether it happened because of a bug in Braindecode, a mistake in user
 code, a corrupted data file, or irregularities in the data itself.
 
 Your first step when asking for help should be the `Braindecode Chat
-<https://gitter.im/braindecodechat/community>`_, not GitHub. This bears
+<braindecode-chat_>`_, not GitHub. This bears
 repeating: *the GitHub issue tracker is not for usage help* — it is for
 software bugs, feature requests, and improvements to documentation. If you
 open an issue that contains only a usage question, we will close the issue and
@@ -37,7 +37,7 @@ I think I found a bug, what do I do?
 If you're pretty sure the problem you've encountered
 is a software bug (not bad data or user error):
 
-- Make sure you're using `the most current version`_. You can check it locally
+- Make sure you're using the most current version. You can check it locally
   at a shell prompt with:
 
   .. code-block:: console
@@ -47,28 +47,16 @@ is a software bug (not bad data or user error):
   which will also give you version info about braindecode.
 
 - If you're already on the most current version, if possible try using
-  :ref:`the latest development version <installing_main>`, as the bug may
+  :ref:`the latest development version <install_source>`, as the bug may
   have been fixed already since the latest release. If you can't try the latest
   development version, search the GitHub issues page to see if the problem has
   already been reported and/or fixed.
 
-- Try to replicate the problem with one of the :ref:`MNE sample datasets
-  <datasets>`. If you can't replicate it with a built-in dataset, provide a
-  link to a small, anonymized portion of your data that does yield the error.
-
-If the problem persists, `open a new issue
-<https://github.com/braindecode/braindecode/issues/new>`__
+If the problem persists, `open a new issue <braindecode-issues_>`_
 and include the *smallest possible* code sample that replicates the error
 you're seeing. Paste the code sample into the issue, with a line containing
 three backticks (\`\`\`) above and below the lines of code. This
-`minimal working example`_ should be self-contained, which means that
+`minimal working example <https://en.wikipedia.org/wiki/Minimal_Working_Example>`__
+should be self-contained, which means that
 Braindecode contributors should be able to copy and paste the provided snippet
 and replicate the bug on their own computers.
-
-References
-----------
-
-.. LINKS
-
-.. _`the most current version`: https://github.com/mne-tools/mne-python/releases/latest
-.. _`minimal working example`: https://en.wikipedia.org/wiki/Minimal_Working_Example

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -6,8 +6,8 @@ Installation
 
 Braindecode is written in Python 3, specifically for version 3.8 or above.
 
-The package is distributed via Python package index (`PyPI <https://pypi.org/project/braincode>`__), and you can access the
-source code via `Github <https://github.com/braincode/braindecode>`__ repository.
+The package is distributed via Python package index (`PyPI <braindecode-pypi_>`_), and you can access the
+source code via `Github <braindecode-github_>`_ repository.
 
 There are different ways to install Braindecode, depending on your needs and:
 
@@ -26,7 +26,7 @@ There are different ways to install Braindecode, depending on your needs and:
             For Beginners
 
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-        .. image:: https://braindecode.org/dev/_static/braindecode_install.png
+        .. image:: /_static/braindecode_install.png
            :alt: Braindecode Installer with pip
 
         +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -73,3 +73,5 @@ There are different ways to install Braindecode, depending on your needs and:
 
     install_pip
     install_source
+
+.. include:: /links.inc

--- a/docs/install/install_pip.rst
+++ b/docs/install/install_pip.rst
@@ -3,7 +3,7 @@
 Installing from PyPI
 ~~~~~~~~~~~~~~~~~~~~
 
-Braincode can be installed via pip from `PyPI <https://pypi.org/project/braindecode>`__.
+Braincode can be installed via pip from `PyPI <braindecode-pypi_>`_.
 
 .. note::
     We recommend the most updated version of pip to install from PyPI.
@@ -14,7 +14,7 @@ Below are the installation commands for the most common use cases.
 
    pip install braindecode
 
-Braindecode can also be installed along MOABB to download open datasets:
+Braindecode can also be installed along `MOABB <moabb_>`_ to download open datasets:
 
 .. code-block:: bash
 
@@ -23,7 +23,9 @@ Braindecode can also be installed along MOABB to download open datasets:
 To use the potential of the deep learning modules PyTorch with GPU, we recommend the following sequence before installing the braindecode:
 
 #. Install the latest NVIDIA driver.
-#. Check `PyTorch Official Guide <https://pytorch.org/get-started/locally/>`__, for the recommended CUDA versions. For the Pip package, the user must download the CUDA manually, install it on the system, and ensure CUDA_PATH is appropriately set and working!
+#. Check `PyTorch's <PyTorch_>`_ official guide, for the recommended CUDA versions. For the Pip package, the user must download the CUDA manually, install it on the system, and ensure CUDA_PATH is appropriately set and working!
 #. Continue to follow the guide and install PyTorch.
 
-See `Troubleshooting <braindecode.faq>`__ section if you have a problem.
+See the :doc:`Frequently Asked Questions (FAQ) </help>` section if you have a problem.
+
+.. include:: /links.inc

--- a/docs/install/install_source.rst
+++ b/docs/install/install_source.rst
@@ -7,7 +7,7 @@ If you want to test features under development or contribute to the library, or 
 
 .. note::
 
-   If you are only trying to install Braindecode, we recommend using the pip installation `Installation <https://braindecode.org/braindecode/install/install_pip.html#install-pip>`__ for details on that.
+   If you are only trying to install Braindecode, we recommend the :doc:`Installing from PyPI </install/install_pip>` section for details on that.
 
 
 
@@ -66,4 +66,6 @@ To verify that Braindecode is installed and running correctly, run the following
 
    python -m "import braindecode; braindecode.__version__"
 
-For more information, please see the `contributors' guidelines <https://github.com/braindecode/braindecode/blob/master/CONTRIBUTING.md>`__.
+For more information, please see the `contribution guide <braindecode-contribution-guide_>`_.
+
+.. include:: /links.inc

--- a/docs/links.inc
+++ b/docs/links.inc
@@ -8,194 +8,58 @@
    __not_case_sensitive__, so only one target definition is needed for
    nipy, NIPY, Nipy, etc...
 
+.. braindecode
+
+.. _braindecode: https://braindecode.org
+.. _braindecode-github: https://github.com/braindecode/braindecode
+.. _braindecode-pypi: https://pypi.org/project/braindecode
+.. _braindecode-contribution-guide: https://github.com/braindecode/braindecode/blob/master/CONTRIBUTING.md
+.. _braindecode-chat: https://gitter.im/braindecodechat/community
+.. _braindecode-issues: https://github.com/braindecode/braindecode/issues/
+.. _braindecode-pulls: https://github.com/braindecode/braindecode/pulls/
 
 .. mne
 
-.. _`MNE-Python`: http://mne.tools/mne-python-intro
-.. _`MNE-Python GitHub`: https://github.com/mne-tools/mne-python
-.. _`mne-scripts`: https://github.com/mne-tools/mne-scripts/
-.. _`MNE-C manual`: https://mne.tools/mne-c-manual/MNE-manual-2.7.3.pdf
-.. _`GitHub issues page`: https://github.com/mne-tools/mne-python/issues/
-.. _`MNE Forum`: https://mne.discourse.group
-.. _`MNE-BIDS`: https://mne.tools/mne-bids
-.. _`MNE-BIDS-Pipeline`: https://mne.tools/mne-bids-pipeline
-.. _`MNE-HCP`: http://mne.tools/mne-hcp
-.. _`MNE-Realtime`: https://mne.tools/mne-realtime
-.. _`MNE-MATLAB git repository`: https://github.com/mne-tools/mne-matlab
-.. _`MNE-Docker`: https://github.com/mne-tools/mne-docker
-.. _EOSS2: https://chanzuckerberg.com/eoss/proposals/improving-usability-of-core-neuroscience-analysis-tools-with-mne-python
-.. _EOSS4: https://chanzuckerberg.com/eoss/proposals/building-pediatric-and-clinical-data-pipelines-for-mne-python/
-.. _`code of conduct`: https://github.com/mne-tools/.github/blob/main/CODE_OF_CONDUCT.md
+.. _MNE-Python: http://mne.tools/
+.. _MNE-glossary-data-channels: https://mne.tools/stable/documentation/glossary.html#term-data-channels
+.. _MNE-clinical-60-sleep: https://mne.tools/stable/auto_tutorials/clinical/60_sleep.html
 
+.. moabb
 
-.. TUTORIAL LINKS
+.. _MOABB: https://moabb.neurotechx.com
+.. _MOABB-github: https://github.com/NeuroTechX/moabb
 
-.. _errors: https://en.wikipedia.org/w/index.php?title=Type_I_and_type_II_errors#Table_of_error_types
-.. _fwer: https://en.wikipedia.org/wiki/Family-wise_error_rate
-.. _fdr: https://en.wikipedia.org/wiki/False_discovery_rate
-.. _ft_cluster: http://www.fieldtriptoolbox.org/faq/how_not_to_interpret_results_from_a_cluster-based_permutation_test
-.. _ft_cluster_effect_size: https://mailman.science.ru.nl/pipermail/fieldtrip/2017-September/024644.html
-.. _ft_exch: https://mailman.science.ru.nl/pipermail/fieldtrip/2008-October/001794.html
+.. main dependencies
 
-
-
-.. TEMPLATE FOR LINKS TO OTHER PROJECTS
-.. _PROJECTNAME: http://neuroimaging.scipy.org
-.. _`PROJECTNAME github`: http://github.com/nipy
-.. _`PROJECTNAME mailing list`: http://projects.scipy.org/mailman/listinfo/nipy-devel
-
-.. numpy
-
+.. _PyTorch: https://pytorch.org
+.. _skorch: https://skorch.readthedocs.io/en/stable
+.. _torchvision: https://pytorch.org/vision/stable/index.html
+.. _lightning: https://lightning.ai/pytorch-lightning
 .. _numpy: http://www.numpy.org
-.. _`numpy github`: http://github.com/numpy/numpy
-.. _`numpy mailing list`: http://mail.scipy.org/mailman/listinfo/numpy-discussion
-
-
-.. scipy
-
 .. _scipy: http://www.scipy.org
-.. _`scipy github`: http://github.com/scipy/scipy
-.. _`scipy mailing list`: http://mail.scipy.org/mailman/listinfo/scipy-dev
-
-.. freesurfer
-
-.. _freesurfer: https://surfer.nmr.mgh.harvard.edu/
-.. _`freesufer github`: https://github.com/freesurfer/freesurfer
-.. _`freesurfer mailing list`: https://surfer.nmr.mgh.harvard.edu/fswiki/FreeSurferSupport
-
-
-.. nipy
-
-.. _nipy: http://nipy.org/nipy
-.. _`nipy github`: http://github.com/nipy/nipy
-.. _`nipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
-
-
-.. ipython
-
-.. _ipython: https://ipython.org
-.. _`ipython github`: https://github.com/ipython/ipython
-.. _`ipython mailing list`: https://mail.python.org/mailman/listinfo/ipython-dev
-
-
-.. dipy
-
-.. _dipy: http://nipy.org/dipy
-.. _`dipy github`: http://github.com/Garyfallidis/dipy
-.. _`dipy mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
-
-
-.. nibabel
-
-.. _nibabel: http://nipy.org/nibabel
-.. _`nibabel github`: http://github.com/nipy/nibabel
-.. _`nibabel mailing list`: http://mail.scipy.org/mailman/listinfo/nipy-devel
-
-
-.. h5py
-
 .. _h5py: http://www.h5py.org
-.. _`h5py github`: http://github.com/h5py/h5py
-.. _`h5py mailing list`: https://groups.google.com/forum/#!forum/h5py
-
-
-.. Pytest
-
 .. _pytest: https://docs.pytest.org/
-
-
-.. Flake8
-
 .. _Flake8: http://flake8.pycqa.org/
-
-
-.. pymatreader
-
-.. _pymatreader: https://gitlab.com/obob/pymatreader
-
-
-.. h5io
-
-.. _h5io: https://github.com/h5io/h5io
-
-
-.. CuPy
-
-.. _CuPy: https://cupy.chainer.org/
-
-.. Dask
-
-.. _Dask: https://dask.org/
+.. _coverage: https://pypi.python.org/pypi/coverage
+.. _joblib: https://pypi.python.org/pypi/joblib
+.. _scikit-learn: https://scikit-learn.org/stable/
+.. _matplotlib: https://matplotlib.org/
+.. _sphinx: https://www.sphinx-doc.org/
+.. _pandas: https://pandas.pydata.org/
+.. _tqdm: https://tqdm.github.io/
+.. _pooch: https://www.fatiando.org/pooch/latest/
 
 .. git stuff
 
 .. _git: https://git-scm.com/
 .. _github: https://github.com
-.. _GitHub Help: https://help.github.com
-.. _GitHub learning lab: https://lab.github.com/
-.. _pro git book: https://git-scm.com/book/
-.. _git bash: https://gitforwindows.org/
-.. _git for Windows: https://gitforwindows.org/
-.. _git clone: http://schacon.github.com/git/git-clone.html
-.. _git checkout: https://schacon.github.io/git/git-checkout.html
-.. _git commit: https://schacon.github.io/git/git-commit.html
-.. _git push: https://schacon.github.io/git/git-push.html
-.. _git pull: https://schacon.github.io/git/git-pull.html
-.. _git add: https://schacon.github.io/git/git-add.html
-.. _git status: https://schacon.github.io/git/git-status.html
-.. _git diff: https://schacon.github.io/git/git-diff.html
-.. _git log: https://schacon.github.io/git/git-log.html
-.. _git branch: https://schacon.github.io/git/git-branch.html
-.. _git remote: https://schacon.github.io/git/git-remote.html
-.. _git rebase: https://schacon.github.io/git/git-rebase.html
-.. _git config: https://schacon.github.io/git/git-config.html
 
 .. other stuff
 
 .. _python: http://www.python.org
 .. _Brain Imaging Data Structure: https://bids.neuroimaging.io/
-
-.. python packages
-
-.. _pep8: https://pypi.org/project/pep8/
-.. _pyflakes: https://pypi.org/project/pyflakes
-.. _coverage: https://pypi.python.org/pypi/coverage
-.. _mayavi: https://docs.enthought.com/mayavi/mayavi/
-.. _nitime: http://nipy.org/nitime/
-.. _joblib: https://pypi.python.org/pypi/joblib
-.. _scikit-learn: https://scikit-learn.org/stable/
-.. _pyDICOM: https://pypi.python.org/pypi/pydicom/
-.. _matplotlib: https://matplotlib.org/
-.. _sphinx: https://www.sphinx-doc.org/
-.. _pandas: https://pandas.pydata.org/
-.. _PIL: https://pypi.python.org/pypi/PIL
-.. _tqdm: https://tqdm.github.io/
-.. _pooch: https://www.fatiando.org/pooch/latest/
-
-.. python editors
-
-.. _Spyder: https://www.spyder-ide.org/
-.. _`integrated development environment`: https://en.wikipedia.org/wiki/Integrated_development_environment
-.. _`spyder`: https://www.spyder-ide.org/
-.. _`visual studio code`: https://code.visualstudio.com/
-.. _`pycharm`: https://www.jetbrains.com/pycharm/
-
-.. _anaconda: https://www.anaconda.com/products/individual
-.. _miniconda: https://conda.io/en/latest/miniconda.html
-.. _miniforge: https://github.com/conda-forge/miniforge
-.. _installation instructions for Anaconda: http://docs.continuum.io/anaconda/install
-.. _installation instructions for Miniconda: https://conda.io/projects/conda/en/latest/user-guide/install/index.html
-.. _Anaconda troubleshooting guide: http://conda.pydata.org/docs/troubleshooting.html
-
-.. installation links
-
-.. _requirements file:  https://raw.githubusercontent.com/mne-tools/mne-python/main/requirements.txt
-.. _NVIDIA CUDA GPU processing: https://developer.nvidia.com/cuda-zone
-.. _NVIDIA proprietary drivers: https://www.geforce.com/drivers
-
 .. _Sphinx documentation: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 .. _sphinx-gallery: https://sphinx-gallery.github.io
 .. _NumPy docstring style guidelines: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
-.. _Stack Overflow: https://stackoverflow.com/
 
 .. vim: ft=rst

--- a/docs/models_summary.rst
+++ b/docs/models_summary.rst
@@ -1,5 +1,3 @@
-.. _data_summary:
-
 .. raw:: html
 
    <style>
@@ -16,9 +14,7 @@
    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bm/dt-1.13.4/datatables.min.css"/>
 
-.. automodule:: braindecode.models
-
-.. currentmodule:: braindecode.models
+.. _models-summary:
 
 Models Summary
 ~~~~~~~~~~~~~~
@@ -54,7 +50,7 @@ The parameter counts shown in the table were calculated using consistent hyperpa
 Submit a new model
 ~~~~~~~~~~~~~~~~~~
 
-Want to contribute a new model to Braindecode? Great! You can propose a new model by opening an `issue <https://github.com/braindecode/braindecode/issues>`__ (please include a link to the relevant publication or description) or, even better, directly submit your implementation via a `pull request <https://github.com/braindecode/braindecode/pulls>`__. We appreciate your contributions to expanding the library!
+Want to contribute a new model to Braindecode? Great! You can propose a new model by opening an `issue <braindecode-issues_>`_ (please include a link to the relevant publication or description) or, even better, directly submit your implementation via a `pull request <braindecode-pulls_>`_. We appreciate your contributions to expanding the library!
 
 .. raw:: html
 
@@ -134,3 +130,5 @@ Want to contribute a new model to Braindecode? Great! You can propose a new mode
       $filterContainer.append(clearBtn);
     });
    </script>
+
+.. include:: links.inc

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -77,6 +77,7 @@ Enhancements
 
 Bugs
 ~~~~
+- Fix dead links in the documentation (:gh:`727` by `Lucas Heck`_)
 - Fix annotations bug for moabb datasets with non-zero interval (:gh: 561 by `Daniel Wilson`_)
 - Fix deprecated test and changing the what's new checker (:gh: 569 by `Bruno Aristimunha`_)
 - Fix issue with coverage CI and adding a condition on the test for avoid HTML errors (:gh: 591 by `Bruno Aristimunha`_)

--- a/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
+++ b/examples/advanced_training/plot_bcic_iv_4_ecog_cropped.py
@@ -1,4 +1,6 @@
 """
+.. _bcic-iv-4-ecog-cropped-decoding:
+
 Fingers flexion cropped decoding on BCIC IV 4 ECoG Dataset
 ==========================================================
 
@@ -62,9 +64,7 @@ test_set = dataset_split["test"]
 # ~~~~~~~~~~~~~
 #
 # Now we apply preprocessing like bandpass filtering to our dataset. You
-# can either apply functions provided by
-# `mne.Raw <https://mne.tools/stable/generated/mne.io.Raw.html>`__ or
-# `mne.Epochs <https://mne.tools/0.11/generated/mne.Epochs.html#mne.Epochs>`__
+# can either apply functions provided by :class:`mne.io.Raw` or :class:`mne.Epochs`
 # or apply your own functions, either to the MNE object or the underlying
 # numpy array.
 #
@@ -77,7 +77,7 @@ test_set = dataset_split["test"]
 #    These prepocessings are now directly applied to the loaded
 #    data, and not on-the-fly applied as transformations in
 #    PyTorch-libraries like
-#    `torchvision <https://pytorch.org/docs/stable/torchvision/index.html>`__.
+#    `<torchvision_>`_.
 #
 
 
@@ -107,7 +107,7 @@ preprocess(test_set, [Preprocessor("crop", tmin=0, tmax=24)], n_jobs=-1)
 # In time series targets setup, targets variables are stored in mne.Raw object as channels
 # of type `misc`. Thus those channels have to be selected for further processing. However,
 # many mne functions ignore `misc` channels and perform operations only on data channels
-# (see https://mne.tools/stable/glossary.html#term-data-channels).
+# (see `MNE's glossary on data channels <MNE-glossary-data-channels_>`_).
 preprocessors = [
     # TODO: ensure that misc is not removed
     Preprocessor("pick_types", ecog=True, misc=True),
@@ -152,12 +152,11 @@ n_times = 1000
 ######################################################################
 # Now we create the deep learning model! Braindecode comes with some
 # predefined convolutional neural network architectures for raw
-# time-domain EEG. Here, we use the shallow ConvNet model from `Deep
-# learning with convolutional neural networks for EEG decoding and
-# visualization <https://arxiv.org/abs/1703.05051>`__. These models are
-# pure `PyTorch <https://pytorch.org>`__ deep learning models, therefore
+# time-domain EEG. Here, we use the :class:`ShallowFBCSPNet
+# <braindecode.models.ShallowFBCSPNet>` model from [1]_. These models are
+# pure `PyTorch <pytorch_>`_ deep learning models, therefore
 # to use your own model, it just has to be a normal PyTorch
-# `nn.Module <https://pytorch.org/docs/stable/nn.html#torch.nn.Module>`__.
+# :class:`torch.nn.Module`.
 #
 
 import torch
@@ -264,8 +263,10 @@ test_set.target_transform = lambda x: x[0:1]
 # --------
 #
 # In difference to trialwise decoding, we now should supply
-# ``cropped=True`` to the EEGClassifier, and ``CroppedLoss`` as the
-# criterion, as well as ``criterion__loss_function`` as the loss function
+# ``cropped=True`` to the :class:`EEGClassifer
+# <braindecode.classifier.EEGClassifier>`, and :class:`CroppedLoss
+# <braindecode.training.CroppedLoss>` as the criterion,
+# as well as ``criterion__loss_function`` as the loss function
 # applied to the meaned predictions.
 #
 # .. note::
@@ -325,7 +326,7 @@ regressor = EEGRegressor(
 set_log_level(verbose="WARNING")
 
 ######################################################################
-# Model training for a specified number of epochs. ``y`` is None as it is already supplied
+# Model training for a specified number of epochs. ``y`` is ``None`` as it is already supplied
 # in the dataset.
 regressor.fit(train_set, y=None, epochs=n_epochs)
 
@@ -449,3 +450,16 @@ handles.append(
 )
 plt.legend(handles, [h.get_label() for h in handles], fontsize=14, loc="center right")
 plt.tight_layout()
+
+#############################################################
+#
+#
+# References
+# ----------
+#
+# .. [1] Schirrmeister, R.T., Springenberg, J.T., Fiederer, L.D.J., Glasstetter, M.,
+#        Eggensperger, K., Tangermann, M., Hutter, F., Burgard, W. and Ball, T. (2017),
+#        Deep learning with convolutional neural networks for EEG decoding and visualization.
+#        Hum. Brain Mapping, 38: 5391-5420. https://doi.org/10.1002/hbm.23730.
+#
+# .. include:: /links.inc

--- a/examples/advanced_training/plot_data_augmentation_search.py
+++ b/examples/advanced_training/plot_data_augmentation_search.py
@@ -1,4 +1,6 @@
 """
+.. _bcic-iv-2a-best-data-aug:
+
 Searching the best data augmentation on BCIC IV 2a Dataset
 ====================================================================================
 
@@ -80,7 +82,7 @@ factor = 1e6
 # In time series targets setup, targets variables are stored in mne.Raw object as channels
 # of type `misc`. Thus those channels have to be selected for further processing. However,
 # many mne functions ignore `misc` channels and perform operations only on data channels
-# (see https://mne.tools/stable/glossary.html#term-data-channels).
+# (see `MNE's glossary on data channels <MNE-glossary-data-channels_>`_).
 
 preprocessors = [
     Preprocessor("pick_types", eeg=True, meg=False, stim=False),  # Keep EEG sensors
@@ -365,3 +367,5 @@ plt.tight_layout()
 # .. [2] Banville, H., Chehab, O., Hyvärinen, A., Engemann, D. A., & Gramfort, A. (2021).
 #        Uncovering the structure of clinical EEG signals with self-supervised learning.
 #        Journal of Neural Engineering, 18(4), 046020.
+#
+# .. include:: /links.inc

--- a/examples/advanced_training/plot_relative_positioning.py
+++ b/examples/advanced_training/plot_relative_positioning.py
@@ -1,4 +1,6 @@
 """
+.. _self-supervised-learning-eeg:
+
 Self-supervised learning on EEG with relative positioning
 =========================================================
 
@@ -137,6 +139,7 @@ preprocess(windows_dataset, [Preprocessor(standard_scale, channel_wise=True)])
 
 import numpy as np
 from sklearn.model_selection import train_test_split
+
 from braindecode.datasets import BaseConcatDataset
 
 subjects = np.unique(windows_dataset.description["subject"])
@@ -186,15 +189,15 @@ for name, values in split_ids.items():
 # sample pairs of examples to train and validate our model with
 # self-supervision.
 #
-# The RP samplers have two main hyperparameters. `tau_pos` and `tau_neg`
+# The RP samplers have two main hyperparameters. ``tau_pos`` and ``tau_neg``
 # control the size of the "positive" and "negative" contexts, respectively.
-# Pairs of windows that are separated by less than `tau_pos` samples will be
-# given a label of `1`, while pairs of windows that are separated by more than
-# `tau_neg` samples will be given a label of `0`. Here, we use the same values
-# as in [1]_, i.e., `tau_pos`= 1 min and `tau_neg`= 15 mins.
+# Pairs of windows that are separated by less than ``tau_pos`` samples will be
+# given a label of ``1``, while pairs of windows that are separated by more than
+# ``tau_neg`` samples will be given a label of ``0``. Here, we use the same values
+# as in [1]_, i.e., ``tau_pos`` = 1 min and ``tau_neg`` = 15 mins.
 #
 # The samplers also control the number of pairs to be sampled (defined with
-# `n_examples`). This number can be large to help regularize the pretext task
+# ``n_examples``). This number can be large to help regularize the pretext task
 # training, for instance 2,000 pairs per recording as in [1]_. Here, we use a
 # lower number of 250 pairs per recording to reduce training time.
 
@@ -352,7 +355,7 @@ clf = EEGClassifier(
     device=device,
     classes=classes,
 )
-# Model training for a specified number of epochs. `y` is None as it is already
+# Model training for a specified number of epochs. ``y`` is None as it is already
 # supplied in the dataset.
 clf.fit(splitted["train"], y=None)
 clf.load_params(checkpoint=cp)  # Load the model with the lowest valid_loss

--- a/examples/applied_examples/plot_bcic_iv_4_ecog_trial.py
+++ b/examples/applied_examples/plot_bcic_iv_4_ecog_trial.py
@@ -1,4 +1,6 @@
 """
+.. _bcic-iv-4-ecog-decoding:
+
 Fingers flexion decoding on BCIC IV 4 ECoG Dataset
 ==================================================
 
@@ -59,8 +61,7 @@ dataset = BCICompetitionIVDataset4(subject_ids=[subject_id])
 ######################################################################
 # Now we apply preprocessing like bandpass filtering to our dataset. You
 # can either apply functions provided by
-# `mne.Raw <https://mne.tools/stable/generated/mne.io.Raw.html>`__ or
-# `mne.Epochs <https://mne.tools/0.11/generated/mne.Epochs.html#mne.Epochs>`__
+# :class:`mne.io.Raw` or :class:`mne.Epochs`
 # or apply your own functions, either to the MNE object or the underlying
 # numpy array.
 #
@@ -72,8 +73,7 @@ dataset = BCICompetitionIVDataset4(subject_ids=[subject_id])
 # .. note::
 #    These prepocessings are now directly applied to the loaded
 #    data, and not on-the-fly applied as transformations in
-#    PyTorch-libraries like
-#    `torchvision <https://pytorch.org/docs/stable/torchvision/index.html>`__.
+#    PyTorch-libraries like `<torchvision_>`_.
 #
 
 
@@ -98,7 +98,7 @@ preprocess(dataset, [Preprocessor("crop", tmin=0, tmax=30)])
 # In time series targets setup, targets variables are stored in mne.Raw object as channels
 # of type `misc`. Thus those channels have to be selected for further processing. However,
 # many mne functions ignore `misc` channels and perform operations only on data channels
-# (see https://mne.tools/stable/glossary.html#term-data-channels).
+# (see `MNE's glossary on data channels <MNE-glossary-data-channels_>`_).
 preprocessors = [
     Preprocessor("pick_types", ecog=True, misc=True),
     Preprocessor(lambda x: x / 1e6, picks="ecog"),  # Convert from V to uV
@@ -157,8 +157,8 @@ windows_dataset.target_transform = lambda x: x[0:1]
 
 ######################################################################
 # We can easily split the dataset using additional info stored in the
-# description attribute, in this case ``session`` column. We select `train` dataset
-# for training and validation and `test` for final evaluation.
+# description attribute, in this case ``session`` column. We select ``train`` dataset
+# for training and validation and ``test`` for final evaluation.
 
 subsets = windows_dataset.split("session")
 train_set = subsets["train"]
@@ -166,7 +166,8 @@ test_set = subsets["test"]
 
 ######################################################################
 # We can split train dataset into training and validation datasets using
-# ``sklearn.model_selection.train_test_split`` and ``torch.utils.data.Subset``.
+# :func:`sklearn.model_selection.train_test_split` and :class:`torch.utils.data.Subset`.
+
 import torch
 from sklearn.model_selection import train_test_split
 
@@ -190,9 +191,9 @@ train_set = torch.utils.data.Subset(train_set, idx_train)
 # time-domain EEG. Here, we use the shallow ConvNet model from `Deep
 # learning with convolutional neural networks for EEG decoding and
 # visualization <https://arxiv.org/abs/1703.05051>`__. These models are
-# pure `PyTorch <https://pytorch.org>`__ deep learning models, therefore
+# pure `PyTorch <pytorch_>`_ deep learning models, therefore
 # to use your own model, it just has to be a normal PyTorch
-# `nn.Module <https://pytorch.org/docs/stable/nn.html#torch.nn.Module>`__.
+# :class:`torch.nn.Module`.
 
 
 from braindecode.models import ShallowFBCSPNet
@@ -235,10 +236,10 @@ if cuda:
 
 
 ######################################################################
-# Now we train the network! EEGRegressor is a Braindecode object
-# responsible for managing the training of neural networks. It inherits
-# from skorch.NeuralNetRegressor, so the training logic is the same as in
-# `Skorch <https://skorch.readthedocs.io/en/stable/>`__.
+# Now we train the network! :class:`braindecode.regressor.EEGRegressor`
+# is a Braindecode object responsible for managing the training of neural networks.
+# It inherits from :class:`skorch.regressor.NeuralNetRegressor`, so the training
+# logic is the same as in `<skorch_>`_.
 #
 # .. note::
 #    In this tutorial, we use some default parameters that we
@@ -418,3 +419,7 @@ handles.append(
 )
 plt.legend(handles, [h.get_label() for h in handles], fontsize=14, loc="center right")
 plt.tight_layout()
+
+######################################################################
+#
+# .. include:: /links.inc

--- a/examples/applied_examples/plot_sleep_staging_chambon2018.py
+++ b/examples/applied_examples/plot_sleep_staging_chambon2018.py
@@ -1,4 +1,6 @@
 """
+.. _sleep-staging-physionet-chambon2018:
+
 Sleep staging on the Sleep Physionet dataset using Chambon2018 network
 ======================================================================
 
@@ -23,13 +25,12 @@ sequences of EEG windows using the openly accessible Sleep Physionet dataset
 # First, we load the data using the
 # :class:`braindecode.datasets.sleep_physionet.SleepPhysionet` class. We load
 # two recordings from two different individuals: we will use the first one to
-# train our network and the second one to evaluate performance (as in the `MNE`_
-# sleep staging example).
-#
-# .. _MNE: https://mne.tools/stable/auto_tutorials/sample-datasets/plot_sleep.html
+# train our network and the second one to evaluate performance (as in the `MNE
+# sleep staging example <mne-clinical-60-sleep_>`_).
 #
 
 from numbers import Integral
+
 from braindecode.datasets import SleepPhysionet
 
 subject_ids = [0, 1]
@@ -226,11 +227,10 @@ if cuda:
 # Training
 # --------
 #
-# We can now train our network. :class:`braindecode.EEGClassifier` is a
+# We can now train our network. :class:`braindecode.classifier.EEGClassifier` is a
 # braindecode object that is responsible for managing the training of neural
-# networks. It inherits from :class:`skorch.NeuralNetClassifier`, so the
-# training logic is the same as in
-# `Skorch <https://skorch.readthedocs.io/en/stable/>`__.
+# networks. It inherits from :class:`skorch.classifier.NeuralNetClassifier`, so the
+# training logic is the same as in `<skorch_>`_.
 #
 # .. note::
 #    We use different hyperparameters from [1]_, as these hyperparameters were
@@ -368,3 +368,5 @@ ax.set_ylabel("Sleep stage")
 #        PhysioBank, PhysioToolkit, and PhysioNet: Components of a New
 #        Research Resource for Complex Physiologic Signals.
 #        Circulation 101(23):e215-e220
+#
+# .. include:: /links.inc

--- a/examples/applied_examples/plot_sleep_staging_eldele2021.py
+++ b/examples/applied_examples/plot_sleep_staging_eldele2021.py
@@ -1,4 +1,6 @@
 """
+.. _sleep-staging-physionet-eldele2021:
+
 Sleep staging on the Sleep Physionet dataset using Eldele2021
 =============================================================
 
@@ -22,10 +24,8 @@ to learn on sequences of EEG windows using the openly accessible Sleep Physionet
 # First, we load the data using the
 # :class:`braindecode.datasets.sleep_physionet.SleepPhysionet` class. We load
 # two recordings from two different individuals: we will use the first one to
-# train our network and the second one to evaluate performance (as in the `MNE`_
-# sleep staging example).
-#
-# .. _MNE: https://mne.tools/stable/auto_tutorials/sample-datasets/plot_sleep.html
+# train our network and the second one to evaluate performance (as in the `MNE
+# sleep staging example <mne-clinical-60-sleep_>`_).
 #
 
 from numbers import Integral
@@ -66,7 +66,8 @@ preprocess(dataset, preprocessors)
 # ~~~~~~~~~~~~~~~
 #
 # We extract 30-s windows to be used in the classification task.
-# The Eldele2021 model takes a single channel as input. Here, the Fpz-Cz channel is used as it
+# The :class:`braindecode.models.SleepStagerEldele2021` model takes a
+# single channel as input. Here, the Fpz-Cz channel is used as it
 # was found to give better performance than using the Pz-Oz channel
 
 from braindecode.preprocessing import create_windows_from_events
@@ -269,7 +270,7 @@ clf = EEGClassifier(
     device=device,
     classes=np.unique(y_train),
 )
-# Model training for a specified number of epochs. `y` is None as it is already
+# Model training for a specified number of epochs. ``y`` is ``None`` as it is already
 # supplied in the dataset.
 clf.fit(train_set, y=None, epochs=n_epochs)
 
@@ -365,3 +366,5 @@ ax.set_ylabel("Sleep stage")
 #        PhysioBank, PhysioToolkit, and PhysioNet: Components of a New
 #        Research Resource for Complex Physiologic Signals.
 #        Circulation 101(23):e215-e220
+#
+# .. include:: /links.inc

--- a/examples/applied_examples/plot_sleep_staging_usleep.py
+++ b/examples/applied_examples/plot_sleep_staging_usleep.py
@@ -1,10 +1,12 @@
 """
+.. _sleep-staging-usleep:
+
 Sleep staging on the Sleep Physionet dataset using U-Sleep network
 ==================================================================
 
 .. note::
     Please take a look at the simpler sleep staging example
-    :ref:`here <sphx_glr_auto_examples_plot_sleep_staging.py>`
+    :ref:`sleep-staging-physionet-chambon2018`
     before going through this example. The current example uses a more complex
     architecture and a sequence-to-sequence (seq2seq) approach.
 
@@ -34,10 +36,8 @@ windows using the openly accessible Sleep Physionet dataset [2]_ [3]_.
 # First, we load the data using the
 # :class:`braindecode.datasets.sleep_physionet.SleepPhysionet` class. We load
 # two recordings from two different individuals: we will use the first one to
-# train our network and the second one to evaluate performance (as in the `MNE`_
-# sleep staging example).
-#
-# .. _MNE: https://mne.tools/stable/auto_tutorials/sample-datasets/plot_sleep.html
+# train our network and the second one to evaluate performance (as in the `MNE
+# sleep staging example <mne-clinical-60-sleep_>`_).
 #
 
 from braindecode.datasets import SleepPhysionet
@@ -188,11 +188,11 @@ if cuda:
 # Training
 # --------
 #
-# We can now train our network. :class:`braindecode.EEGClassifier` is a
+# We can now train our network. :class:`braindecode.classifier.EEGClassifier` is a
 # braindecode object that is responsible for managing the training of neural
-# networks. It inherits from :class:`skorch.NeuralNetClassifier`, so the
+# networks. It inherits from :class:`skorch.classifier.NeuralNetClassifier`, so the
 # training logic is the same as in
-# `Skorch <https://skorch.readthedocs.io/en/stable/>`__.
+# `<skorch_>`_.
 #
 # .. note::
 #    We use different hyperparameters from [1]_, as these hyperparameters were
@@ -331,3 +331,5 @@ ax.set_ylabel("Sleep stage")
 #        PhysioBank, PhysioToolkit, and PhysioNet: Components of a New
 #        Research Resource for Complex Physiologic Signals.
 #        Circulation 101(23):e215-e220
+#
+# .. include:: /links.inc

--- a/examples/applied_examples/plot_tuh_eeg_corpus.py
+++ b/examples/applied_examples/plot_tuh_eeg_corpus.py
@@ -1,9 +1,11 @@
 """
+.. _process-big-dataset-TUH:
+
 Process a big data EEG resource (TUH EEG Corpus)
 ================================================
 
 In this example, we showcase usage of the Temple University Hospital EEG Corpus
-(https://www.isip.piconepress.com/projects/tuh_eeg/html/downloads.shtml#c_tueg)
+(https://isip.piconepress.com/projects/nedc/html/tuh_eeg/)
 including simple preprocessing steps as well as cutting of compute windows.
 
 .. contents:: This example covers:
@@ -175,7 +177,7 @@ plt_histogram(df)
 # -------------------------------------
 #
 # Selecting recordings
-# ~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~
 #
 # First, we will do some selection of available recordings based on the duration.
 # We will select those recordings that have at least five minutes duration.
@@ -250,7 +252,7 @@ tuh = select_by_channels(tuh, short_ch_names)
 
 ###############################################################################
 # Combining preprocessing steps
-# ~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Next, we use braindecode's preprocess to combine and execute several preprocessing
 # steps that are executed through 'mne':
@@ -311,7 +313,7 @@ tuh_preproc = preprocess(
 
 ###############################################################################
 # Cut Compute Windows
-# ~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~
 # We can finally generate compute windows. The resulting dataset is now ready
 # to be used for model training.
 

--- a/examples/datasets_io/benchmark_lazy_eager_loading.py
+++ b/examples/datasets_io/benchmark_lazy_eager_loading.py
@@ -1,11 +1,14 @@
-"""Benchmarking eager and lazy loading
+"""
+.. _benchmark-eager-lazy:
+
+Benchmarking eager and lazy loading
 ======================================
 
 In this example, we compare the execution time and memory requirements of 1)
 eager loading, i.e., preloading the entire data into memory and 2) lazy loading,
 i.e., only loading examples from disk when they are required. We also include
 some other experiment parameters in the comparison for the sake of completeness
-(e.g., `num_workers`, `cuda`, `batch_size`, etc.).
+(e.g., ``num_workers``, ``cuda``, ``batch_size``, etc.).
 
 While eager loading might be required for some preprocessing steps that require
 continuous data (e.g., temporal filtering, resampling), it also allows
@@ -53,7 +56,8 @@ mne.set_log_level("WARNING")  # avoid messages every time a window is extracted
 
 ###############################################################################
 # We start by setting two pytorch internal parameters that can affect the
-# comparison::
+# comparison:
+
 N_JOBS = 8
 torch.backends.cudnn.benchmark = True  # Enables automatic algorithm optimizations
 torch.set_num_threads(N_JOBS)  # Sets the available number of threads

--- a/examples/datasets_io/plot_benchmark_preprocessing.py
+++ b/examples/datasets_io/plot_benchmark_preprocessing.py
@@ -1,4 +1,6 @@
 """
+.. _benchmark-preprocess-parallel-serial:
+
 Benchmarking preprocessing with parallelization and serialization
 =================================================================
 
@@ -19,14 +21,14 @@ other. In this scenario, :func:`braindecode.preprocessing.preprocess` acts
 inplace, which means memory usage will likely stay stable (depending on the
 preprocessing operations) if recordings have been preloaded. However, two
 potential issues arise when working with large datasets: (1) if recordings have
-not been preloaded before preprocessing, `preprocess()` will need to load them
+not been preloaded before preprocessing, ``preprocess()`` will need to load them
 and keep them in memory, in which case memory can become a bottleneck, and (2)
 sequential preprocessing can take a considerable amount of time to run when
 working with many recordings.
 
 A solution to the first issue (memory usage) is to save the preprocessed data
 to a file so it can be cleared from memory before moving on to the next
-recording (case 2). The recordings can then be reloaded with `preload=False`
+recording (case 2). The recordings can then be reloaded with ``preload=False``
 once they have all been saved to disk. This enables using the lazy loading
 capabilities of :class:`braindecode.datasets.BaseConcatDataset` and avoids
 potential memory bottlenecks. The downside is that the writing to disk can take

--- a/examples/datasets_io/plot_bids_dataset_example.py
+++ b/examples/datasets_io/plot_bids_dataset_example.py
@@ -1,4 +1,7 @@
-"""BIDS Dataset Example
+"""
+.. _bids-dataset-example:
+
+BIDS Dataset Example
 ========================
 
 In this example, we show how to fetch and prepare a BIDS dataset for usage

--- a/examples/datasets_io/plot_custom_dataset_example.py
+++ b/examples/datasets_io/plot_custom_dataset_example.py
@@ -1,4 +1,6 @@
 """
+.. _custom-dataset-example:
+
 Custom Dataset Example
 ======================
 
@@ -15,7 +17,7 @@ import mne
 from braindecode.datasets import create_from_X_y
 
 ###############################################################################
-# To set up the example, we first fetch some data using mne:
+# To set up the example, we first fetch some data using `MNE <MNE-Python_>`_:
 
 # 5, 6, 7, 10, 13, 14 are codes for executed and imagined hands/feet
 subject_id = 22
@@ -69,3 +71,6 @@ n_channels, n_times = x_i.shape  # the EEG data
 _, start_ind, stop_ind = window_ind
 print(f"n_channels={n_channels}  -- n_times={n_times} -- y_i={y_i}")
 print(f"start_ind={start_ind} -- stop_ind={stop_ind}")
+
+###############################################################################
+# .. include:: /links.inc

--- a/examples/datasets_io/plot_load_save_datasets.py
+++ b/examples/datasets_io/plot_load_save_datasets.py
@@ -1,4 +1,6 @@
 """
+.. _load-save-dataset:
+
 Load and save dataset example
 =============================
 
@@ -92,3 +94,6 @@ windows_dataset_loaded = load_concat_dataset(
 )
 
 windows_dataset_loaded.description
+
+###############################################################################
+# .. include:: /links.inc

--- a/examples/datasets_io/plot_mne_dataset_example.py
+++ b/examples/datasets_io/plot_mne_dataset_example.py
@@ -1,4 +1,6 @@
 """
+.. _mne-dataset-example:
+
 MNE Dataset Example
 ===================
 """
@@ -48,7 +50,7 @@ windows_dataset = create_from_mne_raw(
 )
 
 ###############################################################################
-# If trials were already cut beforehand and are available as mne.Epochs:
+# If trials were already cut beforehand and are available as :class:`mne.Epochs`:
 list_of_epochs = [mne.Epochs(raw, [[0, 0, 0]], tmin=0, baseline=None) for raw in parts]
 windows_dataset = create_from_mne_epochs(
     list_of_epochs,

--- a/examples/datasets_io/plot_moabb_dataset_example.py
+++ b/examples/datasets_io/plot_moabb_dataset_example.py
@@ -1,4 +1,7 @@
-"""MOABB Dataset Example
+"""
+.. _moabb-dataset-example:
+
+MOABB Dataset Example
 ========================
 
 In this example, we show how to fetch and prepare a MOABB dataset for usage
@@ -49,6 +52,6 @@ subsets = dataset.split("session")
 print({subset_name: len(subset) for subset_name, subset in subsets.items()})
 
 ##############################################################################
-# See our `Trialwise Decoding <../model_building/plot_bcic_iv_2a_moabb_trial.html>`__ and
-# `Cropped Decoding <../model_building/plot_bcic_iv_2a_moabb_cropped.html>`__ examples for
+# See our :ref:`Trialwise Decoding <bcic-iv-2a-moabb-trial>` and
+# :ref:`Cropped Decoding <bcic-iv-2a-moabb-cropped>` examples for
 # training with this dataset.

--- a/examples/datasets_io/plot_split_dataset.py
+++ b/examples/datasets_io/plot_split_dataset.py
@@ -1,4 +1,6 @@
 """
+.. _split-dataset-example:
+
 Split Dataset Example
 =====================
 
@@ -22,7 +24,8 @@ from braindecode.preprocessing import create_windows_from_events
 # Loading the dataset
 # -------------------------------------
 #
-# Firstly, we create a dataset using the braindecode class <MOABBDataset> to load
+# Firstly, we create a dataset using the braindecode
+# :class:`MOABBDataset <braindecode.datasets.MOABBDataset>` to load
 # it fetched from MOABB. In this example, we're using Dataset 2a from BCI
 # Competition IV.
 
@@ -33,10 +36,11 @@ dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[1])
 # -------------------------------------
 #
 # By description information
-# ~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# The class <MOABBDataset> has a pandas DataFrame containing additional
-# description of its internal datasets, which can be used to help splitting the data
+# The class :class:`MOABBDataset <braindecode.datasets.MOABBDataset>` has a pandas
+# DataFrame containing additional description of its internal datasets,
+# which can be used to help splitting the data
 # based on recording information, such as subject, session, and run of each trial.
 
 dataset.description

--- a/examples/datasets_io/plot_tuh_discrete_multitarget.py
+++ b/examples/datasets_io/plot_tuh_discrete_multitarget.py
@@ -1,10 +1,12 @@
 """
+.. _multiple-discrete-targets-TUH:
+
 Multiple discrete targets with the TUH EEG Corpus
 =================================================
 
 Welcome to this tutorial where we demonstrate how to work with multiple discrete
- targets for each recording in the TUH EEG Corpus. We'll guide you through the
- process step by step.
+targets for each recording in the TUH EEG Corpus. We'll guide you through the
+process step by step.
 
 """
 
@@ -38,7 +40,7 @@ from braindecode.datasets.tuh import _TUHMock as TUH  # noqa F811
 # Creating Temple University Hospital (TUH) EEG Corpus Dataset
 # ------------------------------------------------------------
 #
-# We start by creating a TUH dataset. Instead of just a `str, we give it
+# We start by creating a TUH dataset. Instead of just a `str`, we give it
 # multiple strings as target names. Each of the strings has to exist as a
 # column in the description DataFrame.
 
@@ -56,9 +58,9 @@ print(tuh.description)
 # Exploring Data
 # --------------
 #
-# Iterating through the dataset gives `x` as an ndarray with shape
-# `(n_channels x 1)` and `y` as a list containing `[age of the subject, gender
-# of the subject]`.
+# Iterating through the dataset gives ``x`` as an ndarray with shape
+# ``(n_channels x 1)`` and ``y`` as a list containing ``[age of the subject, gender
+# of the subject]``.
 # Let's look at the last example as it has more interesting age/gender labels
 # (compare to the last row of the dataframe above).
 x, y = tuh[-1]
@@ -92,8 +94,8 @@ tuh_windows.set_description({"n_windows": [len(d) for d in tuh_windows.datasets]
 # Exploring Windows
 # -----------------
 #
-# Iterating through the dataset gives `x` as an ndarray with shape
-# `(n_channels x 1000)`, `y` as `[age, gender]`, and `ind`.
+# Iterating through the dataset gives ``x`` as an ndarray with shape
+# ``(n_channels x 1000)``, ``y`` as ``[age, gender]``, and ``ind``.
 # Let's look at the last example again.
 x, y, ind = tuh_windows[-1]
 print(f"{x=}\n{y=}\n{ind=}")
@@ -115,9 +117,9 @@ dl = DataLoader(
 # Exploring DataLoader
 # --------------------
 #
-# When iterating through the DataLoader, we get `batch_X` as a tensor with shape
-# `(4 x n_channels x 1000)`, `batch_y` as `[tensor([4 x age of subject]),
-# tensor([4 x gender of subject])]`, and `batch_ind`. To view the last example,
+# When iterating through the DataLoader, we get ``batch_X`` as a tensor with shape
+# ``(4 x n_channels x 1000)``, ``batch_y`` as ``[tensor([4 x age of subject]),
+# tensor([4 x gender of subject])]``, and ``batch_ind``. To view the last example,
 # simply iterate through the DataLoader:
 
 for batch_X, batch_y, batch_ind in dl:

--- a/examples/model_building/plot_basic_training_epochs.py
+++ b/examples/model_building/plot_basic_training_epochs.py
@@ -1,4 +1,6 @@
 """
+.. _basic-training-epochs:
+
 Simple training on MNE epochs
 =============================
 
@@ -23,7 +25,7 @@ train one of the Braindecode models on it.
 # --------------------------
 #
 # Exploring the braindecode online documentation
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 #
 # Let's suppose you recently stumbled upon the Schirrmeister 2017 article [1]_.
 # In this article, the authors mention that their novel architecture ShallowConvNet
@@ -32,12 +34,10 @@ train one of the Braindecode models on it.
 # architecture on Braindecode!
 #
 # In order to use this architecture, you first need to find what is its exact
-# name in Braindecode. To do so, you can visit the Braindecode online documentation
-# which lists all the available models.
+# name in Braindecode. To do so, you can visit Braindecode's :doc:`Models Summary </models_summary>`
+# page for information on which are the available models.
 #
-# Models list: https://braindecode.org/stable/api.html#models
-#
-# Alternatively, the API also provide a dictionary with all available models:
+# Alternatively, the :doc:`API </api>` also provide a dictionary with all available models:
 
 from braindecode.models.util import models_dict
 
@@ -105,23 +105,24 @@ print(epochs)
 # and that we have some fake data, it is time to train the model!
 #
 # .. note::
-#    `Skorch <https://skorch.readthedocs.io>`_  is a library that allows you to wrap
+#    `<skorch_>`_  is a library that allows you to wrap
 #    any PyTorch module into a scikit-learn-compatible classifier or regressor.
 #    Braindecode provides wrappers that inherit form the original Skorch ones and simply
 #    implement a few additional features that facilitate the use of Braindecode models.
 #
 # To train a Braindecode model, the easiest way is by using braindecode's
-# Skorch wrappers. These wrappers are :class:`braindecode.EEGClassifier` and
-# :class:`braindecode.EEGRegressor`. As our fake data is a classification task,
+# Skorch wrappers. These wrappers are :class:`braindecode.classifier.EEGClassifier` and
+# :class:`braindecode.regressor.EEGRegressor`. As our fake data is a classification task,
 # we will use the former.
 #
-# The wrapper :class:`braindecode.EEGClassifier` expects a model class as its first argument but
+# The wrapper :class:`braindecode.classifier.EEGClassifier` expects a model class as its first argument but
 # to facilitate the usage, you can also simply pass the name of any braindecode model as a string.
 # The wrapper automatically finds and instantiates the model for you.
 # If you want to pass parameters to your model, you can give them to the wrapper
 # with the prefix ``module__``.
 #
 from skorch.dataset import ValidSplit
+
 from braindecode import EEGClassifier
 
 net = EEGClassifier(
@@ -136,7 +137,7 @@ net = EEGClassifier(
 # that will be forwarded to the model (without the prefix ``module__``).
 #
 # We also note that the parameters ``n_chans``, ``n_times`` and ``n_outputs`` were not specified
-# even if :class:`braindecode.ShallowFBCSPNet` needs them to be initialized. This is because the
+# even if :class:`braindecode.models.ShallowFBCSPNet` needs them to be initialized. This is because the
 # wrapper will automatically infer them, along with some other signal-related parameters,
 # from the input data at training time.
 #
@@ -162,8 +163,8 @@ print(
 ######################################################################
 # Depending on the type of data used for training, some parameters might not be
 # possible to infer. For example if you pass a numpy array or a
-# :class:`braindecode.dataset.WindowsDataset` with ``target_from="metadata"``,
-#  then only ``n_chans``, ``n_times`` and ``n_outputs`` will be inferred.
+# :class:`braindecode.datasets.WindowsDataset` with ``targets_from="metadata"``,
+# then only ``n_chans``, ``n_times`` and ``n_outputs`` will be inferred.
 # And if you pass other types of datasets, only ``n_chans`` and ``n_times`` will be inferred.
 # In these case, you will have to pass the missing parameters manually
 # (with the prefix ``module__``).
@@ -177,3 +178,5 @@ print(
 #        Deep learning with convolutional neural networks for EEG decoding and visualization.
 #        Human Brain Mapping, Aug. 2017.
 #        Online: http://dx.doi.org/10.1002/hbm.23730
+#
+# .. include:: /links.inc

--- a/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
+++ b/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 """
+.. _bcic-iv-2a-moabb-cropped:
+
 Cropped Decoding on BCIC IV 2a Dataset
 ======================================
 
@@ -10,17 +12,18 @@ Cropped Decoding on BCIC IV 2a Dataset
 """
 
 ######################################################################
-# Building on the `Trialwise decoding <./plot_bcic_iv_2a_moabb_trial.html>`__,
+# Building on the :ref:`Trialwise Decoding <bcic-iv-2a-moabb-trial>`,
 # we now do more data-efficient cropped decoding!
 #
 # In Braindecode, there are two supported configurations created for
 # training models: trialwise decoding and cropped decoding. We will
 # explain this visually by comparing trialwise to cropped decoding.
 #
-# .. image:: https://braindecode.org/stable/_static/trialwise_explanation.png
+# .. image:: /_static/trialwise_explanation.png
 #    :alt: Trialwise decoding
-# .. image:: https://braindecode.org/stable/_static/cropped_explanation.png
+# .. image:: /_static/cropped_explanation.png
 #    :alt: Cropped decoding
+#
 # On the left, you see trialwise decoding:
 #
 # 1. A complete trial is pushed through the network.
@@ -82,8 +85,8 @@ Cropped Decoding on BCIC IV 2a Dataset
 # Loading and preprocessing the dataset
 # -------------------------------------
 #
-# Loading and preprocessing stays the same as in the `Trialwise decoding
-# tutorial <./plot_bcic_iv_2a_moabb_trial.html>`__.
+# Loading and preprocessing stays the same as in the
+# :ref:`Trialwise decoding tutorial <bcic-iv-2a-moabb-trial>`.
 
 from braindecode.datasets import MOABBDataset
 
@@ -203,8 +206,8 @@ n_preds_per_input = model.get_output_shape()[2]
 # Cut the data into windows
 # -------------------------
 # In contrast to trialwise decoding, we have to supply an explicit
-# window size and window stride to the ``create_windows_from_events``
-# function.
+# window size and window stride to the
+# :func:`braindecode.preprocessing.create_windows_from_events` function.
 #
 
 from braindecode.preprocessing import create_windows_from_events
@@ -244,8 +247,10 @@ valid_set = splitted["1test"]  # Session evaluation
 # Training
 # --------
 # In difference to trialwise decoding, we now should supply
-# ``cropped=True`` to the EEGClassifier, and ``CroppedLoss`` as the
-# criterion, as well as ``criterion__loss_function`` as the loss function
+# ``cropped=True`` to the :class:`EEGClassifer
+# <braindecode.classifier.EEGClassifier>`, and :class:`CroppedLoss
+# <braindecode.training.CroppedLoss>` as the criterion,
+# as well as ``criterion__loss_function`` as the loss function
 # applied to the meaned predictions.
 #
 # .. note::
@@ -291,7 +296,7 @@ clf = EEGClassifier(
     device=device,
     classes=classes,
 )
-# Model training for a specified number of epochs. `y` is None as it is already supplied
+# Model training for a specified number of epochs. ``y`` is None as it is already supplied
 # in the dataset.
 _ = clf.fit(train_set, y=None, epochs=n_epochs)
 

--- a/examples/model_building/plot_bcic_iv_2a_moabb_trial.py
+++ b/examples/model_building/plot_bcic_iv_2a_moabb_trial.py
@@ -1,4 +1,6 @@
 """
+.. _bcic-iv-2a-moabb-trial:
+
 Basic Brain Decoding on EEG Data
 ========================================
 
@@ -27,13 +29,12 @@ labels (e.g., Right Hand, Left Hand, etc.).
 ######################################################################
 # First, we load the data. In this tutorial, we load the BCI Competition
 # IV 2a data [1]_ using braindecode's wrapper to load via
-# `MOABB library <https://github.com/NeuroTechX/moabb>`__ [2]_.
+# `MOABB library <moabb_>`_ [2]_.
 #
 # .. note::
 #    To load your own datasets either via mne or from
-#    preprocessed X/y numpy arrays, see `MNE Dataset
-#    Tutorial <./plot_mne_dataset_example.html>`__ and `Numpy Dataset
-#    Tutorial <./plot_custom_dataset_example.html>`__.
+#    preprocessed X/y numpy arrays, see :ref:`mne-dataset-example`
+#    and :ref:`custom-dataset-example`.
 #
 
 from braindecode.datasets import MOABBDataset
@@ -49,18 +50,15 @@ dataset = MOABBDataset(dataset_name="BNCI2014_001", subject_ids=[subject_id])
 
 
 ######################################################################
-# Now we apply preprocessing like bandpass filtering to our dataset. You
-# can either apply functions provided by
-# `mne.Raw <https://mne.tools/stable/generated/mne.io.Raw.html>`__ or
-# `mne.Epochs <https://mne.tools/0.11/generated/mne.Epochs.html#mne.Epochs>`__
-# or apply your own functions, either to the MNE object or the underlying
-# numpy array.
+# Now we apply preprocessing like bandpass filtering to our dataset.
+# You can either apply functions provided by :class:`mne.io.Raw` or
+# :class:`mne.Epochs` or apply your own functions, either to the
+# MNE object or the underlying numpy array.
 #
 # .. note::
 #    Generally, braindecode prepocessing is directly applied to the loaded
 #    data, and not applied on-the-fly as transformations, such as in
-#    PyTorch-libraries like
-#    `torchvision <https://pytorch.org/docs/stable/torchvision/index.html>`__.
+#    PyTorch-libraries like `<torchvision_>`_.
 #
 
 from numpy import multiply
@@ -136,7 +134,7 @@ windows_dataset = create_windows_from_events(
 ######################################################################
 # We can easily split the dataset using additional info stored in the
 # description attribute, in this case ``session`` column. We select
-# ``T`` for training and ``test`` for validation.
+# ``0train`` for training and ``1test`` for validation.
 #
 
 splitted = windows_dataset.split("session")
@@ -146,17 +144,18 @@ valid_set = splitted["1test"]  # Session evaluation
 
 ######################################################################
 # Creating a model
-# ------------
+# ----------------
 #
 
 
 ######################################################################
 # Now we create the deep learning model! Braindecode comes with some
 # predefined convolutional neural network architectures for raw
-# time-domain EEG. Here, we use the shallow ConvNet model from [3]_. These models are
-# pure `PyTorch <https://pytorch.org>`__ deep learning models, therefore
+# time-domain EEG. Here, we use the :class:`ShallowFBCSPNet
+# <braindecode.models.ShallowFBCSPNet>` model from [3]_. These models are
+# pure `PyTorch <pytorch_>`_ deep learning models, therefore
 # to use your own model, it just has to be a normal PyTorch
-# `nn.Module <https://pytorch.org/docs/stable/nn.html#torch.nn.Module>`__.
+# :class:`torch.nn.Module`.
 #
 
 import torch
@@ -205,10 +204,11 @@ if cuda:
 
 
 ######################################################################
-# Now we will train the network! ``EEGClassifier`` is a Braindecode object
-# responsible for managing the training of neural networks. It inherits
-# from skorch `NeuralNetClassifier <https://skorch.readthedocs.io/en/stable/classifier.html#>`__,
-# so the training logic is the same as in `Skorch <https://skorch.readthedocs.io/en/stable/>`__.
+# Now we will train the network! :class:`EEGClassifier
+# <braindecode.classifier.EEGClassifier>` is a Braindecode object
+# responsible for managing the training of neural networks.
+# It inherits from :class:`skorch.classifier.NeuralNetClassifier`,
+# so the training logic is the same as in `<skorch_>`_.
 #
 
 
@@ -251,19 +251,19 @@ clf = EEGClassifier(
     device=device,
     classes=classes,
 )
-# Model training for the specified number of epochs. `y` is None as it is
+# Model training for the specified number of epochs. ``y`` is ``None`` as it is
 # already supplied in the dataset.
 _ = clf.fit(train_set, y=None, epochs=n_epochs)
 
 
 ######################################################################
 # Plotting Results
-# ------------
+# ----------------
 #
 
 
 ######################################################################
-# Now we use the history stored by Skorch throughout training to plot
+# Now we use the history stored by skorch throughout training to plot
 # accuracy and loss curves.
 #
 
@@ -366,3 +366,5 @@ plot_confusion_matrix(confusion_mat, class_names=labels)
 #        Eggensperger, K., Tangermann, M., Hutter, F., Burgard, W. and Ball, T. (2017),
 #        Deep learning with convolutional neural networks for EEG decoding and visualization.
 #        Hum. Brain Mapping, 38: 5391-5420. https://doi.org/10.1002/hbm.23730.
+#
+# .. include:: /links.inc

--- a/examples/model_building/plot_how_train_test_and_tune.py
+++ b/examples/model_building/plot_how_train_test_and_tune.py
@@ -1,4 +1,6 @@
 """
+.. _train-test-tune-model:
+
 How to train, test and tune your model?
 =======================================
 
@@ -8,7 +10,7 @@ models with Braindecode. We will use the BCIC IV 2a dataset [1]_ as a showcase e
 The methods shown can be applied to any standard supervised trial-based decoding setting.
 This tutorial will include additional parts of code like loading and preprocessing of data,
 defining a model, and other details which are not exclusive to this page (see
-`Cropped Decoding Tutorial <./plot_bcic_iv_2a_moabb_cropped.html>`__). Therefore we
+:ref:`Cropped Decoding Tutorial <bcic-iv-2a-moabb-cropped>`). Therefore we
 will not further elaborate on these parts and you can feel free to skip them.
 
 In general, we distinguish between "usual" training and evaluation and hyperparameter search.
@@ -87,7 +89,7 @@ and one for the two different hyperparameter tuning methods.
 #
 # In this example, we load the BCI Competition IV 2a data [1]_, for one
 # subject (subject id 3), using braindecode's wrapper to load via
-# `MOABB library <https://github.com/NeuroTechX/moabb>`__ [2]_.
+# `MOABB library <moabb_>`_ [2]_.
 #
 from braindecode.datasets import MOABBDataset
 
@@ -141,7 +143,7 @@ preprocess(dataset, preprocessors, n_jobs=-1)
 # events inside the dataset. One event is the demarcation of the stimulus or
 # the beginning of the trial. In this example, we want to analyse 0.5 [s] long
 # before the corresponding event and the duration of the event itself.
-# #Therefore, we set the ``trial_start_offset_seconds`` to -0.5 [s] and the
+# Therefore, we set the ``trial_start_offset_seconds`` to -0.5 [s] and the
 # ``trial_stop_offset_seconds`` to 0 [s].
 #
 # We extract from the dataset the sampling frequency, which is the same for
@@ -181,7 +183,7 @@ windows_dataset = create_windows_from_events(
 ######################################################################
 # We can easily split the dataset BCIC IV 2a dataset using additional
 # info stored in the description attribute, in this case the ``session``
-# column. We select ``0train`` for training and ``0test`` for testing.
+# column. We select ``0train`` for training and ``1test`` for testing.
 # For other datasets, you might have to choose another column and/or column.
 #
 # .. note::
@@ -413,7 +415,7 @@ print(f"Test acc: {(test_acc * 100):.2f}%")
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # The following figure illustrates split of entire dataset into the
 # training, validation and testing subsets.
-# ``Making more compact plot_train_valid_test function.``
+# Making more compact ``plot_train_valid_test`` function.
 #
 
 
@@ -483,10 +485,8 @@ plot_train_valid_test(
 #    estimate of the generalization performance.
 #
 # To implement this, we will make use of sklearn function
-# `cross_val_score <https://scikit-learn.org/stable/modules/generated/
-# sklearn.model_selection.cross_val_score.html>`__ and the `KFold
-# <https://scikit-learn.org/stable/modules/generated/sklearn.model_
-# selection.KFold.html>`__. CV splitter.
+# :func:`sklearn.model_selection.cross_val_score` and the
+# :class:`sklearn.model_selection.KFold` CV splitter.
 # The ``train_split`` argument has to be set to ``None``, as sklearn
 # will take care of the splitting.
 #
@@ -625,14 +625,14 @@ plot_k_fold(
 #
 
 ######################################################################
-# We will again make use of the `sklearn <https://scikit-learn.org/stable/>`__
-# library to do the hyperparameter search. `GridSearchCV
-# <https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`__
+# We will again make use of the `<scikit-learn_>`_
+# library to do the hyperparameter search. :class:`GridSearchCV
+# <sklearn.model_selection.GridSearchCV>`
 # will perform a Grid Search over the parameters specified in ``param_grid``.
-# We use grid search for the model selection as a simple example, but you can use other strategies
-# as well.
-# (`List of the sklearn classes for model selection
-# <https://scikit-learn.org/stable/modules/classes.html#module-sklearn.model_selection>`__.)
+# We use grid search for the model selection as a simple example,
+# but you can use other strategies as well.
+# (:mod:`List of the sklearn classes for model selection
+# <sklearn.model_selection>`.)
 #
 
 import pandas as pd
@@ -676,8 +676,7 @@ best_parameters = best_run["params"]
 
 ######################################################################
 # To perform a full k-Fold CV just replace ``train_val_split`` from
-# above with the `KFold <https://scikit-learn.org/stable/modules/generated/
-# sklearn.model_selection.KFold.html>`__ cross-validator from sklearn.
+# above with the :class:`sklearn.model_selection.KFold` cross-validator.
 
 train_val_split = KFold(n_splits=5, shuffle=False)
 
@@ -698,3 +697,5 @@ train_val_split = KFold(n_splits=5, shuffle=False)
 #        Eggensperger, K., Tangermann, M., Hutter, F., Burgard, W. and Ball, T. (2017),
 #        Deep learning with convolutional neural networks for EEG decoding and visualization.
 #        Hum. Brain Mapping, 38: 5391-5420. https://doi.org/10.1002/hbm.23730.
+#
+# .. include:: /links.inc

--- a/examples/model_building/plot_hyperparameter_tuning_with_scikit-learn.py
+++ b/examples/model_building/plot_hyperparameter_tuning_with_scikit-learn.py
@@ -1,9 +1,11 @@
 """
+.. _tuning-with-scikit-learn:
+
 Hyperparameter tuning with scikit-learn
 =======================================
 
 The braindecode provides some compatibility with
-`scikit-learn <https://scikit-learn.org/stable/>`__. This allows us
+`<scikit-learn_>`_. This allows us
 to use scikit-learn functionality to find the best hyperparameters for our
 model. This is especially useful to tune hyperparameters or
 parameters for one decoding task or a specific dataset.
@@ -12,7 +14,7 @@ parameters for one decoding task or a specific dataset.
 
     Deep learning models are often sensitive to the choice of hyperparameters
     and parameters. Hyperparameters are the parameters set before
-    training the model. The hyeperparameters determine (1) the capacity of the model,
+    training the model. The hyperparameters determine (1) the capacity of the model,
     e.g. its depth (the number of layers) and its width (the number of
     convolutional kernels, sizes of fully connected layers) and (2) the
     learning process via the choice of optimizer and its learning rate,
@@ -53,15 +55,13 @@ of the learning rate and dropout probability on the model's performance.
 
 ######################################################################
 # First, we load the data. In this tutorial, we use the functionality of
-# braindecode to load datasets via
-# `MOABB <https://github.com/NeuroTechX/moabb>`__ [2]_ to load the BCI
-# Competition IV 2a data [3]_.
+# braindecode to load datasets via `MOABB <moabb_>`_ [2]_
+# to load the BCI Competition IV 2a data [3]_.
 #
 # .. note::
 #    To load your own datasets either via mne or from
-#    preprocessed X/y numpy arrays, see `MNE Dataset
-#    Tutorial <./plot_mne_dataset_example.html>`__ and `Numpy Dataset
-#    Tutorial <./plot_custom_dataset_example.html>`__.
+#    preprocessed X/y numpy arrays, see :ref:`mne-dataset-example`
+#    and :ref:`custom-dataset-example`.
 #
 
 from braindecode.datasets.moabb import MOABBDataset
@@ -76,20 +76,17 @@ dataset = MOABBDataset(dataset_name="BNCI2014001", subject_ids=[subject_id])
 
 
 ######################################################################
-# In this example, preprocessing includes signal rescaling, the bandpass filtering
-# (low and high cut-off frequencies are 4 and 38 Hz) and the standardization using
-# the exponential moving mean and variance.
-# You can either apply functions provided by
-# `mne.Raw <https://mne.tools/stable/generated/mne.io.Raw.html>`__ or
-# `mne.Epochs <https://mne.tools/stable/generated/mne.Epochs.html>`__
-# or apply your own functions, either to the MNE object or the underlying
-# numpy array.
+# In this example, preprocessing includes signal rescaling, the bandpass
+# filtering (low and high cut-off frequencies are 4 and 38 Hz) and
+# the standardization using the exponential moving mean and variance.
+# You can either apply functions provided by :class:`mne.io.Raw`
+# or :class:`mne.Epochs` or apply your own functions,
+# either to the MNE object or the underlying numpy array.
 #
 # .. note::
 #    These prepocessings are now directly applied to the loaded
 #    data, and not on-the-fly applied as transformations in
-#    PyTorch-libraries like
-#    `torchvision <https://pytorch.org/docs/stable/torchvision/index.html>`__.
+#    PyTorch-libraries like `<torchvision_>`_.
 #
 
 from braindecode.preprocessing.preprocess import (
@@ -138,7 +135,7 @@ preprocess(dataset, preprocessors, n_jobs=-1)
 # events inside the dataset. One event is the demarcation of the stimulus or
 # the beginning of the trial. In this example, we want to analyse 0.5 [s] long
 # before the corresponding event and the duration of the event itself.
-# #Therefore, we set the ``trial_start_offset_seconds`` to -0.5 [s] and the
+# Therefore, we set the ``trial_start_offset_seconds`` to -0.5 [s] and the
 # ``trial_stop_offset_seconds`` to 0 [s].
 #
 # We extract from the dataset the sampling frequency, which is the same for
@@ -197,9 +194,9 @@ eval_set = splitted["1test"]  # Session evaluation
 # time-domain EEG. Here, we use the ShallowFBCSPNet model from `Deep
 # learning with convolutional neural networks for EEG decoding and
 # visualization <https://arxiv.org/abs/1703.05051>`__ [4]_. These models are
-# pure `PyTorch <https://pytorch.org>`__ deep learning models, therefore
+# pure `PyTorch <pytorch_>`_ deep learning models, therefore
 # to use your own model, it just has to be a normal PyTorch
-# `nn.Module <https://pytorch.org/docs/stable/nn.html#torch.nn.Module>`__.
+# :class:`torch.nn.Module`.
 #
 from functools import partial
 import torch
@@ -246,12 +243,11 @@ if cuda and hasattr(model, "cuda"):
 
 
 ######################################################################
-# Now we train the network! EEGClassifier is a Braindecode object
+# Now we train the network! :class:`EEGClassifier
+# <braindecode.classifier.EEGClassifier>` is a Braindecode object
 # responsible for managing the training of neural networks. It inherits
-# from `skorch.NeuralNetClassifier <https://skorch.readthedocs.io/
-# en/latest/classifier.html>`__,
-# so the training logic is the same as in
-# `Skorch <https://skorch.readthedocs.io/en/stable/>`__.
+# from :class:`skorch.classifier.NeuralNetClassifier`,
+# so the training logic is the same as in `<skorch_>`_.
 #
 
 from skorch.callbacks import LRScheduler
@@ -276,11 +272,10 @@ clf = EEGClassifier(
 )
 
 ######################################################################
-# We use scikit-learn `GridSearchCV
-# <https://scikit-learn.org/stable/modules/generated/
-# sklearn.model_selection.GridSearchCV.html>`__ to tune hyperparameters.
+# We use scikit-learn :class:`GridSearchCV
+# <sklearn.model_selection.GridSearchCV>` to tune hyperparameters.
 # To be able to do this, we slice the braindecode datasets that by default
-# return a 3-tuple to return X and y, respectively.
+# return a 3-tuple to return ``X`` and ``y``, respectively.
 #
 
 ######################################################################
@@ -386,3 +381,5 @@ print(f"Eval accuracy is {score * 100:.2f}%.")
 #        Eggensperger, K., Tangermann, M., Hutter, F., Burgard, W. and Ball, T. (2017),
 #        Deep learning with convolutional neural networks for EEG decoding and visualization.
 #        Hum. Brain Mapping, 38: 5391-5420. https://doi.org/10.1002/hbm.23730.
+#
+# .. include:: /links.inc

--- a/examples/model_building/plot_regression.py
+++ b/examples/model_building/plot_regression.py
@@ -1,4 +1,6 @@
 """
+.. _convnet-regression-fake:
+
 Convolutional neural network regression model on fake data.
 ===========================================================
 
@@ -14,9 +16,9 @@ function from the classifier's output layer and how to train it on a fake regres
 ###################################################################################################
 # Fake regression data
 # --------------------
-# Function for generation of the fake regression dataset generates `n_fake_recs` recordings,
+# Function for generation of the fake regression dataset generates ``n_fake_recs`` recordings,
 # each containing sinusoidal signals with Gaussian noise. Each fake recording signal has
-# `n_fake_chs` channels, it lasts `fake_duration` [s] and it is sampled with `fake_sfreq` [Hz].
+# ``n_fake_chs`` channels, it lasts ``fake_duration`` [s] and it is sampled with ``fake_sfreq`` [Hz].
 # The recordings are split into train, validation and testing sessions.
 
 import numpy as np
@@ -108,7 +110,8 @@ dataset = fake_regression_dataset(
 # Defining a CNN regression model
 # -------------------------------
 #
-# Choosing and defining a CNN classifier, `ShallowFBCSPNet` or `Deep4Net`, introduced in [1]_.
+# Choosing and defining a CNN classifier, :class:`ShallowFBCSPNet <braindecode.models.ShallowFBCSPNet>`
+# or :class:`Deep4Net <braindecode.models.Deep4Net>`, introduced in [1]_.
 # To convert a classifier to a regressor, `softmax` function is removed from its output layer.
 from braindecode.util import set_random_seeds
 from braindecode.models import Deep4Net
@@ -162,7 +165,8 @@ if cuda:
 ###################################################################################################
 # Data windowing
 # ----------------
-# Windowing data with a sliding window into the epochs of the size `window_size_samples`.
+# Windowing data with a sliding window into the epochs of the size ``window_size_samples``.
+
 from braindecode.models.util import to_dense_prediction_model, get_output_shape
 from braindecode.preprocessing import create_fixed_length_windows
 

--- a/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
+++ b/examples/model_building/plot_train_in_pure_pytorch_and_pytorch_lightning.py
@@ -1,17 +1,19 @@
 """
+.. _train-model-in-pytorch:
+
 Training a Braindecode model in PyTorch
 =======================================
 
 This tutorial shows you how to train a Braindecode model with PyTorch. The data
 preparation and model instantiation steps are identical to that of the tutorial
-`How to train, test and tune your model <./plot_how_train_test_and_tune.html>`__
+:ref:`train-test-tune-model`.
 
 We will use the BCIC IV 2a dataset as a showcase example.
 
 The methods shown can be applied to any standard supervised trial-based decoding setting.
 This tutorial will include additional parts of code like loading and preprocessing,
 defining a model, and other details which are not exclusive to this page (compare
-`Cropped Decoding Tutorial <./plot_bcic_iv_2a_moabb_trial.html>`__). Therefore we
+:ref:`bcic-iv-2a-moabb-trial`). Therefore we
 will not further elaborate on these parts and you can feel free to skip them.
 
 The goal of this tutorial is to present braindecode in the PyTorch perceptive.
@@ -67,7 +69,7 @@ The goal of this tutorial is to present braindecode in the PyTorch perceptive.
 
 ######################################################################
 # Loading the Dataset Structure
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # Here, we have a data structure with equal behavior to the Pytorch Dataset.
 
 from braindecode.datasets import MOABBDataset
@@ -185,7 +187,7 @@ if cuda:
 ######################################################################
 # We can easily split the dataset using additional info stored in the
 # description attribute, in this case the ``session`` column. We
-# select ``Train`` for training and ``test`` for testing.
+# select ``0train`` for training and ``1test`` for testing.
 # For other datasets, you might have to choose another column.
 #
 # .. note::
@@ -208,8 +210,8 @@ test_set = splitted["1test"]  # Session evaluation
 
 
 ######################################################################
-# `model` is an instance of `torch.nn.Module`, and can as such be trained
-# using PyTorch optimization capabilities.
+# ``model`` is an instance of :class:`torch.nn.Module`,
+# and can as such be trained using PyTorch optimization capabilities.
 # The following training scheme is simple as the dataset is only
 # split into two distinct sets (``train_set`` and ``test_set``).
 # This scheme uses no separate validation split and should only be
@@ -368,7 +370,7 @@ for epoch in range(1, n_epochs + 1):
 #    :alt: Pytorch Lightning logo
 
 ######################################################################
-# Alternatively, lightning provides a nice interface around torch modules
+# Alternatively, `<lightning_>`_ provides a nice interface around torch modules
 # which integrates the previous logic.
 
 
@@ -416,3 +418,7 @@ trainer.fit(lit_model, train_loader)
 
 # After training, you can test the model using the test DataLoader
 trainer.test(dataloaders=test_loader)
+
+######################################################################
+#
+# .. include:: /links.inc


### PR DESCRIPTION
Closes #720

Besides the installation page, there were a couple of other links broken or pointing to the wrong pages.

Now external links use the `links.inc` file via substitution refs, and links between tutorials use `:ref:` with labels. This should make things less likely to 404s.

Also corrected some minor typos along the way.