### PR TITLE
handle missing numpydantic in config without crashing on import

### DIFF
--- a/braindecode/models/config.py
+++ b/braindecode/models/config.py
@@ -1,3 +1,4 @@
+# Authors: Sarthak Tayal <sarthaktayal2@gmail.com>
 from collections.abc import Callable
 from inspect import signature
 from types import UnionType
@@ -17,10 +18,10 @@ from braindecode.models.util import (
 
 try:
     from numpydantic import NDArray, Shape
+
+    _loc_type = NDArray[Shape["12"], np.float64]
 except ImportError:
-    # we can't use soft import for numpydantic because numpydantic does not define its version in __init__
-    NDArray = Any  # type: ignore
-    Shape = Any  # type: ignore
+    _loc_type = np.ndarray  # type: ignore[misc]
 
 
 class ChsInfoType(TypedDict, total=False, closed=True):  # type: ignore[call-arg]
@@ -29,7 +30,7 @@ class ChsInfoType(TypedDict, total=False, closed=True):  # type: ignore[call-arg
     coil_type: int
     coord_frame: int
     kind: str
-    loc: NDArray[Shape["12"], np.float64]  # type: ignore[misc]
+    loc: _loc_type  # type: ignore[misc]
     logno: int
     range: float
     scanno: int

--- a/braindecode/models/config.py
+++ b/braindecode/models/config.py
@@ -30,7 +30,7 @@ class ChsInfoType(TypedDict, total=False, closed=True):  # type: ignore[call-arg
     coil_type: int
     coord_frame: int
     kind: str
-    loc: _loc_type  # type: ignore[misc]
+    loc: _loc_type  # type: ignore[valid-type,misc]
     logno: int
     range: float
     scanno: int

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -72,6 +72,9 @@ Bug fixes
 - Register :class:`braindecode.models.BIOT` encoder ``index`` as a non-trainable
   buffer instead of a parameter (``torch.long``), so it is treated as module
   state rather than trainable weights (:gh:`988` by `Pierre Guetschel`_)
+- Fix ``TypeError: type 'Any' is not subscriptable`` when importing
+  ``braindecode.models.config`` without ``numpydantic`` installed on
+  Python 3.12+ (:gh:`871` by `Sarthak Tayal`_)
 
 Code health
 ============

--- a/test/unit_tests/models/test_config_numpydantic_fallback.py
+++ b/test/unit_tests/models/test_config_numpydantic_fallback.py
@@ -1,0 +1,27 @@
+# Authors: Sarthak Tayal <sarthaktayal2@gmail.com>
+import importlib
+import sys
+import unittest.mock
+
+import pytest
+from mne.utils import _soft_import
+
+pydantic = _soft_import(name="pydantic", purpose="model config testing", strict=False)
+
+if pydantic is False:
+    pytest.skip("pydantic not installed, skipping", allow_module_level=True)
+
+
+def test_config_import_without_numpydantic():
+    # config module should load fine when numpydantic is missing
+    saved = sys.modules.pop("numpydantic", None)
+    try:
+        with unittest.mock.patch.dict(sys.modules, {"numpydantic": None}):
+            import braindecode.models.config as cfg_mod
+
+            importlib.reload(cfg_mod)
+            assert hasattr(cfg_mod, "ChsInfoType")
+            assert "loc" in cfg_mod.ChsInfoType.__annotations__
+    finally:
+        if saved is not None:
+            sys.modules["numpydantic"] = saved


### PR DESCRIPTION
when numpydantic is not installed, importing braindecode.models.config crashes with TypeError because the fallback sets NDArray and Shape to typing.Any, which is not subscriptable on python 3.12+ in certain builds and python 3.14.

the fix precomputes the loc type annotation inside the try/except block. if numpydantic is available it uses the precise NDArray type, otherwise it falls back to np.ndarray. this avoids subscripting Any at annotation evaluation time.

closes #871 