### PR TITLE
raise clearer error when joblib memmaps preloaded data in preprocess

### DIFF
--- a/braindecode/preprocessing/preprocess.py
+++ b/braindecode/preprocessing/preprocess.py
@@ -6,6 +6,7 @@
 #          David Sabbagh <dav.sabbagh@gmail.com>
 #          Bruno Aristimunha <b.aristimunha@gmail.com>
 #          Léo Burgund <leo.burgund@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -217,6 +218,7 @@ def preprocess(
     offset: int = 0,
     copy_data: bool | None = None,
     parallel_kwargs: dict | None = None,
+    max_nbytes: int | str | None = "1M",
 ):
     """Apply preprocessors to a concat dataset.
 
@@ -244,14 +246,22 @@ def preprocess(
         Additional keyword arguments forwarded to ``joblib.Parallel``.
         Defaults to None (equivalent to ``{}``).
         See https://joblib.readthedocs.io/en/stable/generated/joblib.Parallel.html for details.
+    max_nbytes : int, str, or None
+        Forwarded to ``joblib.Parallel`` to control the size threshold above
+        which preloaded arrays are memory mapped to disk as read-only. Pass
+        ``None`` to disable memory mapping when a preprocessor resizes the
+        underlying data (for example ``filterbank``), which would otherwise
+        fail with an ``mmap can't resize a readonly`` error. When the
+        preprocessing run hits that error, ``preprocess`` automatically
+        retries once with memory mapping disabled to avoid wasting the work
+        already done. ``parallel_kwargs['max_nbytes']`` takes precedence if
+        both are provided.
 
     Returns
     -------
     BaseConcatDataset
         Preprocessed dataset.
     """
-    # In case of serialization, make sure directory is available before
-    # preprocessing
     if save_dir is not None and not overwrite:
         _check_save_dir_empty(save_dir)
 
