### PR TITLE
[Hotfix] backward compatibility for loading old datasets

### DIFF
--- a/braindecode/datautil/serialization.py
+++ b/braindecode/datautil/serialization.py
@@ -138,7 +138,7 @@ def _load_signals(fif_file, preload, is_raw):
         with open(pkl_file, "rb") as f:
             signals = pickle.load(f)
 
-        if all(f.exists() for f in signals.filenames):
+        if all(Path(f).exists() for f in signals.filenames):
             if preload:
                 signals.load_data()
             return signals


### PR DESCRIPTION
In old datasets, the file paths were saved as `str`, not `pathlib.Path`. 
I got this error:
```
File braindecode/datautil/serialization.py:141, in <genexpr>(.0)
    138 with open(pkl_file, "rb") as f:
    139     signals = pickle.load(f)
--> 141 if all(f.exists() for f in signals.filenames):
    142     if preload:
    143         signals.load_data()

AttributeError: 'str' object has no attribute 'exists'
```

This PR allows loading both old and new

