### PR TITLE
EEG data augmentations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=Gool,carin,splitted,meaned,wil,whats,additionals,alle,alot,bund,currenty,datas,farenheit,falsy,fo,haa,hass,iif,incomfort,ines,ist,nam,nd,pres,pullrequests,resset,rime,ser,serie,te,technik,ue,unsecure,withing,zar,mane,THIRDPARTY
+          - --ignore-words-list=Gool,carin,splitted,meaned,wil,whats,additionals,alle,alot,bund,currenty,datas,farenheit,falsy,fo,haa,hass,iif,incomfort,ines,ist,nam,nd,pres,pullrequests,resset,rime,ser,serie,te,technik,ue,unsecure,withing,zar,mane,THIRDPARTY,Hsi,Buss,Claus,Lew,Shepard,Comon
           - --skip="./.*,*.csv,*.json,*.ambr,*.toml"
           - --quiet-level=2
         exclude_types: [ csv, json ]

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -1,6 +1,7 @@
 # Authors: Cédric Rommel <cedric.rommel@inria.fr>
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Gustavo Rodrigues <gustavenrique01@gmail.com>
+#          Bruna Lopes <brunajaflopes@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -17,7 +18,7 @@ from .functional import (
     bandstop_filter,
     channels_dropout,
     channels_permute,
-    channels_recomb,
+    channels_rereference,
     channels_shuffle,
     frequency_shift,
     ft_surrogate,
@@ -1275,7 +1276,7 @@ class MaskEncoding(Transform):
         }
 
 
-class ChannelsRecomb(Transform):
+class ChannelsReref(Transform):
     """Randomly re-reference channels in EEG data matrix.
 
     Part of the augmentations proposed in [1]_
@@ -1299,13 +1300,13 @@ class ChannelsRecomb(Transform):
 
     """
 
-    operation = staticmethod(channels_recomb)  # type: ignore[assignment]
+    operation = staticmethod(channels_rereference)  # type: ignore[assignment]
 
     def __init__(self, probability, random_state=None):
         super().__init__(probability=probability, random_state=random_state)
 
     def get_augmentation_params(self, *batch):
-        """Return transform parameters """
+        """Return transform parameters"""
         return {
             "random_state": self.rng,
         }
@@ -1337,13 +1338,10 @@ class AmplitudeScale(Transform):
 
     operation = staticmethod(amplitude_scale)  # type: ignore[assignment]
 
-    def __init__(self, probability, interval = (0.5,2), random_state=None):
+    def __init__(self, probability, interval=(0.5, 2), random_state=None):
         super().__init__(probability=probability, random_state=random_state)
         self.scale = interval
 
     def get_augmentation_params(self, *batch):
-        """Return transform parameters """
-        return {
-            "random_state": self.rng,
-            "scale": self.scale
-        }
+        """Return transform parameters"""
+        return {"random_state": self.rng, "scale": self.scale}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -573,6 +573,8 @@ frequency'domain transformations, and spatial transformations.
     Mixup
     SegmentationReconstruction
     MaskEncoding
+    AmplitudeScale
+    ChannelsReref
 
 
 The functional augmentation API contains the same transformations as the
@@ -600,6 +602,8 @@ transforms API, but they are implemented as functions.
     mixup
     segmentation_reconstruction
     mask_encoding
+    amplitude_scale
+    channels_rereference
 
 
 Classifier

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -272,3 +272,2551 @@ url={https://openreview.net/forum?id=3y1K6buO8c}
   booktitle={International Conference on Learning Representations},
   year={2020}
 }
