### PR TITLE
Fix documentation + interface of FBC models

### DIFF
--- a/braindecode/models/fbcnet.py
+++ b/braindecode/models/fbcnet.py
@@ -69,7 +69,9 @@ class FBCNet(EEGModuleMixin, nn.Module):
     linear_max_norm : float, default=0.5
         Maximum norm for the final linear layer.
     filter_parameters: dict, default None
-        Parameters for the FilterBankLayer
+        Dictionary of parameters to use for the FilterBankLayer.
+        If None, a default Chebyshev Type II filter with transition bandwidth of
+        2 Hz and stop-band ripple of 30 dB will be used.
 
     References
     ----------

--- a/braindecode/models/fbmsnet.py
+++ b/braindecode/models/fbmsnet.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Sequence
+from typing import Any, Sequence
 
 import torch
 from einops.layers.torch import Rearrange
@@ -57,16 +57,28 @@ class FBMSNet(EEGModuleMixin, nn.Module):
     ----------
     n_bands : int, default=9
         Number of input channels (e.g., number of frequency bands).
-    stride_factor : int, default=4
-        Stride factor for temporal segmentation.
-    temporal_layer : str, default='LogVarLayer'
-        Temporal aggregation layer to use.
     n_filters_spat : int, default=36
         Number of output channels from the MixedConv2d layer.
+    temporal_layer : str, default='LogVarLayer'
+        Temporal aggregation layer to use.
+    n_dim: int, default=3
+        Dimension of the temporal reduction layer.
+    stride_factor : int, default=4
+        Stride factor for temporal segmentation.
     dilatability : int, default=8
         Expansion factor for the spatial convolution block.
     activation : nn.Module, default=nn.SiLU
         Activation function class to apply.
+    kernels_weights : Sequence[int], default=(15, 31, 63, 125)
+        Kernel sizes for the MixedConv2d layer.
+    cnn_max_norm : float, default=2
+        Maximum norm constraint for the convolutional layers.
+    linear_max_norm : float, default=0.5
+        Maximum norm constraint for the linear layers.
+    filter_parameters : dict, default=None
+        Dictionary of parameters to use for the FilterBankLayer.
+        If None, a default Chebyshev Type II filter with transition bandwidth of
+        2 Hz and stop-band ripple of 30 dB will be used.
     verbose: bool, default False
         Verbose parameter to create the filter using mne.
 
@@ -103,7 +115,7 @@ class FBMSNet(EEGModuleMixin, nn.Module):
         cnn_max_norm: float = 2,
         linear_max_norm: float = 0.5,
         verbose: bool = False,
-        filter_parameters: Optional[dict] = None,
+        filter_parameters: dict[Any, Any] | None = None,
     ):
         super().__init__(
             n_chans=n_chans,

--- a/braindecode/modules/filter.py
+++ b/braindecode/modules/filter.py
@@ -109,11 +109,6 @@ class FilterBankLayer(nn.Module):
         or "firwin2" to use :func:`scipy.signal.firwin2`. "firwin" uses
         a time-domain design technique that generally gives improved
         attenuation using fewer samples than "firwin2".
-    pad : str, default='reflect_limited'
-        The type of padding to use. Supports all func:`numpy.pad()` mode options.
-        Can also be "reflect_limited", which pads with a reflected version of
-        each vector mirrored on the first and last values of the vector,
-        followed by zeros. Only used for ``method='fir'``.
     verbose: bool | str | int | None, default=True
         Control verbosity of the logging output. If ``None``, use the default
         verbosity level. See the func:`mne.verbose` for details.
@@ -183,7 +178,6 @@ class FilterBankLayer(nn.Module):
                     "The band_filters items should be splitable in 2 values."
                 )
 
-        # and we accepted as
         self.band_filters = band_filters
         self.n_bands = len(band_filters)
         self.phase = phase

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,6 +33,7 @@ Enhancements
 - Fix minor documentation issues in Labram (:gh:`808` by `Matthew Chen`_)
 - Including missed tag in all the models and creating some test for it (:gh:`811` by `Bruno Aristimunha`_ )
 - Modify verbosity of create_window_from_events (:gh:`814` by `Matthew Chen`_)
+- Modify the interface of FBMSNet for consistency with FBCNet + Unit Tests (:gh:`819` by `Matthew Chen`_)
 
 
 API changes


### PR DESCRIPTION
- Clean up the constructor parameterizations of FBMSNet so they are consistent with FBCNet.
- Added documentation for constructors
- Removed "padding" documentation from FilterBankLayer as it is not used. Note that the pad parameter was added in [MNE v 0.15](https://mne.tools/stable/generated/mne.filter.filter_data.html) to the filter_data function, but it is never called in the filter bank layer. Instead, external modules that call FilterBankLayer, such as FBMSNet and FBCNet, pad after FilterBankLayer's forward pass.
- Also added additional unit tests to `test_models.py` since there were no unit tests for FBMSNet in that file.
    - Note that the [FBMSNet paper](https://ieeexplore.ieee.org/document/9837422) does not provide a calculation of total parameters, so no unit test mirrors the FBCNet's parametrization unit test.
    - Otherwise, in general, the new unit tests mirror FBCNet's unit tests.
- With regards to the issue, https://github.com/braindecode/braindecode/issues/725, I originally wanted the constructor filter parameter arguments to be like: 

```
filter_parameters: dict[Any, Any] | None = {}
```
which would simplify the line:

```
self.filter_parameters = filter_parameters or {} -> self.filter_parameters = filter_parameters
```
But it seems like `mypy` complains about it even though it is valid Python syntax. Therefore, I chose to keep the initialization as:

```
filter_parameters: dict[Any, Any] | None = Mpme
self.filter_parameters = filter_parameters or {} 
```

Also, since I worked on these files, I formatted them because I noticed some weren't following flake8 conventions (line too long, etc.).
   