### PR TITLE
Pin openneuro-py>=2026.4.0 to fix docs build

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -141,6 +141,12 @@ Bug fixes
   embedding weights when fine-tuning on a subset of the pre-training channels.
   Two new HuggingFace checkpoints are published: ``braindecode/signal-jepa`` and
   ``braindecode/signal-jepa_without-chans`` (:gh:`991` by `Pierre Guetschel`_)
+- Bump ``openneuro-py`` to ``>=2026.4.0`` so the docs build picks up upstream
+  PR ``#308`` (``DatasetFile.key`` → ``id``). The previous ``<2026.4`` pin
+  (:gh:`1000`) avoided a libc double-free seen with newer releases but broke
+  ``examples/datasets_io/plot_bids_dataset_example.py`` against the live
+  OpenNeuro 5.0.0 GraphQL schema (``Cannot query field "key" on type
+  "DatasetFile"``) (:gh:`1002` by `Bruno Aristimunha`_)
 
 Code health
 ============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ docs = [
     'lightning',
     'seaborn',
     'pre-commit',
-    'openneuro-py==2026.4.0',  # 2026.4.0 brings the DatasetFile.key->id GraphQL fix; 2026.4.1 raises HEAD concurrency 5->50 which has been linked to a libc double-free in docs CI
+    'openneuro-py>=2026.4.0',  # 2026.4.0 fixes DatasetFile.key->id after the OpenNeuro 5.0.0 schema change; older versions break against the live GraphQL server
     'plotly',
     'shap',
     'nbformat',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ docs = [
     'lightning',
     'seaborn',
     'pre-commit',
-    'openneuro-py<2026.4',  # 2026.4.x crashes (libc double-free) during concurrent HEAD requests in docs CI
+    'openneuro-py==2026.4.0',  # 2026.4.0 brings the DatasetFile.key->id GraphQL fix; 2026.4.1 raises HEAD concurrency 5->50 which has been linked to a libc double-free in docs CI
     'plotly',
     'shap',
     'nbformat',


### PR DESCRIPTION
## Summary

- The previous pin (`openneuro-py<2026.4`, #1000) avoids the libc double-free seen in 2026.4.x but reintroduces a different docs failure: older openneuro-py versions still send GraphQL queries referencing `DatasetFile.key`, a field OpenNeuro 5.0.0 removed.
- Latest master docs run fails with: `RuntimeError: Query failed when retrieving metadata for dataset: \"Cannot query field \"key\" on type \"DatasetFile\".\"` while rendering `examples/datasets_io/plot_bids_dataset_example.py`.
- openneuro-py 2026.4.0 (PR openneuro-py#308) rewrites the affected queries to use `id`, fixing the schema error.
- This PR sets `openneuro-py>=2026.4.0`. The libc double-free that motivated freezing has not been reported upstream; locking to a specific version would block future fixes (e.g. openneuro-py#317, share a single AsyncClient). If the crash recurs, we can drop back to `==2026.4.0`.

## Test plan

- [ ] Docs CI builds successfully against this branch
- [ ] `examples/datasets_io/plot_bids_dataset_example.py` renders without GraphQL errors