### PR TITLE
fix squeeze and excitation channel reduction

### DIFF
--- a/braindecode/modules/attention.py
+++ b/braindecode/modules/attention.py
@@ -8,6 +8,7 @@ AttentionBaseNet class.
 
 # Authors: Martin Wimpff <martin.wimpff@iss.uni-stuttgart.de>
 #          Bruno Aristimunha <b.aristimunha@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -60,7 +61,7 @@ class SqueezeAndExcitation(nn.Module):
         )
         self.nonlinearity = nn.ReLU()
         self.fc2 = nn.Conv2d(
-            in_channels=reduction_rate,
+            in_channels=sq_channels,
             out_channels=in_channels,
             kernel_size=1,
             bias=bias,

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -82,6 +82,9 @@ Bugs
 - Fix Zenodo citation: update to global concept DOI and add BibTeX/APA citation formats
   in ``docs/cite.rst``, ``README.rst``, ``CITATION.cff``, and ``docs/conf.py``
   (:gh:`937` by `Bruno Aristimunha`_)
+- Fix channel reduction in :class:`braindecode.modules.SqueezeAndExcitation` to avoid
+  runtime shape mismatches when the reduced channel count differs from the reduction rate
+  (:gh:`889` by `Sarthak Tayal`_)
 - Push large datasets to HuggingFace Hub using :func:`huggingface_hub.upload_large_folder` to avoid limitations, and allow resuming downloads (:gh:`945` and :gh:`953` by `Pierre Guetschel`_)
 
 Code health

--- a/test/unit_tests/models/test_modules.py
+++ b/test/unit_tests/models/test_modules.py
@@ -1,4 +1,5 @@
 # Authors: Hubert Banville <hubert.jbanville@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 from warnings import catch_warnings, simplefilter
@@ -29,6 +30,7 @@ from braindecode.modules import (
     LinearWithConstraint,
     MaxNormLinear,
     SafeLog,
+    SqueezeAndExcitation,
     TimeDistributed,
 )
 
@@ -226,6 +228,16 @@ def test_mlp_increase(hidden_features):
         # For each layer that we add, the model
         # increase with 2 layers + 2 initial layers (input, output layer)
         assert len(model) == 2 * (len(hidden_features)) + 2
+
+
+def test_squeeze_and_excitation_forward():
+    module = SqueezeAndExcitation(in_channels=32, reduction_rate=4)
+    inputs = torch.rand(2, 32, 1, 64)
+
+    outputs = module(inputs)
+
+    assert module.fc1.out_channels == module.fc2.in_channels
+    assert outputs.shape == inputs.shape
 
 
 def test_segm_patch_not_learning():


### PR DESCRIPTION
fix channel reduction in squeezandexcitation to avoid shape mismatches

fixes issue #889

the squeezandexcitation module had a bug in its fc2 layer initialization. it was using reduction_rate as the in_channels parameter instead of sq_channels, which caused a shape mismatch at runtime.

specifically:
- fc1 outputs sq_channels (e.g., 8 when in_channels=32 and reduction_rate=4)
- fc2 was incorrectly expecting in_channels=reduction_rate (e.g., 4)
- this mismatch would cause a runtime error when data passed through fc2

the fix updates attention.py to use sq_channels for fc2's in_channels, ensuring the channel dimensions match through the module.

changes:
- attention.py: line 63 changed in_channels from reduction_rate to sq_channels
- test_modules.py: added test_squeeze_and_excitation_forward to verify correct channel flow
- whats_new.rst: documented the fix in the bugs section