+
+% MNE-Python References
+% Source: https://github.com/mne-tools/mne-python/blob/main/doc/references.bib
+% Encoding: UTF-8
+%
+% If available, include a DOI (preferred) *or* a URL for a given reference, but
+# not both, as the DOI turns into a link which is redundant with the URL.
+
+% MNE-C reference
+@article{GramfortEtAl2014,
+  title = {{{MNE}} Software for Processing {{MEG}} and {{EEG}} Data},
+  author = {Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A. and Strohmeier, Daniel and Brodbeck, Christian and Parkkonen, Lauri and H{\"a}m{\"a}l{\"a}inen, Matti S.},
+  year = {2014},
+  volume = {86},
+  pages = {446--460},
+  doi = {10.1016/j.neuroimage.2013.10.027},
+  journal = {NeuroImage},
+}
+% MNE-Python reference
+@article{GramfortEtAl2013a,
+  title = {{{MEG}} and {{EEG}} Data Analysis with {{MNE}}-{{Python}}},
+  author = {Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A. and Strohmeier, Daniel and Brodbeck, Christian and Goj, Roman and Jas, Mainak and Brooks, Teon and Parkkonen, Lauri and H{\"a}m{\"a}l{\"a}inen, Matti S.},
+  year = {2013},
+  volume = {7},
+  pages = {1--13},
+  doi = {10.3389/fnins.2013.00267},
+  journal = {Frontiers in Neuroscience},
+  number = {267}
+}
+% everything else
+@article{AblinEtAl2018,
+  author = {Ablin, Pierre and Cardoso, Jean-Francois and Gramfort, Alexandre},
+  doi = {10.1109/TSP.2018.2844203},
+  journal = {IEEE Transactions on Signal Processing},
+  number = {15},
+  pages = {4040-4049},
+  title = {Faster {{Independent Component Analysis}} by Preconditioning with Hessian Approximations},
+  volume = {66},
+  year = {2018}
+}
+
+@article{AcunzoEtAl2012,
+  author = {Acunzo, David J. and MacKenzie, Graham and {van Rossum}, Mark C.W.},
+  doi = {10.1016/j.jneumeth.2012.06.011},
+  journal = {Journal of Neuroscience Methods},
+  number = {1},
+  pages = {212-218},
+  title = {Systematic Biases in Early {{ERP}} and {{ERF}} Components as a Result of High-Pass Filtering},
+  volume = {209},
+  year = {2012}
+}
+
+@article{Alday2019,
+  title = {How much baseline correction do we need in {ERP} research? Extended {GLM} model can replace baseline correction while lifting its limits},
+  author = {Alday, Phillip M.},
+  year = {2019},
+  volume = {56},
+  doi = {10.1111/psyp.13451},
+  journal = {Psychophysiology},
+  number = {12}
+}
+
+@article{ArtoniEtAl2018,
+  author = {Artoni, Fiorenzo and Delorme, Arnaud and Makeig, Scott},
+  doi = {10.1016/j.neuroimage.2018.03.016},
+  journal = {NeuroImage},
+  pages = {176-187},
+  title = {Applying Dimension Reduction to {{EEG}} Data by {{Principal Component Analysis}} Reduces the Quality of Its Subsequent {{Independent Component}} Decomposition},
+  volume = {175},
+  year = {2018}
+}
+
+@article{AvantsEtAl2008,
+  author = {Avants, Brian B. and Epstein, Charles L. and Grossman, Murray C. and Gee, James C.},
+  doi = {10.1016/j.media.2007.06.004},
+  journal = {Medical Image Analysis},
+  number = {1},
+  pages = {26-41},
+  shorttitle = {Symmetric Diffeomorphic Image Registration with Cross-Correlation},
+  title = {Symmetric Diffeomorphic Image Registration with Cross-Correlation: Evaluating Automated Labeling of Elderly and Neurodegenerative Brain},
+  volume = {12},
+  year = {2008}
+}
+
+@article{BailletEtAl2001,
+  author = {Baillet, Sylvain and Mosher, John C. and Leahy, Richard M.},
+  doi = {10.1109/79.962275},
+  journal = {IEEE Signal Processing Magazine},
+  number = {6},
+  pages = {14-30},
+  title = {Electromagnetic Brain Mapping},
+  volume = {18},
+  year = {2001}
+}
+
+@inproceedings{BarachantEtAl2010,
+  author = {Barachant, Alexandre and Bonnet, Stephane and Congedo, Marco and Jutten, Christian},
+  booktitle = {2010 IEEE International Workshop on Multimedia Signal Processing},
+  title = {Common Spatial Pattern revisited by {Riemannian} geometry},
+  year = {2010},
+  pages={472-476},
+  doi = {10.1109/MMSP.2010.5662067}
+}
+
+@book{Barber2012,
+  address = {{Cambridge}},
+  author = {Barber, David},
+  isbn = {978-0-521-51814-7},
+  publisher = {{Cambridge University Press}},
+  title = {Bayesian Reasoning and Machine Learning},
+  url = {http://www.cs.ucl.ac.uk/staff/d.barber/brml/},
+  year = {2012}
+}
+
+@inproceedings{BekhtiEtAl2016,
+  address = {{Trento}},
+  author = {Bekhti, Yousra and Strohmeier, Daniel and Jas, Mainak and Badeau, Roland and Gramfort, Alexandre},
+  booktitle = {Proceedings of {{PRNI}}-2016},
+  doi = {10.1109/PRNI.2016.7552337},
+  isbn = {978-1-4673-6530-7},
+  pages = {1-4},
+  publisher = {{IEEE}},
+  title = {M/{{EEG}} Source Localization with Multi-Scale Time-Frequency Dictionaries},
+  year = {2016}
+}
+
+@article{BellSejnowski1995,
+  author = {Bell, Anthony J. and Sejnowski, Terrence J.},
+  doi = {10.1162/neco.1995.7.6.1129},
+  journal = {Neural Computation},
+  number = {6},
+  pages = {1129-1159},
+  title = {An Information-Maximization Approach to Blind Separation and Blind Deconvolution},
+  volume = {7},
+  year = {1995}
+}
+
+@article{BentivoglioEtAl1997,
+  author = {Bentivoglio, Anna Rita and Bressman, Susan B. and Cassetta, Emanuele and Carretta, Donatella and Tonali, Pietro and Albanese, Alberto},
+  doi = {10.1002/mds.870120629},
+  journal = {Movement Disorders},
+  number = {6},
+  pages = {1028-1034},
+  title = {Analysis of Blink Rate Patterns in Normal Subjects},
+  volume = {12},
+  year = {1997}
+}
+
+@article{BergScherg1994,
+  author = {Berg, Patrick and Scherg, Michael},
+  doi = {10.1016/0013-4694(94)90113-9},
+  journal = {Electroencephalography and Clinical Neurophysiology},
+  number = {1},
+  pages = {58-64},
+  title = {A Fast Method for Forward Computation of Multiple-Shell Spherical Head Models},
+  volume = {90},
+  year = {1994}
+}
+
+@inproceedings{BigdelyShamloEtAl2013,
+  author = {Bigdely-Shamlo, Nima and Kreutz-Delgado, Kenneth and Robbins, Kay and Miyakoshi, Makoto and Westerfield, Marissa and Bel-Bahar, Tarik and Kothe, Christian and Hsi, Jessica and Makeig, Scott},
+  doi = {10.1109/GlobalSIP.2013.6736796},
+  booktitle = {2013 IEEE Global Conference on Signal and Information Processing},
+  pages = {1--4},
+  title = {Hierarchical event descriptor {(HED)} tags for analysis of event-related {EEG} studies},
+  organization = {IEEE},
+  year = {2013},
+}
+
+@article{BlankertzEtAl2008,
+  author = {Blankertz, Benjamin and Tomioka, Ryota and Lemm, Steven and Kawanabe, Motoaki and Müller, Klaus-Robert},
+  doi = {10.1109/MSP.2008.4408441},
+  journal = {IEEE Signal Processing Magazine},
+  number = {1},
+  pages = {41-56},
+  title = {Optimizing Spatial Filters for Robust {{EEG}} Single-Trial Analysis},
+  volume = {25},
+  year = {2008}
+}
+
+@article{Bookstein1989,
+  author = {Bookstein, Fred L.},
+  doi = {10.1109/34.24792},
+  journal = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+  number = {6},
+  pages = {567-585},
+  shorttitle = {Principal Warps},
+  title = {Principal Warps: Thin-Plate Splines and the Decomposition of Deformations},
+  volume = {11},
+  year = {1989}
+}
+
+@article{BrookesEtAl2008,
+  author = {Brookes, Matthew J. and Vrba, Jiri and Robinson, Stephen E. and Stevenson, Claire M. and Peters, Andrew M. and Barnes, Gareth R. and Hillebrand, Arjan and Morris, Peter G.},
+  doi = {10.1016/j.neuroimage.2007.09.050},
+  journal = {NeuroImage},
+  number = {4},
+  pages = {1788-1802},
+  title = {Optimising Experimental Design for {{MEG}} Beamformer Imaging},
+  volume = {39},
+  year = {2008}
+}
+
+@article{BrunaEtAl2018,
+  doi = {10.1088/1741-2552/aacfe4},
+  year = {2018},
+  publisher = {{IOP} Publishing},
+  volume = {15},
+  number = {5},
+  pages = {056011},
+  author = {Ricardo Bru{\~{n}}a, Fernando Maest{\'{u}}, Ernesto Pereda},
+  title = {Phase locking value revisited: teaching new tricks to an old dog},
+  journal = {Journal of Neural Engineering},
+}
+
+@techreport{BurdakovMerkulov2001,
+  title={On a new norm for data fitting and optimization problems},
+  author={Burdakov, Oleg and Merkulov, Boris},
+  number={LiTH-MAT-R-2001-29},
+  address={Link{\"o}ping},
+  institution={Link{\"o}ping University},
+  type = {Technical {{Report}}},
+  year={2001}
+}
+
+@article{CamposViolaEtAl2009,
+  author = {Campos Viola, Filipa and Thorne, Jeremy and Edmonds, Barrie and Schneider, Till and Eichele, Tom and Debener, Stefan},
+  doi = {10.1016/j.clinph.2009.01.015},
+  journal = {Clinical Neurophysiology},
+  number = {5},
+  pages = {868-877},
+  title = {Semi-Automatic Identification of Independent Components Representing {{EEG}} Artifact},
+  volume = {120},
+  year = {2009}
+}
+
+@article{ChambonEtAl2018,
+  author = {Chambon, Stanislas and Galtier, Mathieu N. and Arnal, Pierrick J. and Wainrib, Gilles and Gramfort, Alexandre},
+  doi = {10.1109/TNSRE.2018.2813138},
+  journal = {IEEE Transactions on Neural Systems and Rehabilitation Engineering},
+  number = {4},
+  pages = {758-769},
+  title = {A Deep Learning Architecture for Temporal Sleep Stage Classification Using Multivariate and Multimodal Time Series},
+  volume = {26},
+  year = {2018}
+}
+
+@article{ChenEtAl2010,
+  author = {Chen, Yilun and Wiesel, Ami and Eldar, Yonina C. and Hero, Alfred O.},
+  doi = {10.1109/TSP.2010.2053029},
+  journal = {IEEE Transactions on Signal Processing},
+  number = {10},
+  pages = {5016-5029},
+  title = {Shrinkage Algorithms for {{MMSE}} Covariance Estimation},
+  volume = {58},
+  year = {2010}
+}
+
+@article{CichyEtAl2014,
+  author = {Cichy, Radoslaw Martin and Pantazis, Dimitrios and Oliva, Aude},
+  doi = {10.1038/nn.3635},
+  journal = {Nature Neuroscience},
+  number = {3},
+  pages = {455-462},
+  title = {Resolving Human Object Recognition in Space and Time},
+  volume = {17},
+  year = {2014}
+}
+
+@book{Cohen2014,
+  place={Cambridge, MA},
+  title={Analyzing Neural Time Series Data: Theory and Practice},
+  publisher={MIT Press},
+  author={Cohen, Mike X.},
+  year={2014}
+}
+
+@article{Cohen2019,
+  author={Cohen, Michael X},
+  doi = {10.1016/j.neuroimage.2019.05.048},
+  journal = {NeuroImage},
+  pages = {81-86},
+  title = {A better way to define and describe {Morlet} wavelets for time-frequency analysis},
+  volume = {199},
+  year = {2019}
+}
+
+@article{Cohen2022,
+author = {Cohen, Michael X},
+doi = {10.1016/j.neuroimage.2021.118809},
+journal = {NeuroImage},
+pages = {118809},
+title = {A tutorial on generalized eigendecomposition for denoising, contrast enhancement, and dimension reduction in multichannel electrophysiology},
+volume = {247},
+year = {2022},
+issn = {1053-8119},
+
+}
+
+@article{CohenHosaka1976,
+  author = {Cohen, David and Hosaka, Hidehiro},
+  doi = {10.1016/S0022-0736(76)80041-6},
+  journal = {Journal of Electrocardiology},
+  number = {4},
+  pages = {409-417},
+  title = {Part {{II}} Magnetic Field Produced by a Current Dipole},
+  volume = {9},
+  year = {1976}
+}
+
+@article{CrosseEtAl2016,
+  author = {Crosse, Michael J. and Di Liberto, Giovanni M. and Bednar, Adam and Lalor, Edmund C.},
+  doi = {10.3389/fnhum.2016.00604},
+  journal = {Frontiers in Human Neuroscience},
+  shorttitle = {The Multivariate Temporal Response Function ({{mTRF}}) Toolbox},
+  title = {The Multivariate Temporal Response Function ({{mTRF}}) Toolbox: A {{MATLAB}} Toolbox for Relating Neural Signals to Continuous Stimuli},
+  volume = {10},
+  year = {2016}
+}
+
+@article{DahneEtAl2014,
+  author = {Dähne, Sven and Meinecke, Frank C. and Haufe, Stefan and Höhne, Johannes and Tangermann, Michael and Müller, Klaus-Robert and Nikulin, Vadim V.},
+  doi = {10.1016/j.neuroimage.2013.07.079},
+  journal = {NeuroImage},
+  pages = {111-122},
+  shorttitle = {{{SPoC}}},
+  title = {{{SPoC}}: A Novel Framework for Relating the Amplitude of Neuronal Oscillations to Behaviorally Relevant Parameters},
+  volume = {86},
+  year = {2014}
+}
+
+@article{DalalEtAl2008,
+  author = {Dalal, Sarang S. and Guggisberg, Adrian G. and Edwards, Erik and Sekihara, Kensuke and Findlay, Anne M. and Canolty, Ryan T. and Berger, Mitchel S. and Knight, Robert T. and Barbaro, Nicholas M. and Kirsch, Heidi E. and Nagarajan, Srikantan S.},
+  doi = {10.1016/j.neuroimage.2008.01.023},
+  journal = {NeuroImage},
+  number = {4},
+  pages = {1686-1700},
+  shorttitle = {Five-Dimensional Neuroimaging},
+  title = {Five-Dimensional Neuroimaging: Localization of the Time–Frequency Dynamics of Cortical Activity},
+  volume = {40},
+  year = {2008}
+}
+
+@article{DaleEtAl1999,
+  author = {Dale, Anders M. and Fischl, Bruce and Sereno, Martin I.},
+  doi = {10.1006/nimg.1998.0395},
+  journal = {NeuroImage},
+  number = {2},
+  pages = {179-194},
+  title = {Cortical Surface-Based Analysis: {{I}}. Segmentation and Surface Reconstruction},
+  volume = {9},
+  year = {1999}
+}
+
+@article{DaleEtAl2000,
+  author = {Dale, Anders M. and Liu, Arthur K. and Fischl, Bruce R. and Buckner, Randy L. and Belliveau, John W. and Lewine, Jeffrey D. and Halgren, Eric},
+  doi = {10.1016/S0896-6273(00)81138-1},
+  journal = {Neuron},
+  number = {1},
+  pages = {55-67},
+  title = {Dynamic Statistical Parametric Mapping: Combining {{fMRI}} and {{MEG}} for High-Resolution Imaging of Cortical Activity},
+  volume = {26},
+  year = {2000}
+}
+
+@article{DaleSereno1993,
+  author = {Dale, Anders M. and Sereno, Martin I.},
+  doi = {10.1162/jocn.1993.5.2.162},
+  journal = {Journal of Cognitive Neuroscience},
+  number = {2},
+  pages = {162-176},
+  shorttitle = {Improved Localization of Cortical Activity by Combining {{EEG}} and {{MEG}} with {{MRI}} Cortical Surface Reconstruction},
+  title = {Improved Localization of Cortical Activity by Combining {{EEG}} and {{MEG}} with {{MRI}} Cortical Surface Reconstruction: A Linear Approach},
+  volume = {5},
+  year = {1993}
+}
+
+@article{DammersEtAl2008,
+  author = {Dammers, Jürgen and Schiek, Michael and Boers, Frank and Silex, Carmen and Zvyagintsev, Mikhail and Pietrzyk, Uwe and Mathiak, Klaus},
+  doi = {10.1109/TBME.2008.926677},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {10},
+  pages = {2353-2362},
+  title = {Integration of Amplitude and Phase Statistics for Complete Artifact Removal in Independent Components of Neuromagnetic Recordings},
+  volume = {55},
+  year = {2008}
+}
+
+@article{DarvasEtAl2006,
+  author = {Darvas, Felix and Ermer, John J. and Mosher, John C. and Leahy, Richard M.},
+  doi = {10.1002/hbm.20171},
+  journal = {Human Brain Mapping},
+  number = {2},
+  pages = {129-143},
+  title = {Generic Head Models for Atlas-Based {{EEG}} Source Analysis},
+  volume = {27},
+  year = {2006}
+}
+
+@article{DelormeMakeig2004,
+  title = {{EEGLAB}: an open source toolbox for analysis of single-trial {EEG} dynamics including independent component analysis},
+  volume = {134},
+  issn = {0165-0270},
+  shorttitle = {{EEGLAB}},
+  doi = {10.1016/j.jneumeth.2003.10.009},
+  language = {eng},
+  number = {1},
+  journal = {Journal of Neuroscience Methods},
+  author = {Delorme, Arnaud and Makeig, Scott},
+  month = mar,
+  year = {2004},
+  pmid = {15102499},
+  keywords = {Computer Simulation, Electroencephalography, Evoked Potentials, Software},
+  pages = {9--21}
+}
+
+@article{DestrieuxEtAl2010,
+  author = {Destrieux, Christophe and Fischl, Bruce and Dale, Anders and Halgren, Eric},
+  doi = {10.1016/j.neuroimage.2010.06.010},
+  journal = {NeuroImage},
+  number = {1},
+  pages = {1-15},
+  title = {Automatic Parcellation of Human Cortical Gyri and Sulci Using Standard Anatomical Nomenclature},
+  volume = {53},
+  year = {2010}
+}
+
+@inproceedings{DharmapraniEtAl2016,
+  address = {Orlando, FL, USA},
+  title = {A comparison of independent component analysis algorithms and measures to discriminate between {EEG} and artifact components},
+  isbn = {978-1-4577-0220-4},
+  doi = {10.1109/EMBC.2016.7590828},
+  booktitle = {2016 38th {Annual} {International} {Conference} of the {IEEE} {Engineering} in {Medicine} and {Biology} {Society} ({EMBC})},
+  publisher = {IEEE},
+  author = {Dharmaprani, Dhani and Nguyen, Hoang K. and Lewis, Trent W. and DeLosAngeles, Dylan and Willoughby, John O. and Pope, Kenneth J.},
+  year = {2016},
+  pages = {825--828},
+}
+
+
+@article{DufauEtAl2015,
+  author = {Dufau, Stéphane and Grainger, Jonathan and Midgley, Katherine J. and Holcomb, Phillip J.},
+  doi = {10.1177/0956797615603934},
+  journal = {Psychological Science},
+  number = {12},
+  pages = {1887-1897},
+  shorttitle = {A Thousand Words Are Worth a Picture},
+  title = {A Thousand Words Are Worth a Picture: Snapshots of Printed-Word Processing in an Event-Related Potential Megastudy},
+  volume = {26},
+  year = {2015}
+}
+
+@book{EfronHastie2016,
+  address = {{New York}},
+  author = {Efron, Bradley and Hastie, Trevor},
+  isbn = {978-1-107-14989-2},
+  number = {5},
+  publisher = {{Cambridge University Press}},
+  series = {Institute of {{Mathematical Statistics}} Monographs},
+  shorttitle = {Computer Age Statistical Inference},
+  title = {Computer Age Statistical Inference: Algorithms, Evidence, and Data Science},
+  url = {https://hastie.su.domains/CASI/},
+  year = {2016}
+}
+
+@article{EngemannGramfort2015,
+  author = {Engemann, Denis A. and Gramfort, Alexandre},
+  doi = {10.1016/j.neuroimage.2014.12.040},
+  journal = {NeuroImage},
+  pages = {328-342},
+  title = {Automated Model Selection in Covariance Estimation and Spatial Whitening of {{MEG}} and {{EEG}} Signals},
+  volume = {108},
+  year = {2015}
+}
+
+@article{FischlEtAl1999,
+  author = {Fischl, Bruce and Sereno, Martin I. and Dale, Anders M.},
+  doi = {10.1006/nimg.1998.0396},
+  journal = {NeuroImage},
+  number = {2},
+  pages = {195-207},
+  title = {Cortical Surface-Based Analysis: {{II}}. Inflation, Flattening, and a Surface-Based Coordinate System},
+  volume = {9},
+  year = {1999}
+}
+
+@article{FischlEtAl1999a,
+  author = {Fischl, Bruce and Sereno, Martin I. and Tootell, Roger B.H. and Dale, Anders M.},
+  doi = {10.1002/(SICI)1097-0193(1999)8:4<272::AID-HBM10>3.0.CO;2-4},
+  journal = {Human Brain Mapping},
+  number = {4},
+  pages = {272-284},
+  title = {High-Resolution Intersubject Averaging and a Coordinate System for the Cortical Surface},
+  volume = {8},
+  year = {1999}
+}
+
+@article{FischlEtAl2004,
+  author = {Fischl, Bruce and Salat, David H. and {van der Kouwe}, André J.W. and Makris, Nikos and Ségonne, Florent and Quinn, Brian T. and Dale, Anders M.},
+  doi = {10.1016/j.neuroimage.2004.07.016},
+  journal = {NeuroImage},
+  pages = {S69-S84},
+  title = {Sequence-Independent Segmentation of Magnetic Resonance Images},
+  volume = {23},
+  year = {2004}
+}
+
+@article{FishburnEtAl2019,
+  title={Temporal derivative distribution repair (TDDR): a motion correction method for {fNIRS}},
+  doi = {10.1016/j.neuroimage.2018.09.025},
+  author={Fishburn, Frank A and Ludlum, Ruth S and Vaidya, Chandan J and Medvedev, Andrei V},
+  journal={NeuroImage},
+  volume={184},
+  pages={171--179},
+  year={2019},
+  publisher={Elsevier}
+}
+
+@article{GlasserEtAl2016,
+  author = {Glasser, Matthew F. and Coalson, Timothy S. and Robinson, Emma C. and Hacker, Carl D. and Harwell, John and Yacoub, Essa and Ugurbil, Kamil and Andersson, Jesper and Beckmann, Christian F. and Jenkinson, Mark and Smith, Stephen M. and Van Essen, David C.},
+  doi = {10.1038/nature18933},
+  journal = {Nature},
+  number = {7615},
+  pages = {171-178},
+  title = {A multi-modal parcellation of human cerebral cortex},
+  volume = {536},
+  year = {2016}
+}
+
+@article{GlasserEtAl2016supp,
+  author = {Glasser, Matthew F. and Coalson, Timothy S. and Robinson, Emma C. and Hacker, Carl D. and Harwell, John and Yacoub, Essa and Ugurbil, Kamil and Andersson, Jesper and Beckmann, Christian F. and Jenkinson, Mark and Smith, Stephen M. and Van Essen, David C.},
+  url = {https://static-content.springer.com/esm/art%3A10.1038%2Fnature18933/MediaObjects/41586_2016_BFnature18933_MOESM330_ESM.pdf#page=2},
+  journal = {Nature},
+  number = {7615},
+  title = {Supplementary neuroanatomical results for “{A} multi-modal parcellation of human cerebral cortex”},
+  volume = {536},
+  year = {2016}
+}
+
+@article{GoldbergerEtAl2000,
+  author = {Goldberger, Ary L. and Amaral, Luis A. N. and Glass, Leon and Hausdorff, Jeffrey M. and Ivanov, Plamen Ch. and Mark, Roger G. and Mietus, Joseph E. and Moody, George B. and Peng, Chung-Kang and Stanley, H. Eugene},
+  doi = {10.1161/01.CIR.101.23.e215},
+  journal = {Circulation},
+  number = {23},
+  shorttitle = {{{PhysioBank}}, {{PhysioToolkit}}, and {{PhysioNet}}},
+  title = {{{PhysioBank}}, {{PhysioToolkit}}, and {{PhysioNet}}: {{Components}} of a New Research Resource for Complex Physiologic Signals},
+  volume = {101},
+  year = {2000}
+}
+
+@article{GoldenholzEtAl2009,
+  author = {Goldenholz, Daniel M. and Ahlfors, Seppo P. and Hämäläinen, Matti S. and Sharon, Dahlia and Ishitobi, Mamiko and Vaina, Lucia M. and Stufflebeam, Steven M.},
+  doi = {10.1002/hbm.20571},
+  journal = {Human Brain Mapping},
+  number = {4},
+  pages = {1077-1086},
+  title = {Mapping the Signal-to-Noise-Ratios of Cortical Sources in Magnetoencephalography and Electroencephalography},
+  volume = {30},
+  year = {2009}
+}
+
+@article{GoncalvesEtAl2003,
+  author = {Gonçalves, Sónia I. and {de Munck}, Jan Casper and Verbunt, Jeroen P. A. and Bijma, Fetsje and Heethaar, Rob M. and {Lopes da Silva}, Fernando},
+  doi = {10.1109/TBME.2003.812164},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {6},
+  pages = {754-767},
+  title = {In Vivo Measurement of the Brain and Skull Resistivities Using an {{EIT}}-Based Method and Realistic Models for the Head},
+  volume = {50},
+  year = {2003}
+}
+
+@article{GraimannEtAl2002,
+  author = {Graimann, Bernhard and Huggins, Jane E. and Levine, Simon P. and Pfurtscheller, Gert},
+  doi = {10.1016/S1388-2457(01)00697-6},
+  journal = {Clinical Neurophysiology},
+  number = {1},
+  pages = {43-47},
+  title = {Visualization of Significant {{ERD}}/{{ERS}} Patterns in Multichannel {{EEG}} and {{ECoG}} Data},
+  volume = {113},
+  year = {2002}
+}
+
+@article{GramfortEtAl2010,
+  author = {Alexandre Gramfort and Renaud Keriven and Maureen Clerc},
+  title = {Graph-Based Variability Estimation in Single-Trial Event-Related Neural Responses},
+  journal = {{IEEE} Transactions on Biomedical Engineering},
+  doi = {10.1109/tbme.2009.2037139},
+  year = {2010},
+  publisher = {Institute of Electrical and Electronics Engineers ({IEEE})},
+  volume = {57},
+  number = {5},
+  pages = {1051--1061},
+}
+
+@incollection{GramfortEtAl2011,
+  address = {{Berlin; Heidelberg}},
+  author = {Gramfort, Alexandre and Strohmeier, Daniel and Haueisen, Jens and Hämäläinen, Matti S. and Kowalski, Matthieu},
+  booktitle = {Information {{Processing}} in {{Medical Imaging}}},
+  doi = {10.1007/978-3-642-22092-0_49},
+  editor = {Székely, Gábor and Hahn, Horst K.},
+  isbn = {978-3-642-22091-3 978-3-642-22092-0},
+  pages = {600-611},
+  publisher = {Springer},
+  title = {Functional Brain Imaging with {M/EEG} Using Structured Sparsity in Time-Frequency Dictionaries},
+  volume = {6801},
+  year = {2011}
+}
+
+@article{GramfortEtAl2012,
+  author = {Gramfort, Alexandre and Kowalski, Matthieu and Hämäläinen, Matti S.},
+  doi = {10.1088/0031-9155/57/7/1937},
+  journal = {Physics in Medicine and Biology},
+  number = {7},
+  pages = {1937-1961},
+  title = {Mixed-Norm Estimates for the {M/EEG} Inverse Problem Using Accelerated Gradient Methods},
+  volume = {57},
+  year = {2012}
+}
+
+@article{GramfortEtAl2013b,
+  author = {Gramfort, Alexandre and Strohmeier, Daniel T. and Haueisen, Jens and Hämäläinen, Matti S. and Kowalski, Matthieu},
+  doi = {10.1016/j.neuroimage.2012.12.051},
+  journal = {NeuroImage},
+  pages = {410-422},
+  shorttitle = {Time-Frequency Mixed-Norm Estimates},
+  title = {Time-Frequency Mixed-Norm Estimates: Sparse {M/EEG} Imaging with Non-Stationary Source Activations},
+  volume = {70},
+  year = {2013}
+}
+
+@article{GreischarEtAl2004,
+  title = {Effects of electrode density and electrolyte spreading in dense array electroencephalographic recording},
+  volume = {115},
+  issn = {13882457},
+  doi = {10.1016/j.clinph.2003.10.028},
+  language = {en},
+  number = {3},
+  journal = {Clinical Neurophysiology},
+  author = {Greischar, Lawrence L. and Burghy, Cory A. and van Reekum, Carien M. and Jackson, Daren C. and Pizzagalli, Diego A. and Mueller, Corrina and Davidson, Richard J.},
+  month = mar,
+  year = {2004},
+  pages = {710--720}
+}
+
+@article{GreveEtAl2013,
+  author = {Greve, Douglas N. and {Van der Haegen}, Lise and Cai, Qing and Stufflebeam, Steven and Sabuncu, Mert R. and Fischl, Bruce and Brysbaert, Marc},
+  doi = {10.1162/jocn_a_00405},
+  journal = {Journal of Cognitive Neuroscience},
+  number = {9},
+  pages = {1477-1492},
+  title = {A Surface-Based Analysis of Language Lateralization and Cortical Asymmetry},
+  volume = {25},
+  year = {2013}
+}
+
+@article{Grosse-WentrupBuss2008,
+  author = {{Grosse-Wentrup}, Moritz and Buss, Martin},
+  doi = {10.1109/TBME.2008.921154},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {8},
+  pages = {1991-2000},
+  title = {Multiclass Common Spatial Patterns and Information Theoretic Feature Extraction},
+  volume = {55},
+  year = {2008}
+}
+
+@article{GrossEtAl2001,
+  author = {Groß, Joachim and Kujala, Jan and Hämäläinen, Matti S. and Timmermann, Lars and Schnitzler, Alfons and Salmelin, Riitta},
+  doi = {10.1073/pnas.98.2.694},
+  journal = {Proceedings of the National Academy of Sciences},
+  number = {2},
+  pages = {694-699},
+  shorttitle = {Dynamic Imaging of Coherent Sources},
+  title = {Dynamic Imaging of Coherent Sources: Studying Neural Interactions in the Human Brain},
+  volume = {98},
+  year = {2001}
+}
+
+@article{HamalainenEtAl1993,
+  author = {Hämäläinen, Matti S. and Hari, Riitta and Ilmoniemi, Risto J. and Knuutila, Jukka and Lounasmaa, Olli V.},
+  doi = {10.1103/RevModPhys.65.413},
+  journal = {Reviews of Modern Physics},
+  number = {2},
+  pages = {413-497},
+  title = {Magnetoencephalography—Theory, Instrumentation, and Applications to Noninvasive Studies of the Working Human Brain},
+  volume = {65},
+  year = {1993}
+}
+
+@incollection{HamalainenHari2002,
+  address = {{San Diego}},
+  author = {Hämäläinen, Matti S. and Hari, Riitta},
+  booktitle = {Brain Mapping: The Methods},
+  doi = {10.1016/B978-012693019-1/50012-5},
+  edition = {2},
+  editor = {Toga, Arthur W. and Mazziotta, John C.},
+  isbn = {978-0-12-693019-1},
+  pages = {227 - 253},
+  publisher = {{Academic Press}},
+  title = {Magnetoencephalographic Characterization of Dynamic Brain Activation: Basic Principles and Methods of Data Collection and Source Analysis},
+  year = {2002}
+}
+
+@techreport{HamalainenIlmoniemi1984,
+  address = {{Helsinki}},
+  author = {Hämäläinen, Matti S. and Ilmoniemi, Risto J.},
+  number = {TKK-F-A559},
+  title = {Interpreting Measured Magnetic Fields of the Brain: Estimates of Current Distributions},
+  type = {Technical {{Report}}},
+  institution = {Helsinki University of Technology},
+  year = {1984}
+}
+
+@article{HamalainenIlmoniemi1994,
+  author = {Hämäläinen, Matti S. and Ilmoniemi, Risto J., Ilmoniemi},
+  doi = {10.1007/BF02512476},
+  journal = {Medical \& Biological Engineering \& Computing},
+  number = {1},
+  pages = {35-42},
+  shorttitle = {Interpreting Magnetic Fields of the Brain},
+  title = {Interpreting Magnetic Fields of the Brain: Minimum Norm Estimates},
+  volume = {32},
+  year = {1994}
+}
+
+@article{HamalainenSarvas1989,
+  author = {Hämäläinen, Matti S. and Sarvas, Jukka},
+  doi = {10.1109/10.16463},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {2},
+  pages = {165-171},
+  title = {Realistic Conductivity Geometry Model of the Human Head for Interpretation of Neuromagnetic Data},
+  volume = {36},
+  year = {1989}
+}
+
+@article{HamiltonEtAl2017,
+  author = {Hamilton, Liberty S. and Chang, David L. and Lee, Morgan B. and Chang, Edward F.},
+  doi = {10.3389/fninf.2017.00062},
+  journal = {Frontiers in Neuroinformatics},
+  title = {Semi-automated Anatomical Labeling and Inter-subject Warping of High-Density Intracranial Recording Electrodes in Electrocorticography},
+  volume = {11},
+  issn = {1662-5196},
+  month = oct,
+  year = {2017},
+}
+
+@article{HannaEtAl2020,
+  author = {Hanna, Jeff and Kim, Cora and Müller-Voggel, Nadia},
+  doi = {10.1016/j.jneumeth.2020.108592},
+  journal = {Journal of Neuroscience Methods},
+  title = {External noise removed from magnetoencephalographic signal using Independent Component Analysis of reference channels},
+  year = {2020}
+}
+
+@article{HariSalmelin1997,
+  author = {Hari, Riitta and Salmelin, Riitta},
+  doi = {10.1016/S0166-2236(96)10065-5},
+  journal = {Trends in Neurosciences},
+  number = {1},
+  pages = {44-49},
+  shorttitle = {Human Cortical Oscillations},
+  title = {Human Cortical Oscillations: A Neuromagnetic View through the Skull},
+  volume = {20},
+  year = {1997}
+}
+
+@article{HaufeEtAl2014,
+  author = {Haufe, Stefan and Meinecke, Frank and Görgen, Kai and Dähne, Sven and Haynes, John-Dylan and Blankertz, Benjamin and Bießmann, Felix},
+  doi = {10.1016/j.neuroimage.2013.10.067},
+  journal = {NeuroImage},
+  pages = {96-110},
+  title = {On the Interpretation of Weight Vectors of Linear Models in Multivariate Neuroimaging},
+  volume = {87},
+  year = {2014}
+}
+
+@article{HaufeEtAl2014b,
+  author = {Haufe, Stefan and D{\"a}hne, Sven and Nikulin, Vadim V},
+  doi = {https://doi.org/10.1016/j.neuroimage.2014.06.073},
+  journal = {NeuroImage},
+  pages = {583-597},
+  title = {Dimensionality reduction for the analysis of brain oscillations},
+  volume = {101},
+  year = {2014}
+}
+
+@article{HaukEtAl2006,
+  author = {Hauk, Olaf and Davis, Matt H. and Ford, Michael A. and Pulvermüller, Friedmann and {Marslen-Wilson}, William D.},
+  doi = {10.1016/j.neuroimage.2005.11.048},
+  journal = {NeuroImage},
+  number = {4},
+  pages = {1383-1400},
+  title = {The Time Course of Visual Word Recognition as Revealed by Linear Regression Analysis of {{ERP}} Data},
+  volume = {30},
+  year = {2006}
+}
+
+@article {HaukEtAl2019,
+  author = {Hauk, Olaf and Stenroos, Matti and Treder, Matthias},
+  title = {Towards an Objective Evaluation of {EEG/MEG} Source Estimation Methods: The Linear Tool Kit},
+  year = {2019},
+  doi = {10.1101/672956},
+  publisher = {Cold Spring Harbor Laboratory},
+  journal = {bioRxiv}
+}
+
+@book{Heiman2002,
+  address = {{Boston}},
+  author = {Heiman, Gary W.},
+  edition = {3},
+  isbn = {978-0-618-17028-9},
+  publisher = {{Houghton Mifflin Company}},
+  title = {Research Methods in Psychology},
+  year = {2002}
+}
+
+@article{HippEtAl2011,
+  author = {Hipp, Joerg F. and Engel, Andreas K. and Siegel, Markus},
+  doi = {10.1016/j.neuron.2010.12.027},
+  journal = {Neuron},
+  number = {2},
+  pages = {387-396},
+  title = {Oscillatory Synchronization in Large-Scale Cortical Networks Predicts Perception},
+  volume = {69},
+  year = {2011}
+}
+
+@article{HippEtAl2012,
+  author = {Hipp, Joerg F and Hawellek, David J and Corbetta, Maurizio and Siegel, Markus and Engel, Andreas K},
+  doi = {10.1038/nn.3101},
+  journal = {Nature Neuroscience},
+  number = {6},
+  pages = {884-890},
+  title = {Large-Scale Cortical Correlation Structure of Spontaneous Oscillatory Activity},
+  volume = {15},
+  year = {2012}
+}
+
+@article{HoldgrafEtAl2016,
+  author = {Holdgraf, Christopher R. and {de Heer}, Wendy and Pasley, Brian and Rieger, Jochem and Crone, Nathan and Lin, Jack J. and Knight, Robert T. and Theunissen, Frédéric E.},
+  doi = {10.1038/ncomms13654},
+  journal = {Nature Communications},
+  number = {1},
+  title = {Rapid Tuning Shifts in Human Auditory Cortex Enhance Speech Intelligibility},
+  volume = {7},
+  year = {2016}
+}
+
+@article{HouckClaus2020,
+	author = {Houck, Jon M. and Claus, Eric D.},
+	doi = {10.1371/journal.pone.0232100},
+	journal = {PLOS ONE},
+	pages = {e0232100},
+	title = {A comparison of automated and manual co-registration for magnetoencephalography},
+	volume = {15},
+	year = {2020}
+}
+
+@article{Hyvarinen1999,
+  author = {Hyvärinen, Aapo},
+  doi = {10.1109/72.761722},
+  journal = {IEEE Transactions on Neural Networks},
+  number = {3},
+  pages = {626-634},
+  title = {Fast and Robust Fixed-Point Algorithms for Independent Component Analysis},
+  volume = {10},
+  year = {1999}
+}
+
+@book{IfeachorJervis2002,
+  author = {Ifeachor, Emmanuel C. and Jervis, Barrie W.},
+  edition = {2},
+  publisher = {{Pearson}},
+  shorttitle = {Digital Signal Processing},
+  title = {Digital Signal Processing: A Practical Approach},
+  year = {2002}
+}
+
+@article{JonesEtAl2006,
+  author = {Jones, Kevin A. and Porjesz, Bernice and Chorlian, David and Rangaswamy, Madhavi and Kamarajan, Chella and Padmanabhapillai, Ajayan and Stimus, Arthur and Begleiter, Henri},
+  doi = {10.1016/j.clinph.2006.02.028},
+  journal = {Clinical Neurophysiology},
+  number = {10},
+  pages = {2128-2143},
+  title = {S-Transform Time-Frequency Analysis of {{P300}} Reveals Deficits in Individuals Diagnosed with Alcoholism},
+  volume = {117},
+  year = {2006}
+}
+
+@article{JovicichEtAl2006,
+  author = {Jovicich, Jorge and Czanner, Silvester and Greve, Douglas and Haley, Elizabeth and {van der Kouwe}, Andre and Gollub, Randy and Kennedy, David and Schmitt, Franz and Brown, Gregory and MacFall, James and Fischl, Bruce and Dale, Anders},
+  doi = {10.1016/j.neuroimage.2005.09.046},
+  journal = {NeuroImage},
+  number = {2},
+  pages = {436-443},
+  shorttitle = {Reliability in Multi-Site Structural {{MRI}} Studies},
+  title = {Reliability in Multi-Site Structural {{MRI}} Studies: Effects of Gradient Non-Linearity Correction on Phantom and Human Data},
+  volume = {30},
+  year = {2006}
+}
+
+@article{KappenmanLuck2010,
+  author = {Kappenman, Emily S. and Luck, Steven J.},
+  doi = {10.1111/j.1469-8986.2010.01009.x},
+  journal = {Psychophysiology},
+  title = {The Effects of Electrode Impedance on Data Quality and Statistical Significance in {{ERP}} Recordings},
+  year = {2010}
+}
+
+@article{KempEtAl2000,
+  author = {Kemp, B. and Zwinderman, A. H. and Tuk, B. and Kamphuisen, H. A. C. and Oberyé, J. J. L.},
+  doi = {10.1109/10.867928},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {9},
+  pages = {1185-1194},
+  shorttitle = {Analysis of a Sleep-Dependent Neuronal Feedback Loop},
+  title = {Analysis of a Sleep-Dependent Neuronal Feedback Loop: The Slow-Wave Microcontinuity of the {{EEG}}},
+  volume = {47},
+  year = {2000}
+}
+
+@article{KhanCohen2013,
+  author = {Khan, Sheraz and Cohen, David},
+  doi = {10.1063/1.4802845},
+  journal = {Review of Scientific Instruments},
+  number = {5},
+  pages = {056101},
+  shorttitle = {Magnetic Noise from the Inner Wall of a Magnetically Shielded Room},
+  title = {Note: Magnetic Noise from the Inner Wall of a Magnetically Shielded Room},
+  volume = {84},
+  year = {2013}
+}
+
+@article{KhanEtAl2018,
+  author = {Khan, Sheraz and Hashmi, Javeria A. and Mamashli, Fahimeh and Michmizos, Konstantinos and Kitzbichler, Manfred G. and Bharadwaj, Hari and Bekhti, Yousra and Ganesan, Santosh and Garel, Keri-Lee A. and {Whitfield-Gabrieli}, Susan and Gollub, Randy L. and Kong, Jian and Vaina, Lucia M. and Rana, Kunjan D. and Stufflebeam, Steven M. and Hämäläinen, Matti S. and Kenet, Tal},
+  doi = {10.1016/j.neuroimage.2018.02.018},
+  journal = {NeuroImage},
+  pages = {57-68},
+  title = {Maturation Trajectories of Cortical Resting-State Networks Depend on the Mediating Frequency Band},
+  volume = {174},
+  year = {2018}
+}
+
+@article{KingDehaene2014,
+  author = {King, Jean-Rémi and Dehaene, Stanislas},
+  doi = {10.1016/j.tics.2014.01.002},
+  journal = {Trends in Cognitive Sciences},
+  number = {4},
+  pages = {203-210},
+  shorttitle = {Characterizing the Dynamics of Mental Representations},
+  title = {Characterizing the Dynamics of Mental Representations: The Temporal Generalization Method},
+  volume = {18},
+  year = {2014}
+}
+
+@article{KingEtAl2014,
+  author = {King, Jean-Rémi and Gramfort, Alexandre and Schurger, Aaron and Naccache, Lionel and Dehaene, Stanislas},
+  doi = {10.1371/journal.pone.0085791},
+  editor = {Kiebel, Stefan},
+  journal = {PLoS ONE},
+  number = {1},
+  pages = {e85791},
+  title = {Two Distinct Dynamic Modes Subtend the Detection of Unexpected Sounds},
+  volume = {9},
+  year = {2014}
+}
+
+@unpublished{KingEtAl2018,
+  author = {King, Jean-Rémi and Gwilliams, Laura and Holdgraf, Chris and Sassenhagen, Jona and Barachant, Alexandre and Engemann, Denis and Larson, Eric and Gramfort, Alexandre},
+  title = {Encoding and Decoding Neuronal Dynamics: Methodological Framework to Uncover the Algorithms of Cognition},
+  url = {https://hal.archives-ouvertes.fr/hal-01848442},
+  year = {2018},
+  note = {hal-01848442}
+}
+
+@article{KnuutilaEtAl1993,
+  author = {Knuutila, Jukka E. T. and Ahonen, Antti I. and Hämäläinen, Matti S. and Kajola, Matti J. and Laine, P. P. and Lounasmaa, Olli V. and Parkkonen, Lauri T. and Simola, Juha T. A. and Tesche, Claudia D.},
+  doi = {10.1109/20.281163},
+  journal = {IEEE Transactions on Magnetics},
+  number = {6},
+  pages = {3315-3320},
+  title = {A 122-Channel Whole-Cortex {{SQUID}} System for Measuring the Brain's Magnetic Fields},
+  volume = {29},
+  year = {1993}
+}
+
+@article{Koles1991,
+  author = {Koles, Zoltan J.},
+  doi = {10.1016/0013-4694(91)90163-X},
+  journal = {Electroencephalography and Clinical Neurophysiology},
+  number = {6},
+  pages = {440-447},
+  title = {The Quantitative Extraction and Topographic Mapping of the Abnormal Components in the Clinical {{EEG}}},
+  volume = {79},
+  year = {1991}
+}
+
+@article{KolesEtAl1990,
+  author = {Koles, Zoltan J. and Lazar, Michael S. and Zhou, Steven Z.},
+  doi = {10.1007/BF01129656},
+  journal = {Brain Topography},
+  number = {4},
+  pages = {275-284},
+  title = {Spatial Patterns Underlying Population Differences in the Background {{EEG}}},
+  volume = {2},
+  year = {1990}
+}
+
+@article{KriegeskorteEtAl2008,
+  author = {Kriegeskorte, Nikolaus and Mur, Marieke and Bandettini, Peter},
+  doi = {10.3389/neuro.06.004.2008},
+  journal = {Frontiers in Systems Neuroscience},
+  pages = {4},
+  pmcid = {PMC2605405},
+  pmid = {19104670},
+  title = {Representational Similarity Analysis – Connecting the Branches of Systems Neuroscience},
+  volume = {2},
+  year = {2008}
+}
+
+@article{LaaksoCottrell2000,
+  author = {Laakso, Aarre and Cottrell, Garrison},
+  doi = {10.1080/09515080050002726},
+  journal = {Philosophical Psychology},
+  number = {1},
+  pages = {47-76},
+  shorttitle = {Content and Cluster Analysis},
+  title = {Content and Cluster Analysis: Assessing Representational Similarity in Neural Systems},
+  volume = {13},
+  year = {2000}
+}
+
+@article{LachauxEtAl1999,
+  author = {Lachaux, Jean-Philippe and Rodriguez, Eugenio and Martinerie, Jacques and Varela, Francisco J.},
+  doi = {10.1002/(SICI)1097-0193(1999)8:4<194::AID-HBM4>3.0.CO;2-C},
+  journal = {Human Brain Mapping},
+  number = {4},
+  pages = {194-208},
+  title = {Measuring Phase Synchrony in Brain Signals},
+  volume = {8},
+  year = {1999}
+}
+
+@article{LarsonLee2013,
+  author = {Larson, Eric and Lee, Adrian K.C.},
+  doi = {10.1016/j.neuroimage.2012.09.006},
+  journal = {NeuroImage},
+  pages = {365-370},
+  title = {The Cortical Dynamics Underlying Effective Switching of Auditory Spatial Attention},
+  volume = {64},
+  year = {2013}
+}
+
+@article{LarsonTaulu2017,
+  author = {Larson, Eric and Taulu, Samu},
+  doi = {10.1007/s10548-016-0523-1},
+  journal = {Brain Topography},
+  number = {2},
+  pages = {172-181},
+  title = {The Importance of Properly Compensating for Head Movements during {{MEG}} Acquisition across Different Age Groups},
+  volume = {30},
+  year = {2017}
+}
+
+@article{LarsonTaulu2018,
+  author = {Larson, Eric and Taulu, Samu},
+  doi = {10.1109/TBME.2017.2734641},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {5},
+  pages = {1002-1013},
+  title = {Reducing Sensor Noise in {{MEG}} and {{EEG}} Recordings Using Oversampled Temporal Projection},
+  volume = {65},
+  year = {2018}
+}
+
+@article{LedoitWolf2004,
+  author = {Ledoit, Olivier and Wolf, Michael},
+  doi = {10.1016/S0047-259X(03)00096-4},
+  journal = {Journal of Multivariate Analysis},
+  number = {2},
+  pages = {365-411},
+  title = {A Well-Conditioned Estimator for Large-Dimensional Covariance Matrices},
+  volume = {88},
+  year = {2004}
+}
+
+@article{LeeEtAl1999,
+  author = {Lee, Te-Won and Girolami, Mark and Sejnowski, Terrence J.},
+  doi = {10.1162/089976699300016719},
+  journal = {Neural Computation},
+  number = {2},
+  pages = {417-441},
+  title = {Independent Component Analysis Using an Extended Infomax Algorithm for Mixed Subgaussian and Supergaussian Sources},
+  volume = {11},
+  year = {1999}
+}
+
+@article{LewEtAl2009,
+  author = {Lew, Seok and Wolters, Carsten H. and Anwander, Alfred and Makeig, Scott and MacLeod, Rob S.},
+  doi = {10.1002/hbm.20714},
+  journal = {Human Brain Mapping},
+  number = {9},
+  pages = {2862-2878},
+  title = {Improved {{EEG}} Source Analysis Using Low-Resolution Conductivity Estimation in a Four-Compartment Finite Element Head Model},
+  volume = {30},
+  year = {2009}
+}
+
+@article{LinEtAl2004,
+  author = {Lin, Fa-Hsuan and Witzel, Thomas and Hämäläinen, Matti S. and Dale, Anders M. and Belliveau, John W. and Stufflebeam, Steven M.},
+  doi = {10.1016/j.neuroimage.2004.04.027},
+  journal = {NeuroImage},
+  number = {2},
+  pages = {582-595},
+  title = {Spectral Spatiotemporal Imaging of Cortical Oscillations and Interactions in the Human Brain},
+  volume = {23},
+  year = {2004}
+}
+
+@article{LinEtAl2006,
+  author = {Lin, Fa-Hsuan and Belliveau, John W. and Dale, Anders M. and Hämäläinen, Matti S.},
+  doi = {10.1002/hbm.20155},
+  journal = {Human Brain Mapping},
+  number = {1},
+  pages = {1-13},
+  title = {Distributed Current Estimates Using Cortical Orientation Constraints},
+  volume = {27},
+  year = {2006}
+}
+
+@article{LinEtAl2006a,
+  title = {Assessing and improving the spatial accuracy in {MEG} source localization by depth-weighted minimum-norm estimates},
+  volume = {31},
+  issn = {1053-8119},
+  doi = {10.1016/j.neuroimage.2005.11.054},
+  number = {1},
+  journal = {NeuroImage},
+  author = {Lin, Fa-Hsuan and Witzel, Thomas and Ahlfors, Seppo P. and Stufflebeam, Steven M. and Belliveau, John W. and Hämäläinen, Matti S.},
+  year = {2006},
+  pages = {160--171}
+}
+
+@article{LiuEtAl1998,
+  author = {Liu, Arthur K. and Belliveau, John W. and Dale, Anders M.},
+  doi = {10.1073/pnas.95.15.8945},
+  journal = {Proceedings of the National Academy of Sciences},
+  number = {15},
+  pages = {8945-8950},
+  shorttitle = {Spatiotemporal Imaging of Human Brain Activity Using Functional {{MRI}} Constrained Magnetoencephalography Data},
+  title = {Spatiotemporal Imaging of Human Brain Activity Using Functional {{MRI}} Constrained Magnetoencephalography Data: {{Monte Carlo}} Simulations},
+  volume = {95},
+  year = {1998}
+}
+
+@article{LiuEtAl2002,
+  author = {Liu, Arthur K. and Dale, Anders M. and Belliveau, John W.},
+  doi = {10.1002/hbm.10024},
+  journal = {Human Brain Mapping},
+  number = {1},
+  pages = {47-62},
+  title = {Monte {{Carlo}} Simulation Studies of {{EEG}} and {{MEG}} Localization Accuracy},
+  volume = {16},
+  year = {2002}
+}
+
+@misc{Lowry2014,
+  author = {Lowry, Richard},
+  journal = {Concepts and applications of inferential statistics},
+  title = {One-Way Analysis of Variance for Independent Samples},
+  url = {http://vassarstats.net/textbook/},
+  year = {2014}
+}
+
+@article{LuckEtAl2021,
+  author = {Luck, Steven J. and Stewart, Andrew X. and Simmons, Aaron M. and Rhemtulla, Mijke},
+  journal = {Psychophysiology},
+  title = {Standardized Measurement Error: A Universal Metric of Data Quality for Averaged Event-Related Potentials},
+  volume = {58},
+  number = {6},
+  pages = {e13793},
+  year = {2021},
+  doi = {10.1111/psyp.13793}
+}
+
+@article{MaessEtAl2016,
+  author = {Maess, Burkhard and Schröger, Erich and Widmann, Andreas},
+  doi = {10.1016/j.jneumeth.2015.12.003},
+  journal = {Journal of Neuroscience Methods},
+  pages = {164-165},
+  shorttitle = {High-Pass Filters and Baseline Correction in {{M}}/{{EEG}} Analysis},
+  title = {High-Pass Filters and Baseline Correction in {{M}}/{{EEG}} Analysis. {{Commentary}} on: “{{How}} Inappropriate High-Pass Filters Can Produce Artefacts and Incorrect Conclusions in {{ERP}} Studies of Language and Cognition”},
+  volume = {266},
+  year = {2016}
+}
+
+@article{MaessEtAl2016a,
+  author = {Maess, Burkhard and Schröger, Erich and Widmann, Andreas},
+  doi = {10.1016/j.jneumeth.2016.01.016},
+  journal = {Journal of Neuroscience Methods},
+  pages = {171-172},
+  title = {High-Pass Filters and Baseline Correction in {{M}}/{{EEG}} Analysis-Continued Discussion},
+  volume = {266},
+  year = {2016}
+}
+
+@article{Makeig1993,
+  author = {Makeig, Scott},
+  doi = {10.1016/0013-4694(93)90110-H},
+  journal = {Electroencephalography and Clinical Neurophysiology},
+  number = {4},
+  pages = {283-293},
+  title = {Auditory Event-Related Dynamics of the {{EEG}} Spectrum and Effects of Exposure to Tones},
+  volume = {86},
+  year = {1993}
+}
+
+@article{Makela2018,
+  author = {Mäkelä, Niko and Stenroos, Matti and Sarvas, Jukka and Ilmoniemi, Risto J.},
+  doi = {10.1016/j.neuroimage.2017.11.013},
+  journal = {Neuroimage},
+  number = {},
+  pages = {73-83},
+  title = {Truncated RAP-MUSIC (TRAP-MUSIC) for MEG and EEG source localization},
+  volume = {167},
+  year = {2018}
+}
+
+@article{MarisOostenveld2007,
+  author = {Maris, Eric and Oostenveld, Robert},
+  doi = {10.1016/j.jneumeth.2007.03.024},
+  journal = {Journal of Neuroscience Methods},
+  number = {1},
+  pages = {177-190},
+  title = {Nonparametric Statistical Testing of {{EEG}}- and {{MEG}}-Data},
+  volume = {164},
+  year = {2007}
+}
+
+@misc{Mills2016,
+  author = {Mills, Kathryn},
+  doi = {10.6084/m9.figshare.3498446.v2},
+  publisher = {{Figshare}},
+  title = {{{HCP-MMP1.0}} Projected on {{fsaverage}}},
+  year = {2016}
+}
+
+@article{MolinsEtAl2008,
+  author = {Molins A, and Stufflebeam S. M., and Brown E. N., and Hämäläinen M. S.},
+  doi = {10.1016/j.neuroimage.2008.05.064},
+  journal = {Neuroimage},
+  number = {3},
+  pages = {1069-1077},
+  title = {Quantification of the benefit from integrating {MEG} and {EEG} data in
+           minimum l2-norm estimation},
+  volume = {42},
+  year = {2008}
+}
+
+@incollection{Montoya-MartinezEtAl2017,
+  address = {{Cham}},
+  author = {{Montoya-Martínez}, Jair and Cardoso, Jean-François and Gramfort, Alexandre},
+  booktitle = {Latent Variable Analysis and Signal Separation},
+  doi = {10.1007/978-3-319-53547-0_27},
+  editor = {Tichavský, Petr and {Babaie-Zadeh}, Massoud and Michel, Olivier J.J. and {Thirion-Moreau}, Nadège},
+  isbn = {978-3-319-53546-3 978-3-319-53547-0},
+  number = {10169},
+  pages = {279-289},
+  publisher = {{Springer International Publishing}},
+  series = {Lecture {{Notes}} in {{Computer Science}}},
+  title = {Caveats with Stochastic Gradient and Maximum Likelihood Based {{ICA}} for {{EEG}}},
+  year = {2017}
+}
+
+@article{MosherEtAl1999,
+  author = {Mosher, John C. and Leahy, Richard M. and Lewis, Paul S.},
+  doi = {10.1109/10.748978},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {3},
+  pages = {245-259},
+  shorttitle = {{{EEG}} and {{MEG}}},
+  title = {{{EEG}} and {{MEG}}: Forward Solutions for Inverse Methods},
+  volume = {46},
+  year = {1999}
+}
+
+@article{MosherLeahy1999,
+  author = {Mosher, John C. and Leahy, Richard M.},
+  doi = {10.1109/78.740118},
+  journal = {IEEE Transactions on Signal Processing},
+  number = {2},
+  pages = {332-340},
+  title = {Source Localization Using Recursively Applied and Projected ({{RAP}}) {{MUSIC}}},
+  volume = {47},
+  year = {1999}
+}
+
+@inproceedings{MosherLeahy1996,
+	title = {{EEG} and {MEG} source localization using recursively applied ({RAP}) {MUSIC}},
+	doi = {10.1109/ACSSC.1996.599135},
+	booktitle = {Conference {Record} of {The} {Thirtieth} {Asilomar} {Conference} on {Signals}, {Systems} and {Computers}},
+	author = {Mosher, J.C. and Leahy, R.M.},
+	month = nov,
+	year = {1996},
+	note = {ISSN: 1058-6393},
+	pages = {1201--1207 vol.2}
+}
+
+@inproceedings{MoukademEtAl2014,
+  address = {{Lisbon}},
+  author = {Moukadem, Ali and Bouguila, Zied and Abdeslam, Djaffar Ould and Dieterlen, Alain},
+  booktitle = {Proceedings of {{EUSIPCO}}-2014},
+  pages = {2015-2019},
+  publisher = {{IEEE}},
+  title = {Stockwell Transform Optimization Applied on the Detection of Split in Heart Sounds},
+  url = {https://ieeexplore.ieee.org/document/6952743},
+  year = {2014}
+}
+
+@article{MourtazaevEtAl1995,
+  author = {Mourtazaev, M. S. and Kemp, B. and Zwinderman, A. H. and Kamphuisen, H. A. C.},
+  doi = {10.1093/sleep/18.7.557},
+  journal = {Sleep},
+  number = {7},
+  pages = {557-564},
+  title = {Age and Gender Affect Different Characteristics of Slow Waves in the Sleep {{EEG}}},
+  volume = {18},
+  year = {1995}
+}
+
+@article{Muthukumaraswamy2013,
+  author = {Muthukumaraswamy, Suresh},
+  doi = {10.3389/fnhum.2013.00138},
+  journal = {Frontiers in Human Neuroscience},
+  pages = {138},
+  title = {High-frequency brain activity and muscle artifacts in {{MEG}}/{{EEG}}: A review and recommendations},
+  volume = {7},
+  year = {2013}
+}
+
+@inproceedings{NdiayeEtAl2016,
+  author = {Ndiaye, Eugene and Fercoq, Olivier and Gramfort, Alexandre and Salmon, Joseph},
+  booktitle = {Advances in Neural Information Processing Systems 29},
+  editor = {Lee, D. D. and Sugiyama, M. and Luxburg, U. V. and Guyon, I. and Garnett, R.},
+  pages = {388-396},
+  publisher = {{Curran Associates, Inc.}},
+  title = {{{GAP}} Safe Screening Rules for Sparse-Group Lasso},
+  url = {http://papers.nips.cc/paper/6405-gap-safe-screening-rules-for-sparse-group-lasso.pdf},
+  year = {2016}
+}
+
+@article{NiazyEtAl2005,
+  author = {Niazy, R. K. and Beckmann, C.F. and Iannetti, G.D. and Brady, J. M. and Smith, S. M.},
+  title = {Removal of FMRI environment artifacts from EEG data using optimal basis sets},
+  journal = {NeuroImage},
+  year = {2005},
+  volume = {28},
+  pages = {720-737},
+  doi = {10.1016/j.neuroimage.2005.06.067.}
+}
+
+@article{NicholsHolmes2002,
+  author = {Nichols, Thomas E. and Holmes, Andrew P.},
+  doi = {10.1002/hbm.1058},
+  journal = {Human Brain Mapping},
+  number = {1},
+  pages = {1-25},
+  shorttitle = {Nonparametric Permutation Tests for Functional Neuroimaging},
+  title = {Nonparametric Permutation Tests for Functional Neuroimaging: A Primer with Examples},
+  volume = {15},
+  year = {2002}
+}
+
+@article{NikulinEtAl2011,
+  author = {Nikulin, Vadim V and Nolte, Guido and Curio, Gabriel},
+  doi = {10.1016/j.neuroimage.2011.01.057},
+  journal={NeuroImage},
+  title = {A novel method for reliable and fast extraction of neuronal {EEG/MEG} oscillations on the basis of spatio-spectral decomposition},
+  pages={1528-1535},
+  volume={55},
+  number={4},
+  year={2011}
+}
+
+@article{NolteEtAl2004,
+  author = {Nolte, Guido and Bai, Ou and Wheaton, Lewis and Mari, Zoltan and Vorbach, Sherry and Hallett, Mark},
+  doi = {10.1016/j.clinph.2004.04.029},
+  journal = {Clinical Neurophysiology},
+  number = {10},
+  pages = {2292-2307},
+  title = {Identifying True Brain Interaction from {{EEG}} Data Using the Imaginary Part of Coherency},
+  volume = {115},
+  year = {2004}
+}
+
+@article{NolteEtAl2008,
+  author = {Nolte, Guido and Ziehe, Andreas and Nikulin, Vadim V. and Schlögl, Alois and Krämer, Nicole and Brismar, Tom and Müller, Klaus-Robert},
+  doi = {10.1103/PhysRevLett.100.234101},
+  journal = {Physical Review Letters},
+  number = {23},
+  title = {Robustly Estimating the Flow Direction of Information in Complex Physical Systems},
+  volume = {100},
+  year = {2008}
+}
+
+@misc{NurminenEtAl2017,
+  author = {Nurminen, Jussi and Paananen, Hilla and Mäkelä, Jyrki},
+  doi = {10.5281/zenodo.889234},
+  publisher = {{Zenodo}},
+  shorttitle = {High Frequency Somatosensory {{MEG}}},
+  title = {High Frequency Somatosensory {{MEG}}: Evoked Responses, Freesurfer Reconstruction},
+  year = {2017}
+}
+
+@article{OostendorpEtAl2000,
+  author = {Oostendorp, Thom F. and Delbeke, Jean and Stegeman, Dick F.},
+  doi = {10.1109/TBME.2000.880100},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {11},
+  pages = {1487-1492},
+  shorttitle = {The Conductivity of the Human Skull},
+  title = {The Conductivity of the Human Skull: Results of in Vivo and in Vitro Measurements},
+  volume = {47},
+  year = {2000}
+}
+
+@book{ParksBurrus1987,
+  address = {{New York}},
+  author = {Parks, Thomas W. and Burrus, C. Sidney S.},
+  isbn = {978-0-471-82896-9},
+  publisher = {{Wiley}},
+  series = {Topics in Digital Signal Processing},
+  title = {Digital Filter Design},
+  year = {1987}
+}
+
+@article{Pascual-Marqui2002,
+  author = {{Pascual-Marqui}, Roberto D.},
+  journal = {Methods and Findings in Experimental and Clinical Pharmacology},
+  number = {D},
+  pages = {5-12},
+  pmid = {12575463},
+  shorttitle = {Standardized Low-Resolution Brain Electromagnetic Tomography ({{sLORETA}})},
+  title = {Standardized Low-Resolution Brain Electromagnetic Tomography ({{sLORETA}}): Technical Details},
+  volume = {24},
+  year = {2002},
+  url = {https://pubmed.ncbi.nlm.nih.gov/12575463/}
+}
+
+@article{Pascual-Marqui2011,
+  title = {Assessing interactions in the brain with exact low-resolution electromagnetic tomography},
+  volume = {369},
+  doi = {10.1098/rsta.2011.0081},
+  number = {1952},
+  journal = {Philosophical Transactions of the Royal Society A: Mathematical, Physical and Engineering Sciences},
+  author = {Pascual-Marqui, Roberto D. and Lehmann, Dietrich and Koukkou, Martha and Kochi, Kieko and Anderer, Peter and Saletu, Bernd and Tanaka, Hideaki and Hirata, Koichi and John, E. Roy and Prichep, Leslie and Biscay-Lirio, Rolando and Kinoshita, Toshihiko},
+  year = {2011},
+  pages = {3768--3784}
+}
+
+@book{PercivalWalden1993,
+  address = {{Cambridge; New York}},
+  author = {Percival, Donald B. and Walden, Andrew T.},
+  isbn = {978-0-521-35532-2},
+  publisher = {{Cambridge University Press}},
+  shorttitle = {Spectral Analysis for Physical Applications},
+  title = {Spectral Analysis for Physical Applications: Multitaper and Conventional Univariate Techniques},
+  doi = {10.1017/CBO9780511622762},
+  year = {1993}
+}
+
+@article{PerrinEtAl1987,
+  title = {Scalp {Current} {Density} {Mapping}: {Value} and {Estimation} from {Potential} {Data}},
+  volume = {BME-34},
+  issn = {1558-2531},
+  shorttitle = {Scalp {Current} {Density} {Mapping}},
+  doi = {10.1109/TBME.1987.326089},
+  number = {4},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  author = {Perrin, F. and Bertrand, O. and Pernier, J.},
+  year = {1987},
+  pages = {283--288}
+}
+
+@article{PerrinEtAl1989,
+  author = {Perrin, François M. and Pernier, Jacques and Bertrand, Olivier M. and Echallier, Jean Franćois},
+  doi = {10.1016/0013-4694(89)90180-6},
+  journal = {Electroencephalography and Clinical Neurophysiology},
+  number = {2},
+  pages = {184-187},
+  title = {Spherical Splines for Scalp Potential and Current Density Mapping},
+  volume = {72},
+  year = {1989}
+}
+
+@article{PfurtschellerLopesdaSilva1999,
+  author = {Pfurtscheller, Gert and {Lopes da Silva}, Fernando H.},
+  doi = {10.1016/S1388-2457(99)00141-8},
+  journal = {Clinical Neurophysiology},
+  number = {11},
+  pages = {1842-1857},
+  shorttitle = {Event-Related {{EEG}}/{{MEG}} Synchronization and Desynchronization},
+  title = {Event-Related {{EEG}}/{{MEG}} Synchronization and Desynchronization: Basic Principles},
+  volume = {110},
+  year = {1999}
+}
+
+@article{Pham2001,
+  author = {Pham, Dinh Tuan},
+  doi = {10.1137/S089547980035689X},
+  journal = {SIAM Journal on Matrix Analysis and Applications},
+  number = {4},
+  pages = {1136-1152},
+  title = {Joint Approximate Diagonalization of Positive Definite Hermitian Matrices},
+  volume = {22},
+  year = {2001}
+}
+
+@article{pollonini2014auditory,
+  title={Auditory cortex activation to natural speech and simulated cochlear implant speech measured with functional near-infrared spectroscopy},
+  author={Pollonini, Luca and Olds, Cristen and Abaya, Homer and Bortfeld, Heather and Beauchamp, Michael S and Oghalai, John S},
+  journal={Hearing Research},
+  volume={309},
+  pages={84--93},
+  year={2014},
+  publisher={Elsevier},
+  pmid={24342740},
+  doi={10.1016/j.heares.2013.11.007}
+}
+
+@article{RidgwayEtAl2012,
+  author = {Ridgway, Gerard R. and Litvak, Vladimir and Flandin, Guillaume and Friston, Karl J. and Penny, Will D.},
+  doi = {10.1016/j.neuroimage.2011.10.027},
+  journal = {NeuroImage},
+  number = {3},
+  pages = {2131-2141},
+  title = {The Problem of Low Variance Voxels in Statistical Parametric Mapping; a New Hat Avoids a ‘Haircut’},
+  volume = {59},
+  year = {2012}
+}
+
+@article{RivetEtAl2009,
+  author = {Rivet, Bertrand and Souloumiac, Antoine and Attina, Virginie and Gibert, Guillaume},
+  doi = {10.1109/TBME.2009.2012869},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {8},
+  pages = {2035-2043},
+  shorttitle = {{{xDAWN}} Algorithm to Enhance Evoked Potentials},
+  title = {{{xDAWN}} Algorithm to Enhance Evoked Potentials: Application to Brain–Computer Interface},
+  volume = {56},
+  year = {2009}
+}
+
+@inproceedings{RivetEtAl2011,
+  address = {{Barcelona}},
+  author = {Rivet, Bertrand and Cecotti, Hubert and Souloumiac, Antoine and Maby, Emmanuel and Mattout, Jérémie},
+  booktitle = {Proceedings of {{EUSIPCO}}-2011},
+  pages = {1382-1386},
+  publisher = {{IEEE}},
+  title = {Theoretical Analysis of {{xDAWN}} Algorithm: Application to an Efficient Sensor Selection in a {{P300}} {{BCI}}},
+  url = {https://ieeexplore.ieee.org/document/7073970},
+  year = {2011}
+}
+
+@article{RockhillEtAl2022,
+  doi = {10.21105/joss.03897},
+  year = {2022},
+  publisher = {The Open Journal},
+  volume = {7},
+  number = {70},
+  pages = {3897},
+  author = {Alexander P. Rockhill and Eric Larson and Brittany Stedelin and Alessandra Mantovani and Ahmed M. Raslan and Alexandre Gramfort and Nicole C. Swann},
+  title = {Intracranial Electrode Location and Analysis in MNE-Python},
+  journal = {Journal of Open Source Software}
+}
+
+@article{Rousselet2012,
+  author = {Rousselet, Guillaume A.},
+  doi = {10.3389/fpsyg.2012.00131},
+  journal = {Frontiers in Psychology},
+  title = {Does Filtering Preclude Us from Studying {{ERP}} Time-Courses?},
+  volume = {3},
+  year = {2012}
+}
+
+@misc{Rousselet2016,
+  author = {Rousselet, Guillaume A.},
+  doi = {10.7488/ds/1556},
+  publisher = {{University of Edinburgh, Centre for Clinical Brain Sciences}},
+  title = {{{LIMO EEG}} Dataset},
+  year = {2016}
+}
+
+@article{RousseletEtAl2010,
+  author = {Rousselet, Guillaume A. and Gaspar, Carl M. and Pernet, Cyril R. and Husk, Jesse S. and Bennett, Patrick J. and Sekuler, Allison B.},
+  doi = {10.3389/fpsyg.2010.00019},
+  journal = {Frontiers in Psychology},
+  number = {19},
+  pages = {1-14},
+  title = {Healthy Aging Delays Scalp {{EEG}} Sensitivity to Noise in a Face Discrimination Task},
+  volume = {1},
+  year = {2010}
+}
+
+@article{RousseletEtAl2008,
+  title = {Parametric Study of {{EEG}} Sensitivity to Phase Noise during Face Processing},
+  author = {Rousselet, Guillaume A. and Pernet, Cyril R. and Bennett, Patrick J. and Sekuler, Allison B.},
+  year = {2008},
+  volume = {9},
+  pages = {98},
+  doi = {10.1186/1471-2202-9-98},
+  journal = {BMC Neuroscience},
+  number = {1}
+}
+
+@article{Sabbagh2020,
+  author = {Sabbagh, David and Ablin, Pierre and Varoquaux, Gaël and Gramfort, Alexandre and Engemann, Denis A.},
+  title = {Predictive regression modeling with MEG/EEG: from source power to signals and cognitive states},
+  journal = {NeuroImage},
+  year = {2020},
+  doi = {10.1016/j.neuroimage.2020.116893}
+}
+
+@article{Samuelsson2019,
+  author = {Samuelsson, John and Khan, Sheraz and Sundaram, Padma and Peled, Noam and Hämäläinen, Matti},
+  title = {Cortical Signal Suppression (CSS) for detection of subcortical activity using MEG and EEG},
+  journal = {Brain Topography},
+  year = {2019},
+  volume = {32},
+  pages = {215-228},
+  doi = {10.1007/s10548-018-00694-5}
+}
+
+@article{Sarvas1987,
+  author = {Sarvas, Jukka},
+  doi = {10.1088/0031-9155/32/1/004},
+  journal = {Physics in Medicine and Biology},
+  number = {1},
+  pages = {11-22},
+  publisher = {{IOP Publishing}},
+  title = {Basic Mathematical and Electromagnetic Concepts of the Biomagnetic Inverse Problem},
+  volume = {32},
+  year = {1987}
+}
+
+@article{Sassenhagen2019,
+author = {Sassenhagen, Jona and Draschkow, Dejan},
+doi = {10.1111/psyp.13335},
+journal = {Psychophysiology},
+volume = {56},
+number = {6},
+pages = {e13335},
+keywords = {cluster-based permutation test, EEG, MEG, statistics},
+title = {Cluster-based permutation tests of MEG/EEG data do not establish significance of effect latency or location},
+year = {2019}
+}
+
+@article{SavitzkyGolay1964,
+  author = {Savitzky, Abraham and Golay, Marcel J. E.},
+  doi = {10.1021/ac60214a047},
+  journal = {Analytical Chemistry},
+  number = {8},
+  pages = {1627-1639},
+  title = {Smoothing and Differentiation of Data by Simplified Least Squares Procedures},
+  volume = {36},
+  year = {1964}
+}
+
+@article{SchalkEtAl2004,
+  author = {Schalk, Gerwin and McFarland, Dennis J. and Hinterberger, Thilo and Birbaumer, Niels and Wolpaw, Jonathan R.},
+  doi = {10.1109/TBME.2004.827072},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {6},
+  pages = {1034-1043},
+  shorttitle = {{{BCI2000}}},
+  title = {{{BCI2000}}: A General-Purpose Brain-Computer Interface ({{BCI}}) System},
+  volume = {51},
+  year = {2004}
+}
+
+@article{SchurgerEtAl2013,
+  author = {Schurger, Aaron and Marti, Sebastien and Dehaene, Stanislas},
+  doi = {10.1186/1471-2202-14-122},
+  journal = {BMC Neuroscience},
+  number = {1},
+  title = {Reducing Multi-Sensor Data to a Single Time Course That Reveals Experimental Effects},
+  volume = {14},
+  year = {2013}
+}
+
+@article{SegonneEtAl2004,
+  author = {Ségonne, Florent and Dale, Anders M. and Busa, Evelina and Glessner, Maureen and Salat, David and Hahn, Horst Karl and Fischl, Bruce R.},
+  doi = {10.1016/j.neuroimage.2004.03.032},
+  journal = {NeuroImage},
+  number = {3},
+  pages = {1060-1075},
+  title = {A Hybrid Approach to the Skull Stripping Problem in {{MRI}}},
+  volume = {22},
+  year = {2004}
+}
+
+@book{SekiharaNagarajan2008,
+  address = {{Berlin; Heidelberg}},
+  author = {Sekihara, Kensuke and Nagarajan, Srikantan S.},
+  doi = {10.1007/978-3-540-79370-0},
+  editor = {Nagel, Joachim H.},
+  isbn = {978-3-540-79369-4 978-3-540-79370-0},
+  publisher = {Springer},
+  series = {Series in {{Biomedical Engineering}}},
+  title = {Adaptive Spatial Filters for Electromagnetic Brain Imaging},
+  year = {2008}
+}
+
+@article{Shepard1980,
+  author = {Shepard, Roger N.},
+  doi = {10.1126/science.210.4468.390},
+  journal = {Science},
+  number = {4468},
+  pages = {390-398},
+  title = {Multidimensional Scaling, Tree-Fitting, and Clustering},
+  volume = {210},
+  year = {1980}
+}
+
+@article{Slepian1978,
+  author = {Slepian, David S.},
+  doi = {10.1002/j.1538-7305.1978.tb02104.x},
+  journal = {Bell System Technical Journal},
+  number = {5},
+  pages = {1371-1430},
+  shorttitle = {Prolate Spheroidal Wave Functions, Fourier Analysis, and Uncertainty-{{V}}},
+  title = {Prolate Spheroidal Wave Functions, Fourier Analysis, and Uncertainty-{{V}}: The Discrete Case},
+  volume = {57},
+  year = {1978}
+}
+
+@article{SmithKutas2015,
+  author = {Smith, Nathaniel J. and Kutas, Marta},
+  doi = {10.1111/psyp.12320},
+  journal = {Psychophysiology},
+  number = {2},
+  pages = {169-181},
+  shorttitle = {Regression-Based Estimation of {{ERP}} Waveforms},
+  title = {Regression-Based Estimation of {{ERP}} Waveforms: {{II}}. {{Nonlinear}} Effects, Overlap Correction, and Practical Considerations: {{rERPS II}}},
+  volume = {52},
+  year = {2015}
+}
+
+@article{SmithNichols2009,
+  author = {Smith, Stephen M. and Nichols, Thomas E.},
+  doi = {10.1016/j.neuroimage.2008.03.061},
+  journal = {NeuroImage},
+  number = {1},
+  pages = {83-98},
+  shorttitle = {Threshold-Free Cluster Enhancement},
+  title = {Threshold-Free Cluster Enhancement: Addressing Problems of Smoothing, Threshold Dependence and Localisation in Cluster Inference},
+  volume = {44},
+  year = {2009}
+}
+
+@article{StamEtAl2007,
+  author = {Stam, Cornelis J. and Nolte, Guido and Daffertshofer, Andreas},
+  doi = {10.1002/hbm.20346},
+  journal = {Human Brain Mapping},
+  number = {11},
+  pages = {1178-1193},
+  shorttitle = {Phase Lag Index},
+  title = {Phase Lag Index: Assessment of Functional Connectivity from Multi Channel {{EEG}} and {{MEG}} with Diminished Bias from Common Sources},
+  volume = {28},
+  year = {2007}
+}
+
+@incollection{Stockwell2007,
+  address = {{Providence, RI}},
+  author = {Stockwell, R. G.},
+  booktitle = {Pseudo-{{Differential Operators}}: {{Partial Differential Equations}} and {{Time}}-{{Frequency Analysis}}},
+  doi = {10.1090/fic/052},
+  editor = {Rodino, Luigi and Schulze, Bert-Wolfgang and Wong, M. W.},
+  isbn = {978-0-8218-4276-8 978-1-4704-3086-3},
+  number = {52},
+  pages = {279-309},
+  publisher = {{American Mathematical Society}},
+  series = {Fields {{Institute Communications}}},
+  title = {Why Use the {{S}}-Transform?},
+  year = {2007}
+}
+
+@inproceedings{StrohmeierEtAl2014,
+  address = {{Tübingen}},
+  author = {Strohmeier, Daniel and Haueisen, Jens and Gramfort, Alexandre},
+  booktitle = {Proceedings of {{PRNI}}-2014},
+  doi = {10.1109/PRNI.2014.6858545},
+  isbn = {978-1-4799-4149-0 978-1-4799-4150-6},
+  pages = {1-4},
+  publisher = {{IEEE}},
+  title = {Improved {{MEG}}/{{EEG}} Source Localization with Reweighted Mixed-Norms},
+  year = {2014}
+}
+
+@article{StrohmeierEtAl2016,
+  author = {Strohmeier, Daniel and Bekhti, Yousra and Haueisen, Jens and Gramfort, Alexandre},
+  doi = {10.1109/TMI.2016.2553445},
+  journal = {IEEE Transactions on Medical Imaging},
+  number = {10},
+  pages = {2218-2228},
+  title = {The Iterative Reweighted Mixed-Norm Estimate for Spatio-Temporal {{MEG}}/{{EEG}} Source Reconstruction},
+  volume = {35},
+  year = {2016}
+}
+
+@article{TadelEtAl2011,
+  author = {Tadel, François and Baillet, Sylvain and Mosher, John C. and Pantazis, Dimitrios and Leahy, Richard M.},
+  doi = {10.1155/2011/879716},
+  journal = {Computational Intelligence and Neuroscience},
+  pages = {1-13},
+  shorttitle = {Brainstorm},
+  title = {Brainstorm: A User-Friendly Application for {{MEG}}/{{EEG}} Analysis},
+  volume = {2011},
+  year = {2011}
+}
+
+@article{Tallon-BaudryEtAl1997,
+	author = {Tallon-Baudry, Catherine and Bertrand, Olivier and Delpuech, Claude and Pernier, Jacques},
+  doi = {10.1523/JNEUROSCI.17-02-00722.1997},
+	journal = {Journal of Neuroscience},
+	pages = {722-734},
+	title = {Oscillatory {Gamma}-{Band} (30–70 {Hz}) {Activity} {Induced} by a {Visual} {Search} {Task} in {Humans}},
+	year = {1997},
+}
+
+@article{TannerEtAl2015,
+  author = {Tanner, Darren and {Morgan-Short}, Kara and Luck, Steven J.},
+  doi = {10.1111/psyp.12437},
+  journal = {Psychophysiology},
+  number = {8},
+  pages = {997-1009},
+  shorttitle = {How Inappropriate High-Pass Filters Can Produce Artifactual Effects and Incorrect Conclusions in {{ERP}} Studies of Language and Cognition},
+  title = {How Inappropriate High-Pass Filters Can Produce Artifactual Effects and Incorrect Conclusions in {{ERP}} Studies of Language and Cognition: High-Pass Filtering and Artifactual {{ERP}} Effects},
+  volume = {52},
+  year = {2015}
+}
+
+@article{TannerEtAl2016,
+  author = {Tanner, Darren and Norton, James J.S. and {Morgan-Short}, Kara and Luck, Steven J.},
+  doi = {10.1016/j.jneumeth.2016.01.002},
+  journal = {Journal of Neuroscience Methods},
+  pages = {166-170},
+  title = {On High-Pass Filter Artifacts (They’re Real) and Baseline Correction (It's a Good Idea) in {{ERP}}/{{ERMF}} Analysis},
+  volume = {266},
+  year = {2016}
+}
+
+@article{TauluEtAl2005,
+  author = {Taulu, Samu and Simola, Juha and Kajola, Matti J.},
+  doi = {10.1109/TSP.2005.853302},
+  journal = {IEEE Transactions on Signal Processing},
+  number = {9},
+  pages = {3359-3372},
+  title = {Applications of the Signal Space Separation Method},
+  volume = {53},
+  year = {2005}
+}
+
+@article{TauluKajola2005,
+  author = {Taulu, Samu and Kajola, Matti},
+  doi = {10.1063/1.1935742},
+  journal = {Journal of Applied Physics},
+  number = {12},
+  pages = {124905},
+  shorttitle = {Presentation of Electromagnetic Multichannel Data},
+  title = {Presentation of Electromagnetic Multichannel Data: The Signal Space Separation Method},
+  volume = {97},
+  year = {2005}
+}
+
+@article{TauluSimola2006,
+  author = {Taulu, Samu and Simola, Juha},
+  doi = {10.1088/0031-9155/51/7/008},
+  journal = {Physics in Medicine and Biology},
+  number = {7},
+  pages = {1759-1768},
+  title = {Spatiotemporal Signal Space Separation Method for Rejecting Nearby Interference in {{MEG}} Measurements},
+  volume = {51},
+  year = {2006}
+}
+
+@article{TenkeKayser2001,
+  title = {A convenient method for detecting electrolyte bridges in multichannel electroencephalogram and event-related potential recordings},
+  volume = {112},
+  issn = {1388-2457},
+  doi = {10.1016/s1388-2457(00)00553-8},
+  language = {eng},
+  number = {3},
+  journal = {Clinical Neurophysiology: Official Journal of the International Federation of Clinical Neurophysiology},
+  author = {Tenke, C. E. and Kayser, J.},
+  month = mar,
+  year = {2001},
+  pmid = {11222978},
+  keywords = {Algorithms, Artifacts, Brain, Electrodes, Electroencephalography, Electrolytes, Evoked Potentials, Humans, Scalp},
+  pages = {545--550}
+}
+
+@article{TescheEtAl1995,
+  author = {Tesche, Claudia D. and Uusitalo, Mikko A. and Ilmoniemi, Risto J. and Huotilainen, Minna and Kajola, Matti J. and Salonen, Oili L. M.},
+  doi = {10.1016/0013-4694(95)00064-6},
+  journal = {Electroencephalography and Clinical Neurophysiology},
+  number = {3},
+  pages = {189-200},
+  title = {Signal-Space Projections of {{MEG}} Data Characterize Both Distributed and Well-Localized Neuronal Sources},
+  volume = {95},
+  year = {1995}
+}
+
+@article{TheunissenEtAl2001,
+  author = {Theunissen, Frédéric E. and David, Stephen V. and Singh, Nandini C. and Hsu, Ann and Vinje, William E. and Gallant, Jack L.},
+  doi = {10.1080/net.12.3.289.316},
+  journal = {Network: Computation in Neural Systems},
+  number = {3},
+  pages = {289-316},
+  title = {Estimating Spatio-Temporal Receptive Fields of Auditory and Visual Neurons from Their Responses to Natural Stimuli},
+  volume = {12},
+  year = {2001}
+}
+
+@article{TippingBishop1999,
+  author = {Tipping, Michael E. and Bishop, Christopher M.},
+  doi = {10.1111/1467-9868.00196},
+  journal = {Journal of the Royal Statistical Society: Series B (Statistical Methodology)},
+  number = {3},
+  pages = {611-622},
+  title = {Probabilistic Principal Component Analysis},
+  volume = {61},
+  year = {1999}
+}
+
+@article{UusitaloIlmoniemi1997,
+  author = {Uusitalo, Mikko A. and Ilmoniemi, Risto J.},
+  doi = {10.1007/BF02534144},
+  journal = {Medical \& Biological Engineering \& Computing},
+  number = {2},
+  pages = {135-140},
+  title = {Signal-Space Projection Method for Separating {{MEG}} or {{EEG}} into Components},
+  volume = {35},
+  year = {1997}
+}
+
+@article{VanRullen2011,
+  author = {VanRullen, Rufin},
+  doi = {10.3389/fpsyg.2011.00365},
+  journal = {Frontiers in Psychology},
+  title = {Four Common Conceptual Fallacies in Mapping the Time Course of Recognition},
+  volume = {2},
+  year = {2011}
+}
+
+@article{VanVeenEtAl1997,
+  author = {Van Veen, Barry D. and {van Drongelen}, Wim and Yuchtman, Moshe and Suzuki, Akifumi},
+  doi = {10.1109/10.623056},
+  journal = {IEEE Transactions on Biomedical Engineering},
+  number = {9},
+  pages = {867-880},
+  title = {Localization of Brain Electrical Activity via Linearly Constrained Minimum Variance Spatial Filtering},
+  volume = {44},
+  year = {1997}
+}
+
+@article{vanVlietEtAl2018,
+  author = {{van Vliet}, Marijn and Liljeström, Mia and Aro, Susanna and Salmelin, Riitta and Kujala, Jan},
+  doi = {10.1101/245530},
+  journal = {bioRxiv},
+  shorttitle = {Analysis of Functional Connectivity and Oscillatory Power Using {{DICS}}},
+  title = {Analysis of Functional Connectivity and Oscillatory Power Using {{DICS}}: From Raw {{MEG}} Data to Group-Level Statistics in {{Python}}},
+  year = {2018}
+}
+
+@article{VinckEtAl2010,
+  author = {Vinck, Martin and {van Wingerden}, Marijn and Womelsdorf, Thilo and Fries, Pascal and Pennartz, Cyriel M.A.},
+  doi = {10.1016/j.neuroimage.2010.01.073},
+  journal = {NeuroImage},
+  number = {1},
+  pages = {112-122},
+  shorttitle = {The Pairwise Phase Consistency},
+  title = {The Pairwise Phase Consistency: A Bias-Free Measure of Rhythmic Neuronal Synchronization},
+  volume = {51},
+  year = {2010}
+}
+
+@article{VinckEtAl2011,
+  author = {Vinck, Martin and Oostenveld, Robert and {van Wingerden}, Marijn and Battaglia, Franscesco and Pennartz, Cyriel M.A.},
+  doi = {10.1016/j.neuroimage.2011.01.055},
+  journal = {NeuroImage},
+  number = {4},
+  pages = {1548-1565},
+  title = {An Improved Index of Phase-Synchronization for Electrophysiological Data in the Presence of Volume-Conduction, Noise and Sample-Size Bias},
+  volume = {55},
+  year = {2011}
+}
+
+@article{WehnerEtAl2008,
+  author = {Wehner, Daniel T. and Hämäläinen, Matti S. and Mody, Maria and Ahlfors, Seppo P.},
+  doi = {10.1016/j.neuroimage.2007.12.026},
+  journal = {NeuroImage},
+  number = {2},
+  pages = {541-550},
+  shorttitle = {Head Movements of Children in {{MEG}}},
+  title = {Head Movements of Children in {{MEG}}: Quantification, Effects on Source Estimation, and Compensation},
+  volume = {40},
+  year = {2008}
+}
+
+@article{WestnerEtAl2022,
+  author = {Westner, Britta U. and Dalal, Sarang S. and Gramfort, Alexandre and Litvak, Vladimir and Mosher, John C. and Oostenveld, Robert and Schoffelen, Jan-Mathijs},
+  doi = {10.1016/j.neuroimage.2021.118789},
+  journal = {NeuroImage},
+  pages = {118789},
+  title = {A unified view on beamformers for {M}/{EEG} source reconstruction},
+  volume = {246},
+  year = {2022},
+}
+
+@article{WheatEtAl2010,
+  author = {Wheat, Katherine L. and Cornelissen, Piers L. and Frost, Stephen J. and Hansen, Peter C.},
+  doi = {10.1523/JNEUROSCI.4448-09.2010},
+  journal = {Journal of Neuroscience},
+  number = {15},
+  pages = {5229-5233},
+  shorttitle = {During Visual Word Recognition, Phonology Is Accessed within {{100 ms}} and May Be Mediated by a Speech Production Code},
+  title = {During Visual Word Recognition, Phonology Is Accessed within {{100 ms}} and May Be Mediated by a Speech Production Code: Evidence from Magnetoencephalography},
+  volume = {30},
+  year = {2010}
+}
+
+@article{WhithamEtAl2007,
+  title = {Scalp electrical recording during paralysis: quantitative evidence that {EEG} frequencies above 20 {Hz} are contaminated by {EMG}},
+  volume = {118},
+  issn = {1388-2457},
+  doi = {10.1016/j.clinph.2007.04.027},
+  number = {8},
+  journal = {Clinical Neurophysiology: Official Journal of the International Federation of Clinical Neurophysiology},
+  author = {Whitham, Emma M. and Pope, Kenneth J. and Fitzgibbon, Sean P. and Lewis, Trent and Clark, C. Richard and Loveless, Stephen and Broberg, Marita and Wallace, Angus and DeLosAngeles, Dylan and Lillie, Peter and Hardy, Andrew and Fronsko, Rik and Pulbrook, Alyson and Willoughby, John O.},
+  year = {2007},
+  pmid = {17574912},
+  pages = {1877--1888},
+}
+
+@article{WidmannEtAl2015,
+  author = {Widmann, Andreas and Schröger, Erich and Maess, Burkhard},
+  doi = {10.1016/j.jneumeth.2014.08.002},
+  journal = {Journal of Neuroscience Methods},
+  pages = {34-46},
+  title = {Digital Filter Design for Electrophysiological Data – a Practical Approach},
+  volume = {250},
+  year = {2015}
+}
+
+@article{WidmannSchroger2012,
+  author = {Widmann, Andreas and Schröger, Erich},
+  doi = {10.3389/fpsyg.2012.00233},
+  journal = {Frontiers in Psychology},
+  title = {Filter Effects and Filter Artifacts in the Analysis of Electrophysiological Data},
+  volume = {3},
+  year = {2012}
+}
+
+@article{WillmoreSmyth2003,
+  author = {Willmore, Ben and Smyth, Darragh},
+  doi = {10.1088/0954-898X_14_3_309},
+  journal = {Network: Computation in Neural Systems},
+  number = {3},
+  pages = {553-577},
+  shorttitle = {Methods for First-Order Kernel Estimation},
+  title = {Methods for First-Order Kernel Estimation: Simple-Cell Receptive Fields from Responses to Natural Scenes},
+  volume = {14},
+  year = {2003}
+}
+
+@inproceedings{WinklerEtAl2015,
+  address = {{Milan}},
+  author = {Winkler, Irene and Debener, Stefan and Müller, Klaus-Robert and Tangermann, Michael},
+  booktitle = {Proceedings of {{EMBC}}-2015},
+  doi = {10.1109/EMBC.2015.7319296},
+  isbn = {978-1-4244-9271-8},
+  pages = {4101-4105},
+  publisher = {{IEEE}},
+  title = {On the Influence of High-Pass Filtering on {{ICA}}-Based Artifact Reduction in {{EEG}}-{{ERP}}},
+  year = {2015}
+}
+
+@inproceedings{WipfEtAl2007,
+  author = {Wipf, David P. and Ramírez, Rey and Palmer, Jason and Makeig, Scott and Rao, Bhaskar D.},
+  booktitle = {Advances in Neural Information Processing Systems 19},
+  editor = {Schölkopf, Bernhard and Platt, John C. and Hoffman, T.},
+  pages = {1505-1512},
+  publisher = {{MIT Press}},
+  title = {Analysis of Empirical Bayesian Methods for Neuroelectromagnetic Source Localization},
+  url = {http://papers.nips.cc/paper/3089-analysis-of-empirical-bayesian-methods-for-neuroelectromagnetic-source-localization.pdf},
+  year = {2007}
+}
+
+@article{WipfNagarajan2009,
+  author = {Wipf, David and Nagarajan, Srikantan},
+  doi = {10.1016/j.neuroimage.2008.02.059},
+  journal = {NeuroImage},
+  number = {3},
+  pages = {947-966},
+  title = {A Unified {{Bayesian}} Framework for {{MEG}}/{{EEG}} Source Imaging},
+  volume = {44},
+  year = {2009}
+}
+
+@article{Zhang1995,
+  author = {Zhang, Zhi},
+  doi = {10.1088/0031-9155/40/3/001},
+  journal = {Physics in Medicine and Biology},
+  number = {3},
+  pages = {335-349},
+  title = {A Fast Method to Compute Surface Potentials Generated by Dipoles within Multilayer Anisotropic Spheres},
+  volume = {40},
+  year = {1995}
+}
+
+@article{KayserTenke2015,
+  title = {On the benefits of using surface {Laplacian} ({Current} {Source} {Density}) methodology in electrophysiology},
+  volume = {97},
+  issn = {0167-8760},
+  doi = {10.1016/j.ijpsycho.2015.06.001},
+  number = {3},
+  journal = {International journal of psychophysiology : official journal of the International Organization of Psychophysiology},
+  author = {Kayser, Jürgen and Tenke, Craig E.},
+  year = {2015},
+  pmid = {26071227},
+  pmcid = {PMC4610715},
+  pages = {171--173}
+}
+
+@article{GrattonEtAl1983,
+  title = {A new method for off-line removal of ocular artifact},
+  volume = {55},
+  issn = {0013-4694},
+  doi = {10.1016/0013-4694(83)90135-9},
+  number = {4},
+  urldate = {2020-08-03},
+  journal = {Electroencephalography and Clinical Neurophysiology},
+  author = {Gratton, Gabriele and Coles, Michael G. H and Donchin, Emanuel},
+  year = {1983},
+  pages = {468--484}
+}
+
+@book{OppenheimEtAl1999,
+  address = {Upper Saddle River, NJ},
+  edition = {2 edition},
+  title = {Discrete-{Time} {Signal} {Processing}},
+  isbn = {978-0-13-754920-7},
+  publisher = {Prentice Hall},
+  author = {Oppenheim, Alan V. and Schafer, Ronald W. and Buck, John R.},
+  year = {1999}
+}
+
+@book{CrochiereRabiner1983,
+  address = {Englewood Cliffs, NJ},
+  edition = {1 edition},
+  title = {Multirate {Digital} {Signal} {Processing}},
+  isbn = {978-0-13-605162-6},
+  publisher = {Pearson},
+  author = {Crochiere, Ronald E. and Rabiner, Lawrence R.},
+  year = {1983}
+}
+
+@article{Yao2001,
+  title = {A method to standardize a reference of scalp {EEG} recordings to a point at infinity},
+  volume = {22},
+  issn = {0967-3334},
+  doi = {10.1088/0967-3334/22/4/305},
+  number = {4},
+  journal = {Physiological Measurement},
+  author = {Yao, D.},
+  year = {2001},
+  pmid = {11761077},
+  pages = {693--711}
+}
+
+@inproceedings{StrohmeierEtAl2015,
+  title = {{MEG}/{EEG} {Source} {Imaging} with a {Non}-{Convex} {Penalty} in the {Time}-{Frequency} {Domain}},
+  doi = {10.1109/PRNI.2015.14},
+  booktitle = {2015 {International} {Workshop} on {Pattern} {Recognition} in {NeuroImaging}},
+  author = {Strohmeier, Daniel and Gramfort, Alexandre and Haueisen, Jens},
+  year = {2015},
+  pages = {21--24}
+}
+
+@misc{WikipediaSI,
+    author = "{Wikipedia contributors}",
+    title = "International System of Units — {Wikipedia}{,} The Free Encyclopedia",
+    year = "2020",
+    url = "https://en.wikipedia.org/w/index.php?title=International_System_of_Units&oldid=982683558",
+    urldate = "12-October-2020"
+}
+
+@misc{BIDSdocs,
+    author = "{BIDS} contributors",
+    title = {Brain Imaging Data Structure — Specification},
+    url = {https://bids-specification.readthedocs.io/en/stable/},
+    urldate = "12-October-2020"
+}
+
+@article{OReillyEtAl2021,
+  title = {Structural templates for imaging {EEG} cortical sources in infants},
+  volume = {227},
+  issn = {1053-8119},
+  doi = {10.1016/j.neuroimage.2020.117682},
+  journal = {NeuroImage},
+  author = {O'Reilly, Christian and Larson, Eric and Richards, John E. and Elsabbagh, Mayada},
+  year = {2021},
+  pages = {117682}
+}
+
+@article{RichardsEtAl2016,
+  series = {Sharing the wealth: {Brain} {Imaging} {Repositories} in 2015},
+  title = {A database of age-appropriate average {MRI} templates},
+  volume = {124},
+  issn = {1053-8119},
+  doi = {10.1016/j.neuroimage.2015.04.055},
+  journal = {NeuroImage},
+  author = {Richards, John E. and Sanchez, Carmen and Phillips-Meek, Michelle and Xie, Wanze},
+  year = {2016},
+  pages = {1254--1259}
+}
+
+@Article{Lehmann1980,
+  author    = {Dietrich Lehmann and Wolfgang Skrandies},
+  journal   = {Electroencephalography and Clinical Neurophysiology},
+  title     = {Reference-free identification of components of checkerboard-evoked multichannel potential fields},
+  year      = {1980},
+  issn      = {0013-4694},
+  number    = {6},
+  pages     = {609--621},
+  volume    = {48},
+  doi       = {10.1016/0013-4694(80)90419-8},
+  publisher = {Elsevier {BV}},
+}
+
+@Article{Lehmann1984,
+  author    = {Dietrich Lehmann and Wolfgang Skrandies},
+  journal   = {Progress in Neurobiology},
+  title     = {Spatial analysis of evoked potentials in man—a review},
+  year      = {1984},
+  issn      = {0301-0082},
+  number    = {3},
+  pages     = {227--250},
+  volume    = {23},
+  doi       = {10.1016/0301-0082(84)90003-0},
+  publisher = {Elsevier {BV}},
+}
+
+@Article{Murray2008,
+  author    = {Micah M. Murray and Denis Brunet and Christoph M. Michel},
+  journal   = {Brain Topography},
+  title     = {Topographic {ERP} Analyses: {A} Step-by-Step Tutorial Review},
+  year      = {2008},
+  issn      = {0896-0267},
+  number    = {4},
+  pages     = {249--264},
+  volume    = {20},
+  doi       = {10.1007/s10548-008-0054-5},
+  publisher = {Springer Science and Business Media {LLC}},
+}
+
+@Article{Kappenman2021,
+  author    = {Emily S. Kappenman and Jaclyn L. Farrens and Wendy Zhang and Andrew X. Stewart and Steven J. Luck},
+  journal   = {{NeuroImage}},
+  title     = {{ERP} {CORE}: An open resource for human event-related potential research},
+  year      = {2021},
+  issn      = {1053-8119},
+  pages     = {117465},
+  volume    = {225},
+  doi       = {10.1016/j.neuroimage.2020.117465},
+  publisher = {Elsevier {BV}},
+}
+
+@article{GenoveseEtAl2002,
+  title = {Thresholding of Statistical Maps in Functional Neuroimaging Using the False Discovery Rate},
+  journal = {NeuroImage},
+  volume = {15},
+  number = {4},
+  pages = {870-878},
+  year = {2002},
+  issn = {1053-8119},
+  doi = {https://doi.org/10.1006/nimg.2001.1037},
+  author = {Christopher R. Genovese and Nicole A. Lazar and Thomas Nichols},
+}
+
+@article{YaoEtAl2019,
+  title={Which reference should we use for {EEG} and {ERP} practice?},
+  author={Yao, Dezhong and Qin, Yun and Hu, Shiang and Dong, Li and Vega, Maria L Bringas and Sosa, Pedro A Vald{\'e}s},
+  journal={Brain topography},
+  volume={32},
+  number={4},
+  pages={530--549},
+  year={2019},
+  doi = {10.1007/s10548-019-00707-x},
+  publisher={Springer}
+}
+
+@article{PolonenkoMaddox2019,
+  title = {The {Parallel} {Auditory} {Brainstem} {Response}},
+  volume = {23},
+  issn = {2331-2165},
+  doi = {10.1177/2331216519871395},
+  language = {en},
+  journal = {Trends in Hearing},
+  author = {Polonenko, Melissa J. and Maddox, Ross K.},
+  year = {2019},
+  pages = {2331216519871395}
+}
+
+@article{DeledalleEtAl2014,
+  author = {Deledalle, Charles-Alban and Vaiter, Samuel and Fadili, Jalal and Peyré, Gabriel},
+  title = {Stein Unbiased GrAdient estimator of the Risk (SUGAR) for Multiple Parameter Selection},
+  journal = {SIAM Journal on Imaging Sciences},
+  volume = {7},
+  number = {4},
+  pages = {2448-2487},
+  year = {2014},
+  doi = {10.1137/140968045},
+}
+
+@InProceedings{BertrandEtAl2020,
+  title = { Anderson acceleration of coordinate descent },
+  author = {Bertrand, Quentin and Massias, Mathurin},
+  booktitle = {Proceedings of The 24th International Conference on Artificial Intelligence and Statistics},
+  pages = {1288--1296},
+  year = {2021},
+  editor = {Banerjee, Arindam and Fukumizu, Kenji},
+  volume = {130},
+  series = {Proceedings of Machine Learning Research},
+  month = {13--15 Apr},
+  publisher = {PMLR},
+  url = {http://proceedings.mlr.press/v130/bertrand21a.html}
+}
+
+@book{Luck2014,
+  title = {An Introduction to the Event-Related Potential Technique},
+  author = {Luck, Steven J},
+  year = {2014},
+  edition = {2nd},
+  publisher = {The MIT Press},
+  address = {Cambridge, MA},
+  url = {https://mitpress.mit.edu/books/introduction-event-related-potential-technique-second-edition},
+  isbn = {978-0-262-52585-5}
+}
+
+@article{Lopez-CalderonLuck2014,
+  title = {ERPLAB: An Open-Source Toolbox for the Analysis of Event-Related Potentials},
+  author = {Lopez-Calderon, Javier and Luck, Steven J.},
+  year = {2014},
+  journal = {Frontiers in Human Neuroscience},
+  volume = {8},
+  issn = {1662-5161},
+  doi = {10.3389/fnhum.2014.00213}
+}
+
+@article{LuckGaspelin2017,
+  title = {How to Get Statistically Significant Effects in Any {{ERP}} Experiment (and Why You Shouldn't)},
+  author = {Luck, Steven J. and Gaspelin, Nicholas},
+  year = {2017},
+  journal = {Psychophysiology},
+  volume = {54},
+  number = {1},
+  pages = {146--157},
+  issn = {1469-8986},
+  doi = {10.1111/psyp.12639},
+}
+
+@article{Welch1967,
+  title = {The Use of Fast {{Fourier}} Transform for the Estimation of Power Spectra: {{A}} Method Based on Time Averaging over Short, Modified Periodograms},
+  author = {Welch, Peter D.},
+  year = {1967},
+  journal = {IEEE Transactions on Audio and Electroacoustics},
+  volume = {15},
+  number = {2},
+  pages = {70--73},
+  doi = {10.1109/TAU.1967.1161901},
+}
+
+@article{MaksymenkoEtAl2017,
+  title = {Strategies for statistical thresholding of source localization maps in magnetoencephalography and estimating source extent},
+  volume = {290},
+  issn = {0165-0270},
+  doi = {10.1016/j.jneumeth.2017.07.015},
+  language = {en},
+  journal = {Journal of Neuroscience Methods},
+  author = {Maksymenko, Kostiantyn and Giusiano, Bernard and Roehri, Nicolas and Bénar, Christian-G. and Badier, Jean-Michel},
+  month = oct,
+  year = {2017},
+  pages = {95--104}
+}
+
+@article{BeckerEtAl2017,
+  title = {{SISSY}: {An} efficient and automatic algorithm for the analysis of {EEG} sources based on structured sparsity},
+  volume = {157},
+  issn = {1053-8119},
+  shorttitle = {{SISSY}},
+  doi = {10.1016/j.neuroimage.2017.05.046},
+  language = {en},
+  journal = {NeuroImage},
+  author = {Becker, H. and Albera, L. and Comon, P. and Nunes, J. -C. and Gribonval, R. and Fleureau, J. and Guillotel, P. and Merlet, I.},
+  month = aug,
+  year = {2017},
+  pages = {157--172}
+}
+
+@article{YaoEtAl2005,
+  title = {Evaluation of different cortical source localization methods using simulated and experimental {EEG} data},
+  volume = {25},
+  issn = {1053-8119},
+  doi = {10.1016/j.neuroimage.2004.11.036},
+  language = {en},
+  number = {2},
+  journal = {NeuroImage},
+  author = {Yao, Jun and Dewald, Julius P. A.},
+  month = apr,
+  year = {2005},
+  pages = {369--382}
+}
+
+@article{StenroosHauk2013,
+	title = {Minimum-norm cortical source estimation in layered head models is robust against skull conductivity error},
+	volume = {81},
+	issn = {1053-8119},
+	doi = {10.1016/j.neuroimage.2013.04.086},
+	abstract = {The conductivity profile of the head has a major effect on EEG signals, but unfortunately the conductivity for the most important compartment, skull, is only poorly known. In dipole modeling studies, errors in modeled skull conductivity have been considered to have a detrimental effect on EEG source estimation. However, as dipole models are very restrictive, those results cannot be generalized to other source estimation methods. In this work, we studied the sensitivity of EEG and combined MEG+EEG source estimation to errors in skull conductivity using a distributed source model and minimum-norm (MN) estimation. We used a MEG/EEG modeling set-up that reflected state-of-the-art practices of experimental research. Cortical surfaces were segmented and realistically-shaped three-layer anatomical head models were constructed, and forward models were built with Galerkin boundary element method while varying the skull conductivity. Lead-field topographies and MN spatial filter vectors were compared across conductivities, and the localization and spatial spread of the MN estimators were assessed using intuitive resolution metrics. The results showed that the MN estimator is robust against errors in skull conductivity: the conductivity had a moderate effect on amplitudes of lead fields and spatial filter vectors, but the effect on corresponding morphologies was small. The localization performance of the EEG or combined MEG+EEG MN estimator was only minimally affected by the conductivity error, while the spread of the estimate varied slightly. Thus, the uncertainty with respect to skull conductivity should not prevent researchers from applying minimum norm estimation to EEG or combined MEG+EEG data. Comparing our results to those obtained earlier with dipole models shows that general judgment on the performance of an imaging modality should not be based on analysis with one source estimation method only.},
+	language = {en},
+	journal = {NeuroImage},
+	author = {Stenroos, Matti and Hauk, Olaf},
+	month = nov,
+	year = {2013},
+	keywords = {Electroencephalography, Inverse problem, Magnetoencephalography, Minimum-norm estimation, Skull conductivity},
+	pages = {265--272}
+}
+
+@article{CroftBarry2000,
+  title = {Removal of ocular artifact from the {EEG}: a review},
+  author = {Croft, R. J. and Barry, R. J.},
+  year = {2000},
+  journal = {Clinical Neurophysiology},
+  volume = {30},
+  number = {1},
+  pages = {5--19},
+  doi = {10.1016/S0987-7053(00)00055-1}
+}
+
+
+@article{SeymourEtAl2022,
+	title = {Interference suppression techniques for {OPM}-based {MEG}: {Opportunities} and challenges},
+	volume = {247},
+	issn = {1053-8119},
+	shorttitle = {Interference suppression techniques for {OPM}-based {MEG}},
+	doi = {10.1016/j.neuroimage.2021.118834},
+	language = {en},
+	journal = {NeuroImage},
+	author = {Seymour, Robert A. and Alexander, Nicholas and Mellor, Stephanie and O'Neill, George C. and Tierney, Tim M. and Barnes, Gareth R. and Maguire, Eleanor A.},
+	month = feb,
+	year = {2022},
+	pages = {118834}
+}
+
+@article{TierneyEtAl2021,
+	title = {Modelling optically pumped magnetometer interference in MEG as a spatially homogeneous magnetic field},
+	volume = {244},
+	issn = {1053-8119},
+	doi = {10.1016/j.neuroimage.2021.118484},
+	language = {en},
+	journal = {NeuroImage},
+	author = {Tierney, Tim M. and Alexander, Nicholas and Mellor, Stephanie and Holmes, Niall and Seymour, Robert and O'Neill, George C. and Maguire, Eleanor A. and Barnes, Gareth R.},
+	year = {2021},
+}
+
+@article{TierneyEtAl2022,
+	title = {Spherical harmonic based noise rejection and neuronal sampling with multi-axis OPMs},
+	journal = {NeuroImage},
+	volume = {258},
+	year = {2022},
+	issn = {1053-8119},
+	doi = {10.1016/j.neuroimage.2022.119338},
+	author = {Tierney, Tim M. and Mellor, Stephanie nd O'Neill, George C. and Timms, Ryan C. and Barnes, Gareth R.},
+}
+
+@article{KumaravelEtAl2022,
+	doi = {10.3390/s22197314},
+	url = {https://doi.org/10.3390/s22197314},
+	year = {2022},
+	month = sep,
+	publisher = {{MDPI} {AG}},
+	volume = {22},
+	number = {19},
+	pages = {7314},
+	author = {Velu Prabhakar Kumaravel and Marco Buiatti and Eugenio Parise and Elisabetta Farella},
+	title = {Adaptable and Robust {EEG} Bad Channel Detection Using Local Outlier Factor ({LOF})},
+	journal = {Sensors}
+}
+
+@article{BreunigEtAl2000,
+	author = {Breunig, Markus M. and Kriegel, Hans-Peter and Ng, Raymond T. and Sander, J\"{o}rg},
+	title = {LOF: Identifying Density-Based Local Outliers},
+	year = {2000},
+	issue_date = {June 2000},
+	publisher = {Association for Computing Machinery},
+	address = {New York, NY, USA},
+	volume = {29},
+	number = {2},
+	url = {https://doi.org/10.1145/335191.335388},
+	doi = {10.1145/335191.335388},
+	journal = {SIGMOD Rec.},
+	month = {may},
+	pages = {93–104},
+	numpages = {12},
+	keywords = {outlier detection, database mining}
+}
+
+@article{OyamaEtAl2015,
+	title = {Dry phantom for magnetoencephalography —{Configuration}, calibration, and contribution},
+	volume = {251},
+	issn = {0165-0270},
+	doi = {10.1016/j.jneumeth.2015.05.004},
+	journal = {Journal of Neuroscience Methods},
+	author = {Oyama, Daisuke and Adachi, Yoshiaki and Yumoto, Masato and Hashimoto, Isao and Uehara, Gen},
+	month = aug,
+	year = {2015},
+	pages = {24--36},
+}
+
+@InProceedings{MellotEtAl2024,
+	title = {Physics-informed and Unsupervised Riemannian Domain Adaptation for Machine Learning on Heterogeneous EEG Datasets},
+	author = {Mellot, Apolline and Collas, Antoine and Chevallier, Sylvain and Engemann, Denis and Gramfort, Alexandre},
+	booktitle = {Proceedings of the 32nd European Signal Processing Conference (EUSIPCO)},
+	year = {2024},
+	address = {Lyon, France}
+}
+
+@InProceedings{Moshenvand2020,
+  title = 	 {Contrastive Representation Learning for Electroencephalogram Classification},
+  author =       {Mohsenvand, Mostafa Neo and Izadi, Mohammad Rasool and Maes, Pattie},
+  booktitle = 	 {Proceedings of the Machine Learning for Health NeurIPS Workshop},
+  pages = 	 {238--253},
+  year = 	 {2020},
+  series = 	 {Proceedings of Machine Learning Research},
+}

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -22,6 +22,8 @@ Current 1.3 (dev)
 
 Enhancements
 ~~~~~~~~~~~~
+- Adding augmentation :class:`braindecode.augmentation.AmplitudeScale` (:gh:`848` by `Bruna Lopes`_)
+- Adding augmentation :class:`braindecode.augmentation.ChannelsReref` (:gh:`848` by `Bruna Lopes`_)
 - Added Patched Brain Transformer from Klein T et al 2025 at :class:`braindecode.models.PBT` (:gh:`787` by `José Mauricio`_)
 - Including typing in the augmentation module (:gh:`709` by `Aphel`_)
 - Adding :class:`braindecode.models.SSTDPN`  (:gh:`790` by `Can Han`_ and `Bruno Aristimunha`_ )

--- a/test/unit_tests/augmentation/test_functional.py
+++ b/test/unit_tests/augmentation/test_functional.py
@@ -1,13 +1,12 @@
 import pytest
 import torch
-from sklearn.utils import check_random_state
 
 from braindecode.augmentation.functional import (
     _analytic_transform,
+    amplitude_scale,
+    channels_rereference,
     channels_shuffle,
     segmentation_reconstruction,
-    channels_recomb,
-    amplitude_scale
 )
 
 
@@ -111,7 +110,7 @@ def test_amplitude_scale():
     assert torch.equal(transformed_X0, torch.zeros_like(X))
 
 
-def test_channel_recomb():
+def test_channel_reref():
     X0 = torch.zeros((5, 64, 100))  # sanity
     X1 = torch.ones((5, 64, 100))  # sanity
 
@@ -120,10 +119,8 @@ def test_channel_recomb():
     # Random labels for 5 examples
     random_state = 42
 
-    transformed_X0, _ = channels_recomb(X0, y, random_state)
-    transformed_X1, _ = channels_recomb(X1, y, random_state)
+    transformed_X0, _ = channels_rereference(X0, y, random_state)
+    transformed_X1, _ = channels_rereference(X1, y, random_state)
     # Check if the output is the same as the input
     assert torch.equal(transformed_X0, X0)
     assert torch.equal(transformed_X1.sum(dim=(1,2)), -100*torch.ones(5))
-
-


### PR DESCRIPTION
I added two EEG data augmentation techniques (Amplitude Scale and Channel Recombination/Rereferencing from Mohsenvand et al. (2020) [1], originally implemented for another project, but that could be useful to Braindecode.

[1] Mohsenvand, M.N., Izadi, M.R., & Maes, P. (2020). Contrastive Representation Learning for Electroencephalogram Classification. PMLR 136:238–253.