### PR TITLE
pick channels before average reference in tuh example

### DIFF
--- a/examples/applied_examples/plot_tuh_eeg_corpus.py
+++ b/examples/applied_examples/plot_tuh_eeg_corpus.py
@@ -282,7 +282,7 @@ preprocessors = [
     Preprocessor(
         custom_crop, tmin=tmin, tmax=tmax, include_tmax=False, apply_on_array=False
     ),
-    # pick first so car ref does not pull in artifacts from dropped chans
+    # pick first so the average reference does not pull in artifacts from dropped channels
     Preprocessor("pick_channels", ch_names=short_ch_names, ordered=True),
     Preprocessor("set_eeg_reference", ref_channels="average", ch_type="eeg"),
     Preprocessor(

--- a/examples/applied_examples/plot_tuh_eeg_corpus.py
+++ b/examples/applied_examples/plot_tuh_eeg_corpus.py
@@ -14,7 +14,8 @@ including simple preprocessing steps as well as cutting of compute windows.
 
 """
 
-# Author: Lukas Gemein <l.gemein@gmail.com>
+# Authors: Lukas Gemein <l.gemein@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -257,8 +258,8 @@ tuh = select_by_channels(tuh, short_ch_names)
 # steps that are executed through 'mne':
 #
 # - Crop the recordings to a region of interest
-# - Re-reference all recordings to 'ar' (requires load)
 # - Pick channels of interest
+# - Re-reference all recordings to 'ar' (requires load)
 # - Scale signals to micro volts (requires load)
 # - Clip outlier values to +/- 800 micro volts (requires load)
 # - Resample recordings to a common frequency (requires load)
@@ -281,8 +282,9 @@ preprocessors = [
     Preprocessor(
         custom_crop, tmin=tmin, tmax=tmax, include_tmax=False, apply_on_array=False
     ),
-    Preprocessor("set_eeg_reference", ref_channels="average", ch_type="eeg"),
+    # pick first so car ref does not pull in artifacts from dropped chans
     Preprocessor("pick_channels", ch_names=short_ch_names, ordered=True),
+    Preprocessor("set_eeg_reference", ref_channels="average", ch_type="eeg"),
     Preprocessor(
         lambda data: multiply(data, factor), apply_on_array=True
     ),  # Convert from V to uV

--- a/examples/applied_examples/plot_tuh_eeg_corpus.py
+++ b/examples/applied_examples/plot_tuh_eeg_corpus.py
@@ -259,7 +259,7 @@ tuh = select_by_channels(tuh, short_ch_names)
 #
 # - Crop the recordings to a region of interest
 # - Pick channels of interest
-# - Re-reference all recordings to 'ar' (requires load)
+# - Re-reference all recordings to average reference (CAR) (requires load)
 # - Scale signals to micro volts (requires load)
 # - Clip outlier values to +/- 800 micro volts (requires load)
 # - Resample recordings to a common frequency (requires load)


### PR DESCRIPTION
closes #329 

fix for the tuh example preprocessing order. right now set_eeg_reference with average runs before pick_channels, so the car reference is computed across every channel in the recording, including ones that get dropped a step later. any artifact on a dropped chan still leaks into the chans you keep through the subtracted mean.

swapped the order so pick_channels runs first, then the car reference is computed only on the chans we actually want. also flipped the matching bullet list in the markdown cell description to match the new order.

no api change, no behavior change anywhere else, just the example.