### PR TITLE
Set models to start in train mode by default

### DIFF
--- a/braindecode/models/deep4.py
+++ b/braindecode/models/deep4.py
@@ -319,5 +319,4 @@ class Deep4Net(EEGModuleMixin, nn.Sequential):
         init.xavier_uniform_(self.final_layer.conv_classifier.weight, gain=1)
         init.constant_(self.final_layer.conv_classifier.bias, 0)
 
-        # Start in eval mode
-        self.eval()
+        self.train()

--- a/braindecode/models/eegresnet.py
+++ b/braindecode/models/eegresnet.py
@@ -275,8 +275,8 @@ class EEGResNet(EEGModuleMixin, nn.Sequential):
         # Initialize all weights
         self.apply(lambda module: self._weights_init(module, self.conv_weight_init_fn))
 
-        # Start in eval mode
-        self.eval()
+        # Start in train mode
+        self.train()
 
     @staticmethod
     def _weights_init(module, conv_weight_init_fn):

--- a/braindecode/models/shallow_fbcsp.py
+++ b/braindecode/models/shallow_fbcsp.py
@@ -204,3 +204,5 @@ class ShallowFBCSPNet(EEGModuleMixin, nn.Sequential):
             init.constant_(self.bnorm.bias, 0)
         init.xavier_uniform_(self.final_layer.conv_classifier.weight, gain=1)
         init.constant_(self.final_layer.conv_classifier.bias, 0)
+
+        self.train()

--- a/braindecode/models/tcn.py
+++ b/braindecode/models/tcn.py
@@ -161,7 +161,7 @@ class TCN(nn.Module):
             self.min_len += 2 * (kernel_size - 1) * dilation
 
         # start in eval mode
-        self.eval()
+        self.train()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward pass.

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -22,7 +22,7 @@ Current 0.9 (dev0)
 
 Enhancements
 ~~~~~~~~~~~~
-- Make sure all the models start at train model (:gh:`751` by `Bruno Aristimunha`_)
+- Make sure all the models start at train model (:gh:`745` by `Bruno Aristimunha`_)
 - Enable more models to be pytorch compatible (:gh:`732` by `Bruno Aristimunha`_ and `Lucas Heck`_)
 - Making the braindecode.models compatibility with torch compile, torch export and torch jit (:gh:`729` by `Bruno Aristimunha` and `Pierre Guetschel`_)
 - Reorder the modules, functional and re-organize the codebase (:gh:`728` by `Bruno Aristimunha`_)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -22,6 +22,7 @@ Current 0.9 (dev0)
 
 Enhancements
 ~~~~~~~~~~~~
+- Make sure all the models start at train model (:gh:`751` by `Bruno Aristimunha`_)
 - Enable more models to be pytorch compatible (:gh:`732` by `Bruno Aristimunha`_ and `Lucas Heck`_)
 - Making the braindecode.models compatibility with torch compile, torch export and torch jit (:gh:`729` by `Bruno Aristimunha` and `Pierre Guetschel`_)
 - Reorder the modules, functional and re-organize the codebase (:gh:`728` by `Bruno Aristimunha`_)


### PR DESCRIPTION
Ensure all models initialize in train mode instead of eval mode to facilitate training from the start.

closes: #744