@@ -266,22 +276,49 @@ def preprocess(
     parallel_params.setdefault(
         "prefer", "threads" if platform.system() == "Windows" else None
     )
+    parallel_params.setdefault("max_nbytes", max_nbytes)
 
-    list_of_ds = Parallel(n_jobs=n_jobs, **parallel_params)(
-        delayed(_preprocess)(
-            ds,
-            i + offset,
-            preprocessors,
-            save_dir,
-            overwrite,
-            copy_data=(
-                (parallel_processing and (save_dir is None))
-                if copy_data is None
-                else copy_data
-            ),
+    def _run(params):
+        return Parallel(n_jobs=n_jobs, **params)(
+            delayed(_preprocess)(
+                ds,
+                i + offset,
+                preprocessors,
+                save_dir,
+                overwrite,
+                copy_data=(
+                    (parallel_processing and (save_dir is None))
+                    if copy_data is None
+                    else copy_data
+                ),
+            )
+            for i, ds in enumerate(concat_ds.datasets)
         )
-        for i, ds in enumerate(concat_ds.datasets)
-    )
+
+    try:
+        list_of_ds = _run(parallel_params)
+    except Exception as exc:
+        msg = str(exc)
+        mmap_failure = "mmap" in msg and ("readonly" in msg or "read-only" in msg)
+        if not mmap_failure:
+            raise
+        if parallel_params.get("max_nbytes") is None:
+            raise RuntimeError(
+                "Parallel preprocessing failed because joblib memory mapped "
+                "a preloaded array that a preprocessor then attempted to "
+                "resize, even with memory mapping disabled. Supply a "
+                "``save_dir`` so that the data is reloaded with "
+                "``preload=False``."
+            ) from exc
+        warn(
+            "Parallel preprocessing failed because joblib memory mapped a "
+            "preloaded array that a preprocessor then attempted to resize. "
+            "Retrying with memory mapping disabled (max_nbytes=None). To "
+            "skip this retry on future calls, pass ``max_nbytes=None`` to "
+            "``preprocess`` or supply a ``save_dir``."
+        )
+        parallel_params["max_nbytes"] = None
+        list_of_ds = _run(parallel_params)
 
     if save_dir is not None:  # Reload datasets and replace in concat_ds
         ids_to_load = [i + offset for i in range(len(concat_ds.datasets))]

--- a/braindecode/preprocessing/preprocess.py
+++ b/braindecode/preprocessing/preprocess.py
@@ -247,15 +247,13 @@ def preprocess(
         Defaults to None (equivalent to ``{}``).
         See https://joblib.readthedocs.io/en/stable/generated/joblib.Parallel.html for details.
     max_nbytes : int, str, or None
-        Forwarded to ``joblib.Parallel`` to control the size threshold above
-        which preloaded arrays are memory mapped to disk as read-only. Pass
-        ``None`` to disable memory mapping when a preprocessor resizes the
-        underlying data (for example ``filterbank``), which would otherwise
-        fail with an ``mmap can't resize a readonly`` error. When the
-        preprocessing run hits that error, ``preprocess`` automatically
-        retries once with memory mapping disabled to avoid wasting the work
-        already done. ``parallel_kwargs['max_nbytes']`` takes precedence if
-        both are provided.
+        Threshold (in bytes; or e.g. ``"1M"``) above which joblib memory-maps
+        preloaded arrays as read-only when dispatching to worker processes.
+        Effective only when ``n_jobs != 1``. Pass ``None`` to disable memory
+        mapping when a preprocessor resizes the underlying data (for example
+        ``filterbank``), which would otherwise fail with an ``mmap can't
+        resize a readonly`` error. ``parallel_kwargs['max_nbytes']`` takes
+        precedence if both are provided.
 
     Returns
     -------
@@ -278,8 +276,8 @@ def preprocess(
     )
     parallel_params.setdefault("max_nbytes", max_nbytes)
 
-    def _run(params):
-        return Parallel(n_jobs=n_jobs, **params)(
+    try:
+        list_of_ds = Parallel(n_jobs=n_jobs, **parallel_params)(
             delayed(_preprocess)(
                 ds,
                 i + offset,
@@ -294,31 +292,17 @@ def preprocess(
             )
             for i, ds in enumerate(concat_ds.datasets)
         )
-
-    try:
-        list_of_ds = _run(parallel_params)
-    except Exception as exc:
-        msg = str(exc)
-        mmap_failure = "mmap" in msg and ("readonly" in msg or "read-only" in msg)
-        if not mmap_failure:
-            raise
-        if parallel_params.get("max_nbytes") is None:
+    except (BufferError, ValueError, OSError) as exc:
+        msg = str(exc).lower().replace("-", "")
+        if "mmap" in msg and "readonly" in msg:
             raise RuntimeError(
-                "Parallel preprocessing failed because joblib memory mapped "
+                "Parallel preprocessing failed because joblib memory-mapped "
                 "a preloaded array that a preprocessor then attempted to "
-                "resize, even with memory mapping disabled. Supply a "
-                "``save_dir`` so that the data is reloaded with "
-                "``preload=False``."
+                "resize (e.g. ``filterbank``). Pass ``max_nbytes=None`` to "
+                "``preprocess`` to disable memory mapping, or supply a "
+                "``save_dir`` so the data is reloaded with ``preload=False``."
             ) from exc
-        warn(
-            "Parallel preprocessing failed because joblib memory mapped a "
-            "preloaded array that a preprocessor then attempted to resize. "
-            "Retrying with memory mapping disabled (max_nbytes=None). To "
-            "skip this retry on future calls, pass ``max_nbytes=None`` to "
-            "``preprocess`` or supply a ``save_dir``."
-        )
-        parallel_params["max_nbytes"] = None
-        list_of_ds = _run(parallel_params)
+        raise
 
     if save_dir is not None:  # Reload datasets and replace in concat_ds
         ids_to_load = [i + offset for i in range(len(concat_ds.datasets))]

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -324,6 +324,15 @@ Bugs
   marked all model-specific parameters as "The description is missing"
   when ``DOCSTRING_INHERITANCE_ENABLE=1`` was set during documentation
   builds (:gh:`971` by `Bruno Aristimunha`_)
+- Expose ``max_nbytes`` directly on
+  :func:`braindecode.preprocessing.preprocess.preprocess` and recover from
+  the ``mmap can't resize a readonly`` failure raised when joblib memory
+  maps a preloaded array that a preprocessor later tries to resize.
+  ``preprocess`` now warns and automatically retries the run once with
+  memory mapping disabled so that the preprocessing work already done is
+  not thrown away. Users can opt out of the retry by passing
+  ``max_nbytes=None`` up front or supplying a ``save_dir``
+  (:gh:`325` by `Sarthak Tayal`_)
 
 Code health
 ============

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -325,13 +325,12 @@ Bugs
   when ``DOCSTRING_INHERITANCE_ENABLE=1`` was set during documentation
   builds (:gh:`971` by `Bruno Aristimunha`_)
 - Expose ``max_nbytes`` directly on
-  :func:`braindecode.preprocessing.preprocess.preprocess` and recover from
-  the ``mmap can't resize a readonly`` failure raised when joblib memory
-  maps a preloaded array that a preprocessor later tries to resize.
-  ``preprocess`` now warns and automatically retries the run once with
-  memory mapping disabled so that the preprocessing work already done is
-  not thrown away. Users can opt out of the retry by passing
-  ``max_nbytes=None`` up front or supplying a ``save_dir``
+  :func:`braindecode.preprocessing.preprocess.preprocess` and turn the
+  cryptic ``mmap can't resize a readonly`` failure (raised when joblib
+  memory-maps a preloaded array that a preprocessor later tries to
+  resize) into an actionable error explaining how to fix it: pass
+  ``max_nbytes=None`` to disable memory mapping, or supply a ``save_dir``
+  so data is reloaded with ``preload=False``
   (:gh:`325` by `Sarthak Tayal`_)
 
 Code health

--- a/test/unit_tests/preprocessing/test_mne_preprocessor.py
+++ b/test/unit_tests/preprocessing/test_mne_preprocessor.py
@@ -579,3 +579,53 @@ def test_preprocessing_function_on_raw(base_concat_ds, prep_class_name, init_kwa
         preprocess(base_concat_ds, [preprocessor], n_jobs=1)
     except Exception as e:
         pytest.fail(f"{prep_class_name} failed with {type(e).__name__}: {str(e)}")
+
+
+def test_preprocess_raises_actionable_error_on_mmap_resize_failure(
+    base_concat_ds, monkeypatch
+):
+    """The mmap-readonly failure is converted into an actionable RuntimeError."""
+    import importlib
+
+    preprocess_module = importlib.import_module(
+        "braindecode.preprocessing.preprocess"
+    )
+    n_calls = {"count": 0}
+
+    class FailingParallel:
+        def __init__(self, *args, **kwargs):
+            n_calls["count"] += 1
+
+        def __call__(self, iterable):
+            raise BufferError("mmap can't resize a readonly memory map.")
+
+    monkeypatch.setattr(preprocess_module, "Parallel", FailingParallel)
+
+    preprocessors = [Crop(tmax=10, include_tmax=False)]
+    with pytest.raises(RuntimeError, match=r"max_nbytes=None.*save_dir") as excinfo:
+        preprocess(base_concat_ds, preprocessors, n_jobs=2)
+
+    assert n_calls["count"] == 1, "preprocess must not retry; it should raise once"
+    assert isinstance(excinfo.value.__cause__, BufferError)
+
+
+def test_preprocess_propagates_unrelated_buffer_error(base_concat_ds, monkeypatch):
+    """A BufferError that is not an mmap-resize failure must propagate unchanged."""
+    import importlib
+
+    preprocess_module = importlib.import_module(
+        "braindecode.preprocessing.preprocess"
+    )
+
+    class FailingWithUnrelatedError:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def __call__(self, iterable):
+            raise BufferError("some unrelated buffer error")
+
+    monkeypatch.setattr(preprocess_module, "Parallel", FailingWithUnrelatedError)
+
+    preprocessors = [Crop(tmax=10, include_tmax=False)]
+    with pytest.raises(BufferError, match="unrelated"):
+        preprocess(base_concat_ds, preprocessors, n_jobs=2)


### PR DESCRIPTION
closes #325 

Quick fix on top of the parallel preprocess pipeline! If a dataset is preloaded and bigger than joblib's default max_nbytes, joblib silently memmaps it as readonly. Then any preprocessor that resizes the array, like filterbank calling raw.add_channels, blows up with:

  TypeError: mmap can't resize a readonly or copy-on-write memory map

That traceback points at mne internals, **not at the actual cause**, and the user has no idea what to do. This issue has been open since 2021, & I saw maintainers already agreed on the approach in the thread, just nobody fully went thru with it.

Wrap the Parallel call in preprocess() with a try, detect the mmap readonly error by string match, re raise a RuntimeError that chains the original and tells the user how to unstuck themselves:

- pass parallel_kwargs={'max_nbytes': None} to disable joblib memmap, or
- pass a save_dir to reload with preload=False.
