### PR TITLE
fix: Changed MultiHeadAttention's implementation from a naive one to pytorch's native one

### DIFF
--- a/braindecode/modules/attention.py
+++ b/braindecode/modules/attention.py
@@ -837,8 +837,8 @@ class CATLite(nn.Module):
 class MultiHeadAttention(nn.Module):
     """Multi-head self-attention block.
 
-    Uses ``F.scaled_dot_product_attention`` (PyTorch >= 2.0) for
-    flash-attention / memory-efficient kernels.
+    Uses ``F.scaled_dot_product_attention`` for optimized attention
+    kernels (flash-attention on CUDA, memory-efficient on other devices).
 
     Parameters
     ----------

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -29,7 +29,8 @@ Enhancements
 ============
 
 - Use ``F.scaled_dot_product_attention`` in :class:`braindecode.modules.MultiHeadAttention`,
-  enabling flash-attention and memory-efficient kernels on supported hardware.
+  enabling optimized attention kernels (flash-attention on CUDA,
+  memory-efficient backends on other devices).
   By `Léo Burgund`_ and `Bruno Aristimunha`_.
   (:gh:`902`)
 

--- a/test/unit_tests/models/test_modules.py
+++ b/test/unit_tests/models/test_modules.py
@@ -1264,8 +1264,10 @@ def test_multi_head_attention_forward_shape():
 def test_multi_head_attention_bool_mask():
     from braindecode.modules import MultiHeadAttention
 
+    torch.manual_seed(42)
     mha = MultiHeadAttention(emb_size=16, num_heads=2)
     mha.eval()
+    torch.manual_seed(42)
     x = torch.randn(1, 4, 16)
 
     # Boolean mask: True = ignore. Mask out positions 2 and 3.
@@ -1276,7 +1278,8 @@ def test_multi_head_attention_bool_mask():
     out_no_mask = mha(x)
     assert out_masked.shape == out_no_mask.shape
     # Outputs should differ when mask is applied
-    assert not torch.allclose(out_masked, out_no_mask, atol=1e-5)
+    max_diff = (out_masked - out_no_mask).abs().max().item()
+    assert max_diff > 1e-3, f"Mask had no effect: max_diff={max_diff}"
 
 
 def test_multi_head_attention_invalid_emb_size():


### PR DESCRIPTION
Hello,
This is intended to fix #873 

Two "breaking changes" different from the initial naive implementation:
- The scaling factor becomes `(self.emb_size // self.num_heads) ** (1 / 2)`
- The mask is inverted (the initial implementation used a mask where True meant to keep the value while Pytorch uses True to ignore the value). Braincode doesn't seem to use this mask in other parts of the codebase to I made a direct change without guardrails, I'm not sure how to handle that otherwise.

I made a quick standalone file to compare the difference in output of the two methods (with a fixed scaling factor for the naive method). Caveat: as the weight initialization differ, a manual copy of the initial weights is made between the two methods.

```python
import torch
import torch.nn as nn
import torch.nn.functional as F
from einops.layers.torch import Rearrange


class MultiHeadAttention_new(nn.Module):
    def __init__(self, emb_size, num_heads, dropout=0.0):
        super().__init__()
        self.mha = nn.MultiheadAttention(
            emb_size, num_heads, dropout=dropout, batch_first=True
        )

    def forward(self, x, mask=None):
        return self.mha(x, x, x, attn_mask=mask, need_weights=False)[0]


class MultiHeadAttention_old(nn.Module):
    def __init__(self, emb_size, num_heads, dropout=0):
        super().__init__()
        self.emb_size = emb_size
        self.num_heads = num_heads
        self.keys = nn.Linear(emb_size, emb_size)
        self.queries = nn.Linear(emb_size, emb_size)
        self.values = nn.Linear(emb_size, emb_size)
        self.att_drop = nn.Dropout(dropout)
        self.projection = nn.Linear(emb_size, emb_size)

        self.rearrange_stack = Rearrange(
            "b n (h d) -> b h n d",
            h=num_heads,
        )
        self.rearrange_unstack = Rearrange(
            "b h n d -> b n (h d)",
        )

    def forward(self, x, mask=None):
        queries = self.rearrange_stack(self.queries(x))
        keys = self.rearrange_stack(self.keys(x))
        values = self.rearrange_stack(self.values(x))
        energy = torch.einsum("bhqd, bhkd -> bhqk", queries, keys)
        if mask is not None:
            fill_value = float("-inf")
            energy = energy.masked_fill(~mask, fill_value)

        # scaling = self.emb_size ** (1 / 2)
        scaling = (self.emb_size // self.num_heads) ** (1 / 2)
        att = F.softmax(energy / scaling, dim=-1)
        att = self.att_drop(att)
        out = torch.einsum("bhal, bhlv -> bhav ", att, values)
        out = self.rearrange_unstack(out)
        out = self.projection(out)
        return out


def run_comparison():
    print("--- Comparing Old vs New Attention ---")
    B, L, E, H = 4, 10, 16, 4
    torch.manual_seed(42)

    mha_old = MultiHeadAttention_old(E, H)
    mha_new = MultiHeadAttention_new(E, H)

    # Sync weights
    with torch.no_grad():
        w_q, b_q = mha_old.queries.weight, mha_old.queries.bias
        w_k, b_k = mha_old.keys.weight, mha_old.keys.bias
        w_v, b_v = mha_old.values.weight, mha_old.values.bias
        mha_new.mha.in_proj_weight.copy_(torch.cat([w_q, w_k, w_v], dim=0))
        mha_new.mha.in_proj_bias.copy_(torch.cat([b_q, b_k, b_v], dim=0))
        mha_new.mha.out_proj.weight.copy_(mha_old.projection.weight)
        mha_new.mha.out_proj.bias.copy_(mha_old.projection.bias)

    x = torch.randn(B, L, E)
    x_old = x.clone().detach().requires_grad_(True)
    x_new = x.clone().detach().requires_grad_(True)

    # Test 1: Forward (No Mask)
    out_old = mha_old(x_old)
    out_new = mha_new(x_new)
    diff = (out_old - out_new).abs()
    print(
        f"Forward Diff (No Mask): Max: {diff.max().item():.2e} | Mean: {diff.mean().item():.2e}"
    )

    # Test 2: Backward (No Mask)
    target = torch.randn_like(out_old)
    F.mse_loss(out_old, target).backward()
    F.mse_loss(out_new, target).backward()
    assert x_old.grad is not None and x_new.grad is not None
    diff_grad = (x_old.grad - x_new.grad).abs()
    print(
        f"Grad Diff (No Mask):    Max: {diff_grad.max().item():.2e} | Mean: {diff_grad.mean().item():.2e}"
    )

    # Test 3: Forward (With Mask - Raw / Wrong Convention)
    mask = torch.ones(L, L, dtype=torch.bool)
    mask[:, -3:] = False  # Mask last 3 positions
    out_old_masked = mha_old(x_old, mask=mask)

    # This demonstrates that Old uses True=Keep while New uses True=Ignore
    out_new_raw_mask = mha_new(x_new, mask=mask)
    diff_raw = (out_old_masked - out_new_raw_mask).abs()
    print(
        f"Forward Diff (Masked, Raw):      Max: {diff_raw.max().item():.2e} | Mean: {diff_raw.mean().item():.2e} (High diff confirms mask convention mismatch)"
    )

    # Test 4: Forward (With Mask - Inverted / Correct Convention)
    # Old: True=Keep, New: True=Ignore (so we pass ~mask)
    out_new_masked = mha_new(x_new, mask=~mask)
    diff_masked = (out_old_masked - out_new_masked).abs()
    print(
        f"Forward Diff (Masked, Inverted): Max: {diff_masked.max().item():.2e} | Mean: {diff_masked.mean().item():.2e}"
    )


if __name__ == "__main__":
    run_comparison()
```

Output
```
--- Comparing Old vs New Attention ---
Forward Diff (No Mask): Max: 8.94e-08 | Mean: 1.94e-08
Grad Diff (No Mask):    Max: 4.37e-10 | Mean: 7.25e-11
Forward Diff (Masked, Raw):      Max: 4.84e-01 | Mean: 1.63e-01 (High diff confirms mask convention mismatch)
Forward Diff (Masked, Inverted): Max: 8.94e-08 | Mean: 1.96e-08
```