### PR TITLE
Pin openneuro-py<2026.4 to fix docs build crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ docs = [
     'lightning',
     'seaborn',
     'pre-commit',
-    'openneuro-py',
+    'openneuro-py<2026.4',  # 2026.4.x crashes (libc double-free) during concurrent HEAD requests in docs CI
     'plotly',
     'shap',
     'nbformat',


### PR DESCRIPTION
## Summary
- Pin `openneuro-py<2026.4` in the `docs` extra of `pyproject.toml` to roll back to the last stable `2026.3.1` line.

## Why
The `docs` workflow on master is failing in `build_docs → Create Docs` while sphinx-gallery renders `examples/datasets_io/plot_bids_dataset_example.py`. The example calls `openneuro.download("ds004745", …)`, and the freshly-released `openneuro-py 2026.4.1` aborts mid-download with a libc memory error:

```
double free or corruption (fasttop)
Aborted (core dumped)
make: *** [Makefile:41: html] Error 134
```

The crash happens during a burst of concurrent `httpx` HEAD requests, matching two upstream changes shipped in the 2026.4.x line:
- hoechenberger/openneuro-py#314 — Migrate GraphQL queries from `requests` to `httpx`
- hoechenberger/openneuro-py#316 — Allow more concurrent HEAD requests

Failing run for reference: https://github.com/braindecode/braindecode/actions/runs/25004800112

## Test plan
- [ ] `docs` workflow on this PR completes successfully (validates the pin restores a working `openneuro-py`).
- [ ] Confirm `plot_bids_dataset_example.py` finishes downloading `ds004745` and renders.