### PR TITLE
Update eegprep dependency to a specific version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ documentation = "https://braindecode.org/stable/index.html"
 
 [project.optional-dependencies]
 moabb = ["moabb>=1.4.2"]
-eegprep = ["eegprep @ git+https://github.com/sccn/eegprep.git", "eeglabio"]
+eegprep = ["eegprep[eeglabio]>=0.2.23"]
 hub = ["huggingface_hub[torch]>=0.20.0", "zarr>=3.0"]
 tests = [
     'pytest',


### PR DESCRIPTION
Change the eegprep dependency to require a specific version instead of a direct Git reference, ensuring better stability and compatibility.