### PR TITLE
Modify verbosity of create_windows_from_events to clean printed outputs

### DIFF
--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -11,6 +11,7 @@
 #          Maciej Sliwowski <maciek.sliwowski@gmail.com>
 #          Mohammed Fattouh <mo.fattouh@gmail.com>
 #          Robin Schirrmeister <robintibor@gmail.com>
+#          Matthew Chen <matt.chen42601@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,6 +32,7 @@ Enhancements
 - Better inheritance between the different dataset classes (:gh:`806` by `Pierre Guetschel`_ )
 - Fix minor documentation issues in Labram (:gh:`808` by `Matthew Chen`_)
 - Including missed tag in all the models and creating some test for it (:gh:`811` by `Bruno Aristimunha`_ )
+- Modify verbosity of create_window_from_events (:gh:`814` by `Matthew Chen`_)
 
 
 API changes

--- a/test/unit_tests/preprocessing/test_windowers.py
+++ b/test/unit_tests/preprocessing/test_windowers.py
@@ -2,6 +2,7 @@
 #          Robin Tibor Schirrmeister <robintibor@gmail.com>
 #          Maciej Sliwowski <maciek.sliwowski@gmail.com>
 #          Hubert Banville <hubert.jbanville@gmail.com>
+#          Matthew Chen <matt.chen42601@gmail.com>
 #
 # License: BSD-3
 


### PR DESCRIPTION
Currently, braindecode does not control the verbosity of the function call to `mne.events_from_annotations`, leading to inconveniences such as https://github.com/braindecode/braindecode/issues/778. This small change + unit test ensures that the end user can control the verbosity and that it is propagated directly to MNE. 

For example, a common use case was during the (EEG Challenge 2025)[https://eeg2025.github.io/], where the message: 

```
Used Annotations descriptions: [np.str_('stimulus_anchor')]
```

Was printed every time the data was loaded. This can be specifically attributed to (the MNE line in this commit)[https://github.com/mne-tools/mne-python/blob/7cfcc6ba0bd409e2ec2bb76598853288f61d6dc0/mne/annotations.py#L1924]. 

Instead of specifying the verbosity parameter, it used the default, which caused the logger message to print every time. 

To ensure it was properly fixed, I wrote a unit test. Note that (mne's logger set propagate to false)[https://github.com/mne-tools/mne-python/blob/7cfcc6ba0bd409e2ec2bb76598853288f61d6dc0/mne/utils/_logging.py], so the unit test temporarily changes the logger's propagation properties for the sake of testing. 

Outside of those, I noticed that there were some formatting issues (violated flake8) in the files I was working on (often because the lines were too long) so I also decided it would be better to clean the formatting while I was working on the file. 