### PR TITLE
[ENH] EMG2QwertyNet: built-in SpecAugment + feature-extraction flags

### DIFF
--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -568,11 +568,18 @@ class _SpecAugment(nn.Module):
     r"""SpecAugment masking on the log-spectrogram during training.
 
     Applies up to ``n_time_masks`` × ``time_mask_param``-frame time bands
-    and ``n_freq_masks`` × ``freq_mask_param``-bin frequency bands, IID
-    per ``(sample × band)`` and shared across the electrodes within a band
-    — per-electrode masking is :math:`\\sim 32\\times` more aggressive and
-    collapses CTC. No-op outside training. Defaults match Sivakumar et al.
-    Sec 5.2 (3×25 / 2×4 frames-bins, ``prob=1.0``).
+    and ``n_freq_masks`` × ``freq_mask_param``-bin frequency bands, with
+    one mask drawn per ``(sample × band)`` row and broadcast across all
+    electrodes within that band — so a wristband's 16 electrodes share
+    the same masked window. No-op outside ``training``. Defaults match
+    Sivakumar et al. Sec 5.2 (3×25 / 2×4 frames-bins, ``prob=1.0``).
+
+    Implemented as pure tensor ops (per-row vectorised start / width
+    sampling, on-device mean fill, ``masked_fill`` broadcast) so the
+    forward pass keeps no host round-trips on GPU. ``torchaudio``'s
+    ``TimeMasking(iid_masks=True)`` cannot be reused here because, on a
+    ``(B*num_bands, electrodes, freq, T)`` tensor, it samples one mask
+    per ``(batch, electrode)`` pair instead of per ``(sample × band)``.
     """
 
     def __init__(
@@ -602,11 +609,36 @@ class _SpecAugment(nn.Module):
         self.n_freq_masks = n_freq_masks
         self.freq_mask_param = freq_mask_param
         self.prob = prob
-        # ``iid_masks=True`` so every (sample × band) row gets its own mask;
-        # without it, the same time window is masked across all bands and the
-        # CTC head collapses to all-blank during warmup.
-        self.time_mask = ta_transforms.TimeMasking(time_mask_param, iid_masks=True)
-        self.freq_mask = ta_transforms.FrequencyMasking(freq_mask_param, iid_masks=True)
+
+    @staticmethod
+    def _band_shared_axis_mask(
+        n_rows: int,
+        axis_len: int,
+        max_mask_param: int,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """One mask per row, shared across the orthogonal axes.
+
+        Returns a ``(n_rows, axis_len)`` boolean tensor where row ``i``
+        marks a contiguous span ``[start_i, start_i + width_i)`` to be
+        masked. ``width_i`` is sampled in ``[0, min(max_mask_param,
+        axis_len)]``; ``start_i`` in ``[0, axis_len - width_i]``. Both
+        draws stay on-device.
+        """
+        effective = min(max_mask_param, axis_len)
+        if effective <= 0 or n_rows <= 0:
+            return torch.zeros(n_rows, axis_len, dtype=torch.bool, device=device)
+        widths = torch.randint(0, effective + 1, (n_rows,), device=device)
+        # Float-then-cast keeps integer precision under fp16/bf16 — same trick
+        # ``_MaskAug`` uses in ``meta_neuromotor``.
+        max_starts = (axis_len - widths).to(torch.float32)
+        starts = (
+            torch.rand(n_rows, device=device, dtype=torch.float32) * max_starts
+        ).to(torch.long)
+        positions = torch.arange(axis_len, device=device)
+        return (positions[None, :] >= starts[:, None]) & (
+            positions[None, :] < (starts + widths)[:, None]
+        )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # ``x``: (T_spec, B, num_bands, electrodes, freq).
@@ -619,20 +651,30 @@ class _SpecAugment(nn.Module):
         if self.prob < 1.0 and torch.rand((), device="cpu").item() >= self.prob:
             return x
         n_frames, batch_size, n_bands, n_electrodes, n_freq_bins = x.shape
-        # Reshape to ``(B*num_bands, electrodes, freq, T_spec)`` so iid_masks
-        # draws one mask per (sample × band) shared across electrodes.
-        flat = x.movedim(0, -1).reshape(
-            batch_size * n_bands, n_electrodes, n_freq_bins, n_frames
-        )
-        # Mask to per-window mean: in log-spec space 0 = log(power=1), well
-        # above the typical distribution and would inject artificial spikes.
-        mask_value = float(flat.mean().item())
+        n_rows = batch_size * n_bands
+        # Reshape to ``(B*num_bands, electrodes, freq, T_spec)`` so a mask of
+        # shape ``(n_rows, ..., L)`` broadcasts across the electrode axis —
+        # the missing dim is 1, so every electrode in a band sees the same
+        # masked window.
+        flat = x.movedim(0, -1).reshape(n_rows, n_electrodes, n_freq_bins, n_frames)
+        # 0-D on-device fill value; in log-spec space the natural zero is
+        # ``log(power=1)`` which sits well above the typical distribution and
+        # would inject artificial spikes. Mean over all elements matches the
+        # original neuralbench callback behaviour but stays on-device (no
+        # ``.item()`` host sync per forward).
+        mask_value = flat.mean()
         n_t = int(torch.randint(self.n_time_masks + 1, ()).item())
         for _ in range(n_t):
-            flat = self.time_mask(flat, mask_value=mask_value)
+            time_mask = self._band_shared_axis_mask(
+                n_rows, n_frames, self.time_mask_param, flat.device
+            )
+            flat = flat.masked_fill(time_mask[:, None, None, :], mask_value)
         n_f = int(torch.randint(self.n_freq_masks + 1, ()).item())
         for _ in range(n_f):
-            flat = self.freq_mask(flat, mask_value=mask_value)
+            freq_mask = self._band_shared_axis_mask(
+                n_rows, n_freq_bins, self.freq_mask_param, flat.device
+            )
+            flat = flat.masked_fill(freq_mask[:, None, :, None], mask_value)
         return flat.reshape(
             batch_size, n_bands, n_electrodes, n_freq_bins, n_frames
         ).movedim(-1, 0)

--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -426,18 +426,21 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
         spectrogram = self.spectrogram(x)
         spectrogram = self.spec_augment(spectrogram)
         encoded = self.model(spectrogram)
-        # ``encoded`` is (T_out, B, num_features). Transpose to (B, T_out,
-        # num_features) so feature consumers (and neuroai's downstream
-        # wrappers) see the same batch-first layout as the emissions tensor.
-        features = encoded.transpose(0, 1).contiguous()
+        # ``encoded`` is (T_out, B, num_features); only materialise the
+        # batch-first features tensor in the branches that actually return
+        # it, so the default emissions-only path skips the extra transpose
+        # + contiguous copy on every forward.
         if return_features:
-            return {"features": features, "cls_token": None}
+            return {
+                "features": encoded.transpose(0, 1).contiguous(),
+                "cls_token": None,
+            }
         emissions = self.final_layer(encoded)
         if self.log_softmax:
             emissions = F.log_softmax(emissions, dim=-1)
         emissions = emissions.transpose(0, 1).contiguous()
         if self.return_feature:
-            return emissions, features
+            return emissions, encoded.transpose(0, 1).contiguous()
         return emissions
 
     def reset_head(self, n_outputs: int) -> None:
@@ -654,7 +657,13 @@ class _SpecAugment(nn.Module):
             or (self.n_time_masks == 0 and self.n_freq_masks == 0)
         ):
             return x
-        if self.prob < 1.0 and torch.rand((), device="cpu").item() >= self.prob:
+        # All RNG draws use ``x.device`` so reproducibility seeds the same
+        # stream regardless of whether the user calls ``torch.manual_seed``
+        # or ``torch.cuda.manual_seed`` — and so torchaudio's internal
+        # device-side RNG and our Python-level gate stay in sync. ``.item()``
+        # still forces a host sync for the Python ``if``/loop bound, but
+        # that is unavoidable for control flow.
+        if self.prob < 1.0 and torch.rand((), device=x.device).item() >= self.prob:
             return x
         # ``torchaudio`` masking expects ``(..., freq, time)``; here that means
         # ``(B, num_bands, electrodes, freq, T_spec)``. Move time to the end
@@ -665,10 +674,10 @@ class _SpecAugment(nn.Module):
         # 0-D on-device tensor — ``masked_fill`` / ``torch.where`` accept it
         # without a host sync.
         mask_value = spec.mean()
-        n_t = int(torch.randint(self.n_time_masks + 1, ()).item())
+        n_t = int(torch.randint(self.n_time_masks + 1, (), device=x.device).item())
         for _ in range(n_t):
             spec = self.time_mask(spec, mask_value=mask_value)
-        n_f = int(torch.randint(self.n_freq_masks + 1, ()).item())
+        n_f = int(torch.randint(self.n_freq_masks + 1, (), device=x.device).item())
         for _ in range(n_f):
             spec = self.freq_mask(spec, mask_value=mask_value)
         return spec.movedim(-1, 0)

--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -56,7 +56,11 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
     Returns ``(batch, T_out, n_outputs)``. With ``n_times=8000`` and
     defaults, ``T_out=373``. For :class:`~torch.nn.CTCLoss`, transpose
     to ``(T_out, batch, n_outputs)``; use :meth:`compute_output_lengths`
-    for emission lengths.
+    for emission lengths. Pass ``return_features=True`` to return the
+    pre-classifier encoder representation as a
+    ``{"features": (batch, T_out, num_features), "cls_token": None}``
+    dict, matching the BIOT / signal-JEPA convention used by downstream
+    wrappers (e.g. neuroai's ``DownstreamWrapperModel``).
 
     .. rubric:: Paper training recipe
 
@@ -344,7 +348,9 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
             isinstance(m, _TDSConv2dBlock) for m in self.model[3].tds_conv_blocks
         )
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self, x: torch.Tensor, return_features: bool = False
+    ) -> torch.Tensor | dict[str, torch.Tensor | None]:
         """Run the full pipeline.
 
         Parameters
@@ -353,12 +359,28 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
             Raw EMG of shape ``(batch, n_chans=32, n_times)``. ``n_times``
             must be at least the encoder's receptive field, ``n_fft +
             n_conv_blocks * (kernel_width - 1) * hop_length``.
+        return_features : bool
+            If ``True``, return a ``dict`` with the encoder representation
+            instead of the classification emissions. The encoder is the
+            full TDS-Conv stack up to (but not including)
+            ``self.final_layer`` — i.e. what downstream wrappers want
+            when they apply their own probe/aggregation. Matches the
+            BIOT / signal-JEPA convention so the same neuroai
+            ``DownstreamWrapperModel(model_output_key="features")``
+            can consume it.
 
         Returns
         -------
-        emissions : torch.Tensor
-            Shape ``(batch, T_out, n_outputs)``. Log-probabilities if
+        torch.Tensor or dict
+            Default (``return_features=False``): ``torch.Tensor`` of
+            shape ``(batch, T_out, n_outputs)``. Log-probabilities if
             ``log_softmax=True``, otherwise logits.
+
+            If ``return_features=True``: ``dict`` with
+            ``"features"`` (shape ``(batch, T_out, num_features)``,
+            where ``num_features = num_bands * mlp_features[-1]``) and
+            ``"cls_token"`` (always ``None`` — TDS-Conv has no
+            ``[CLS]``).
         """
         if x.ndim != 3 or x.shape[-2] != self.n_chans:
             raise ValueError(
@@ -379,6 +401,14 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
         spectrogram = self.spectrogram(x)
         spectrogram = self.spec_augment(spectrogram)
         encoded = self.model(spectrogram)
+        if return_features:
+            # ``encoded`` is (T_out, B, num_features). Transpose to
+            # (B, T_out, num_features) so feature consumers see the
+            # same batch-first layout as the default emissions tensor.
+            return {
+                "features": encoded.transpose(0, 1).contiguous(),
+                "cls_token": None,
+            }
         emissions = self.final_layer(encoded)
         if self.log_softmax:
             emissions = F.log_softmax(emissions, dim=-1)
@@ -458,7 +488,11 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
             dummy_input = torch.zeros(
                 1, self.n_chans, n_times, dtype=dtype, device=device
             )
-            return tuple(self.forward(dummy_input).shape)
+            # ``return_features=False`` is the default; assert here so mypy
+            # narrows the union return type to ``Tensor`` for ``.shape``.
+            emissions = self.forward(dummy_input, return_features=False)
+            assert isinstance(emissions, torch.Tensor)
+            return tuple(emissions.shape)
 
 
 class _LogSpectrogram(nn.Module):

--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -69,7 +69,9 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
       local minimum).
     - **Augmentation**: per-band electrode rotations by -1/0/+1 positions,
       ±60-sample temporal jitter, and SpecAugment [park2019specaug]_ on
-      the log-spectrogram.
+      the log-spectrogram. SpecAugment is built into the model
+      (``spec_augment=True``) and only fires in training mode; the
+      time/frequency-jitter pieces are dataset-side augmentations.
     - **Decoding**: greedy CTC. Upstream also reports a 6-gram KenLM
       beam decoder, not ported here.
 
@@ -145,6 +147,27 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
         layers and again after the second :class:`~torch.nn.Linear`.
         Default ``0.0`` matches the upstream paper recipe (no dropout).
         Set ``> 0`` for regularized training.
+    spec_augment : bool
+        If ``True``, apply SpecAugment [park2019specaug]_ time/frequency
+        masking on the log-spectrogram during training only. Disabled in
+        ``eval`` mode and absent from the parameter / state-dict count.
+        Defaults to ``False``; set to ``True`` to match the upstream
+        emg2qwerty paper recipe.
+    n_time_masks : int
+        Maximum number of time masks applied per call. Each forward pass
+        samples a uniform integer in ``[0, n_time_masks]``. Defaults to
+        ``3`` (Sivakumar et al. Sec 5.2).
+    time_mask_param : int
+        Maximum time-mask width in spectrogram frames. Defaults to ``25``.
+    n_freq_masks : int
+        Maximum number of frequency masks applied per call. Each forward
+        pass samples a uniform integer in ``[0, n_freq_masks]``. Defaults
+        to ``2``.
+    freq_mask_param : int
+        Maximum frequency-mask width in STFT bins. Defaults to ``4``.
+    spec_augment_prob : float
+        Probability of running SpecAugment on a given training batch
+        (Bernoulli gate before sampling mask counts). Defaults to ``1.0``.
 
     Examples
     --------
@@ -216,6 +239,12 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
         log_softmax: bool = False,
         activation: type[nn.Module] = nn.ReLU,
         drop_prob: float = 0.0,
+        spec_augment: bool = False,
+        n_time_masks: int = 3,
+        time_mask_param: int = 25,
+        n_freq_masks: int = 2,
+        freq_mask_param: int = 4,
+        spec_augment_prob: float = 1.0,
         # Standard braindecode args
         n_times: int | None = None,
         input_window_seconds: float | None = None,
@@ -268,6 +297,23 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
             electrodes_per_band=electrodes_per_band,
             log_eps=log_eps,
         )
+
+        # Built-in SpecAugment lives between the spectrogram and the BatchNorm
+        # so it operates on the log-power tensor (matches upstream emg2qwerty
+        # and the previous neuralbench callback). ``nn.Identity`` keeps the
+        # forward path symmetrical without contributing parameters or
+        # state-dict keys when SpecAugment is disabled.
+        self.spec_augment: nn.Module
+        if spec_augment:
+            self.spec_augment = _SpecAugment(
+                n_time_masks=n_time_masks,
+                time_mask_param=time_mask_param,
+                n_freq_masks=n_freq_masks,
+                freq_mask_param=freq_mask_param,
+                prob=spec_augment_prob,
+            )
+        else:
+            self.spec_augment = nn.Identity()
 
         # Indices 0/1/3 match upstream's ``TDSConvCTCModule.model``;
         # index 2 is a parameter-free Flatten; upstream's index 4 (head)
@@ -331,6 +377,7 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
                 f"kernel_width={self.kernel_width})."
             )
         spectrogram = self.spectrogram(x)
+        spectrogram = self.spec_augment(spectrogram)
         encoded = self.model(spectrogram)
         emissions = self.final_layer(encoded)
         if self.log_softmax:
@@ -480,6 +527,80 @@ class _LogSpectrogram(nn.Module):
             self.electrodes_per_band,
             n_freq_bins,
             n_frames,
+        ).movedim(-1, 0)
+
+
+class _SpecAugment(nn.Module):
+    r"""SpecAugment masking on the log-spectrogram during training.
+
+    Applies up to ``n_time_masks`` × ``time_mask_param``-frame time bands
+    and ``n_freq_masks`` × ``freq_mask_param``-bin frequency bands, IID
+    per ``(sample × band)`` and shared across the electrodes within a band
+    — per-electrode masking is :math:`\\sim 32\\times` more aggressive and
+    collapses CTC. No-op outside training. Defaults match Sivakumar et al.
+    Sec 5.2 (3×25 / 2×4 frames-bins, ``prob=1.0``).
+    """
+
+    def __init__(
+        self,
+        n_time_masks: int = 3,
+        time_mask_param: int = 25,
+        n_freq_masks: int = 2,
+        freq_mask_param: int = 4,
+        prob: float = 1.0,
+    ) -> None:
+        super().__init__()
+        if n_time_masks < 0 or n_freq_masks < 0:
+            raise ValueError(
+                f"n_time_masks and n_freq_masks must be >= 0; got "
+                f"n_time_masks={n_time_masks}, n_freq_masks={n_freq_masks}."
+            )
+        if time_mask_param < 0 or freq_mask_param < 0:
+            raise ValueError(
+                f"time_mask_param and freq_mask_param must be >= 0; got "
+                f"time_mask_param={time_mask_param}, "
+                f"freq_mask_param={freq_mask_param}."
+            )
+        if not 0.0 <= prob <= 1.0:
+            raise ValueError(f"prob must be in [0, 1]; got {prob}.")
+        self.n_time_masks = n_time_masks
+        self.time_mask_param = time_mask_param
+        self.n_freq_masks = n_freq_masks
+        self.freq_mask_param = freq_mask_param
+        self.prob = prob
+        # ``iid_masks=True`` so every (sample × band) row gets its own mask;
+        # without it, the same time window is masked across all bands and the
+        # CTC head collapses to all-blank during warmup.
+        self.time_mask = ta_transforms.TimeMasking(time_mask_param, iid_masks=True)
+        self.freq_mask = ta_transforms.FrequencyMasking(freq_mask_param, iid_masks=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # ``x``: (T_spec, B, num_bands, electrodes, freq).
+        if (
+            not self.training
+            or self.prob <= 0.0
+            or (self.n_time_masks == 0 and self.n_freq_masks == 0)
+        ):
+            return x
+        if self.prob < 1.0 and torch.rand((), device="cpu").item() >= self.prob:
+            return x
+        n_frames, batch_size, n_bands, n_electrodes, n_freq_bins = x.shape
+        # Reshape to ``(B*num_bands, electrodes, freq, T_spec)`` so iid_masks
+        # draws one mask per (sample × band) shared across electrodes.
+        flat = x.movedim(0, -1).reshape(
+            batch_size * n_bands, n_electrodes, n_freq_bins, n_frames
+        )
+        # Mask to per-window mean: in log-spec space 0 = log(power=1), well
+        # above the typical distribution and would inject artificial spikes.
+        mask_value = float(flat.mean().item())
+        n_t = int(torch.randint(self.n_time_masks + 1, ()).item())
+        for _ in range(n_t):
+            flat = self.time_mask(flat, mask_value=mask_value)
+        n_f = int(torch.randint(self.n_freq_masks + 1, ()).item())
+        for _ in range(n_f):
+            flat = self.freq_mask(flat, mask_value=mask_value)
+        return flat.reshape(
+            batch_size, n_bands, n_electrodes, n_freq_bins, n_frames
         ).movedim(-1, 0)
 
 

--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -172,6 +172,16 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
     spec_augment_prob : float
         Probability of running SpecAugment on a given training batch
         (Bernoulli gate before sampling mask counts). Defaults to ``1.0``.
+    return_feature : bool
+        If ``True``, ``forward`` returns a tuple
+        ``(emissions, features)`` instead of just ``emissions`` —
+        :class:`braindecode.models.BIOT`-style legacy feature path. Lets
+        configuration-driven downstream wrappers (e.g. neuroai's
+        ``DownstreamWrapperModel`` with ``model_output_key=1``) pick up
+        the encoder representation without passing a runtime kwarg.
+        Defaults to ``False``. Mutually compatible with the runtime
+        ``return_features`` (plural) flag, which still wins when set
+        to ``True``.
 
     Examples
     --------
@@ -249,6 +259,7 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
         n_freq_masks: int = 2,
         freq_mask_param: int = 4,
         spec_augment_prob: float = 1.0,
+        return_feature: bool = False,
         # Standard braindecode args
         n_times: int | None = None,
         input_window_seconds: float | None = None,
@@ -289,6 +300,7 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
         self.hop_length = hop_length
         self.kernel_width = kernel_width
         self.log_softmax = log_softmax
+        self.return_feature = return_feature
 
         n_freq_bins = n_fft // 2 + 1
         in_features = electrodes_per_band * n_freq_bins
@@ -350,7 +362,11 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
 
     def forward(
         self, x: torch.Tensor, return_features: bool = False
-    ) -> torch.Tensor | dict[str, torch.Tensor | None]:
+    ) -> (
+        torch.Tensor
+        | dict[str, torch.Tensor | None]
+        | tuple[torch.Tensor, torch.Tensor]
+    ):
         """Run the full pipeline.
 
         Parameters
@@ -367,20 +383,29 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
             when they apply their own probe/aggregation. Matches the
             BIOT / signal-JEPA convention so the same neuroai
             ``DownstreamWrapperModel(model_output_key="features")``
-            can consume it.
+            can consume it. Wins over the constructor-time
+            ``return_feature`` flag when set.
 
         Returns
         -------
-        torch.Tensor or dict
-            Default (``return_features=False``): ``torch.Tensor`` of
-            shape ``(batch, T_out, n_outputs)``. Log-probabilities if
+        torch.Tensor or dict or tuple
+            Default (``return_features=False``, init
+            ``return_feature=False``): ``torch.Tensor`` of shape
+            ``(batch, T_out, n_outputs)``. Log-probabilities if
             ``log_softmax=True``, otherwise logits.
 
-            If ``return_features=True``: ``dict`` with
+            If runtime ``return_features=True``: ``dict`` with
             ``"features"`` (shape ``(batch, T_out, num_features)``,
             where ``num_features = num_bands * mlp_features[-1]``) and
             ``"cls_token"`` (always ``None`` — TDS-Conv has no
             ``[CLS]``).
+
+            If init ``return_feature=True`` and runtime
+            ``return_features=False``: tuple ``(emissions, features)``
+            where ``features`` has shape ``(batch, T_out,
+            num_features)``. Same layout BIOT exposes for
+            configuration-driven feature extraction (e.g. neuroai's
+            ``model_output_key=1``).
         """
         if x.ndim != 3 or x.shape[-2] != self.n_chans:
             raise ValueError(
@@ -401,18 +426,19 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
         spectrogram = self.spectrogram(x)
         spectrogram = self.spec_augment(spectrogram)
         encoded = self.model(spectrogram)
+        # ``encoded`` is (T_out, B, num_features). Transpose to (B, T_out,
+        # num_features) so feature consumers (and neuroai's downstream
+        # wrappers) see the same batch-first layout as the emissions tensor.
+        features = encoded.transpose(0, 1).contiguous()
         if return_features:
-            # ``encoded`` is (T_out, B, num_features). Transpose to
-            # (B, T_out, num_features) so feature consumers see the
-            # same batch-first layout as the default emissions tensor.
-            return {
-                "features": encoded.transpose(0, 1).contiguous(),
-                "cls_token": None,
-            }
+            return {"features": features, "cls_token": None}
         emissions = self.final_layer(encoded)
         if self.log_softmax:
             emissions = F.log_softmax(emissions, dim=-1)
-        return emissions.transpose(0, 1).contiguous()
+        emissions = emissions.transpose(0, 1).contiguous()
+        if self.return_feature:
+            return emissions, features
+        return emissions
 
     def reset_head(self, n_outputs: int) -> None:
         """Replace the classification head for a new vocabulary size.
@@ -488,9 +514,11 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
             dummy_input = torch.zeros(
                 1, self.n_chans, n_times, dtype=dtype, device=device
             )
-            # ``return_features=False`` is the default; assert here so mypy
-            # narrows the union return type to ``Tensor`` for ``.shape``.
-            emissions = self.forward(dummy_input, return_features=False)
+            # ``return_features=False`` keeps the dict path off; the init
+            # ``return_feature`` flag may still produce a tuple, so unpack
+            # the emissions explicitly to report the public output shape.
+            out = self.forward(dummy_input, return_features=False)
+            emissions = out[0] if isinstance(out, tuple) else out
             assert isinstance(emissions, torch.Tensor)
             return tuple(emissions.shape)
 
@@ -567,19 +595,20 @@ class _LogSpectrogram(nn.Module):
 class _SpecAugment(nn.Module):
     r"""SpecAugment masking on the log-spectrogram during training.
 
-    Applies up to ``n_time_masks`` × ``time_mask_param``-frame time bands
-    and ``n_freq_masks`` × ``freq_mask_param``-bin frequency bands, with
-    one mask drawn per ``(sample × band)`` row and broadcast across all
-    electrodes within that band — so a wristband's 16 electrodes share
-    the same masked window. No-op outside ``training``. Defaults match
-    Sivakumar et al. Sec 5.2 (3×25 / 2×4 frames-bins, ``prob=1.0``).
+    Applies up to ``n_time_masks`` × ``time_mask_param``-frame time
+    bands and ``n_freq_masks`` × ``freq_mask_param``-bin frequency
+    bands. Masks are independent per ``(sample × band × electrode)``
+    triple — same recipe as the upstream emg2qwerty
+    :class:`emg2qwerty.transforms.SpecAugment` dataset transform
+    (Sivakumar et al. Sec 5.2 / NeurIPS 2024), which is
+    :func:`torchaudio.functional.mask_along_axis_iid`-style masking
+    sampled per leading dim of a spectrogram with shape
+    ``(..., freq, time)``. No-op outside ``training``.
 
-    Implemented as pure tensor ops (per-row vectorised start / width
-    sampling, on-device mean fill, ``masked_fill`` broadcast) so the
-    forward pass keeps no host round-trips on GPU. ``torchaudio``'s
-    ``TimeMasking(iid_masks=True)`` cannot be reused here because, on a
-    ``(B*num_bands, electrodes, freq, T)`` tensor, it samples one mask
-    per ``(batch, electrode)`` pair instead of per ``(sample × band)``.
+    The mask fill value is the on-device mean of the spectrogram —
+    ``log(power=1)=0`` would sit well above the typical log-power
+    distribution and inject artificial spikes — and stays a 0-D
+    tensor so the forward pass adds no host round-trip on GPU.
     """
 
     def __init__(
@@ -609,36 +638,13 @@ class _SpecAugment(nn.Module):
         self.n_freq_masks = n_freq_masks
         self.freq_mask_param = freq_mask_param
         self.prob = prob
-
-    @staticmethod
-    def _band_shared_axis_mask(
-        n_rows: int,
-        axis_len: int,
-        max_mask_param: int,
-        device: torch.device,
-    ) -> torch.Tensor:
-        """One mask per row, shared across the orthogonal axes.
-
-        Returns a ``(n_rows, axis_len)`` boolean tensor where row ``i``
-        marks a contiguous span ``[start_i, start_i + width_i)`` to be
-        masked. ``width_i`` is sampled in ``[0, min(max_mask_param,
-        axis_len)]``; ``start_i`` in ``[0, axis_len - width_i]``. Both
-        draws stay on-device.
-        """
-        effective = min(max_mask_param, axis_len)
-        if effective <= 0 or n_rows <= 0:
-            return torch.zeros(n_rows, axis_len, dtype=torch.bool, device=device)
-        widths = torch.randint(0, effective + 1, (n_rows,), device=device)
-        # Float-then-cast keeps integer precision under fp16/bf16 — same trick
-        # ``_MaskAug`` uses in ``meta_neuromotor``.
-        max_starts = (axis_len - widths).to(torch.float32)
-        starts = (
-            torch.rand(n_rows, device=device, dtype=torch.float32) * max_starts
-        ).to(torch.long)
-        positions = torch.arange(axis_len, device=device)
-        return (positions[None, :] >= starts[:, None]) & (
-            positions[None, :] < (starts + widths)[:, None]
-        )
+        # ``iid_masks=True`` so masking is sampled over every leading dim
+        # except the trailing ``(freq, time)`` pair — i.e. one mask per
+        # ``(sample × band × electrode)`` on a 5-D
+        # ``(B, num_bands, electrodes, freq, T)`` input. Matches upstream
+        # emg2qwerty's per-``(band × electrode)`` dataset-time recipe.
+        self.time_mask = ta_transforms.TimeMasking(time_mask_param, iid_masks=True)
+        self.freq_mask = ta_transforms.FrequencyMasking(freq_mask_param, iid_masks=True)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # ``x``: (T_spec, B, num_bands, electrodes, freq).
@@ -650,34 +656,22 @@ class _SpecAugment(nn.Module):
             return x
         if self.prob < 1.0 and torch.rand((), device="cpu").item() >= self.prob:
             return x
-        n_frames, batch_size, n_bands, n_electrodes, n_freq_bins = x.shape
-        n_rows = batch_size * n_bands
-        # Reshape to ``(B*num_bands, electrodes, freq, T_spec)`` so a mask of
-        # shape ``(n_rows, ..., L)`` broadcasts across the electrode axis —
-        # the missing dim is 1, so every electrode in a band sees the same
-        # masked window.
-        flat = x.movedim(0, -1).reshape(n_rows, n_electrodes, n_freq_bins, n_frames)
-        # 0-D on-device fill value; in log-spec space the natural zero is
-        # ``log(power=1)`` which sits well above the typical distribution and
-        # would inject artificial spikes. Mean over all elements matches the
-        # original neuralbench callback behaviour but stays on-device (no
-        # ``.item()`` host sync per forward).
-        mask_value = flat.mean()
+        # ``torchaudio`` masking expects ``(..., freq, time)``; here that means
+        # ``(B, num_bands, electrodes, freq, T_spec)``. Move time to the end
+        # rather than reshaping into 4D, because ``mask_along_axis_iid`` draws
+        # one mask per leading-axis index, so the 5-D layout already gives the
+        # desired per-``(B × num_bands × electrodes)`` independence.
+        spec = x.movedim(0, -1).contiguous()
+        # 0-D on-device tensor — ``masked_fill`` / ``torch.where`` accept it
+        # without a host sync.
+        mask_value = spec.mean()
         n_t = int(torch.randint(self.n_time_masks + 1, ()).item())
         for _ in range(n_t):
-            time_mask = self._band_shared_axis_mask(
-                n_rows, n_frames, self.time_mask_param, flat.device
-            )
-            flat = flat.masked_fill(time_mask[:, None, None, :], mask_value)
+            spec = self.time_mask(spec, mask_value=mask_value)
         n_f = int(torch.randint(self.n_freq_masks + 1, ()).item())
         for _ in range(n_f):
-            freq_mask = self._band_shared_axis_mask(
-                n_rows, n_freq_bins, self.freq_mask_param, flat.device
-            )
-            flat = flat.masked_fill(freq_mask[:, None, :, None], mask_value)
-        return flat.reshape(
-            batch_size, n_bands, n_electrodes, n_freq_bins, n_frames
-        ).movedim(-1, 0)
+            spec = self.freq_mask(spec, mask_value=mask_value)
+        return spec.movedim(-1, 0)
 
 
 class _SpectrogramNorm(nn.Module):

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -41,14 +41,20 @@ Enhancements
   gated by a new ``spec_augment`` constructor flag (default ``False``).
   When enabled, applies up to ``n_time_masks`` × ``time_mask_param``
   time bands and ``n_freq_masks`` × ``freq_mask_param`` frequency bands
-  on the log-spectrogram during ``train()`` only, with one mask drawn
-  per ``(sample × band)`` and broadcast across all electrodes within
-  the band. Implemented with on-device tensor ops (no host syncs).
-  Also adds a ``return_features`` flag to
-  :meth:`braindecode.models.EMG2QwertyNet.forward` so the encoder can
-  drop into downstream wrappers expecting a
-  ``{"features": (B, T_out, num_features), "cls_token": None}`` dict
-  (BIOT / signal-JEPA convention). By `Bruno Aristimunha`_.
+  on the log-spectrogram during ``train()`` only, with masks sampled
+  IID per ``(sample × band × electrode)`` triple — same recipe as the
+  upstream ``emg2qwerty.transforms.SpecAugment`` dataset transform. The
+  mask fill value stays a 0-D on-device tensor (``spec.mean()``) so the
+  forward pass adds no host round-trip on GPU. Also adds a
+  ``return_features`` runtime flag to
+  :meth:`braindecode.models.EMG2QwertyNet.forward` (returns
+  ``{"features": (B, T_out, num_features), "cls_token": None}``,
+  BIOT / signal-JEPA convention) and a matching ``return_feature``
+  constructor flag (returns ``(emissions, features)`` tuple, BIOT-style
+  legacy path) so downstream wrappers — such as neuroai's
+  ``DownstreamWrapperModel`` — can pick up the encoder representation
+  via ``model_output_key="features"`` (dict) or ``model_output_key=1``
+  (tuple) without changes to their call site. By `Bruno Aristimunha`_.
 
 - Add :meth:`braindecode.datasets.BaseConcatDataset.set_target` to swap
   any per-window metadata column or per-record description field

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -36,7 +36,7 @@ Enhancements
   noise between two arms, from the emg2qwerty paper (Sivakumar et al.,
   NeurIPS 2024).  By `Bruno Aristimunha`_.
 
-- Build SpecAugment [park2019specaug]_ into
+- Build SpecAugment (Park et al., Interspeech 2019) into
   :class:`braindecode.models.EMG2QwertyNet` as a parameter-free submodule
   gated by a new ``spec_augment`` constructor flag (default ``False``).
   When enabled, applies up to ``n_time_masks`` × ``time_mask_param``

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -36,6 +36,20 @@ Enhancements
   noise between two arms, from the emg2qwerty paper (Sivakumar et al.,
   NeurIPS 2024).  By `Bruno Aristimunha`_.
 
+- Build SpecAugment [park2019specaug]_ into
+  :class:`braindecode.models.EMG2QwertyNet` as a parameter-free submodule
+  gated by a new ``spec_augment`` constructor flag (default ``False``).
+  When enabled, applies up to ``n_time_masks`` × ``time_mask_param``
+  time bands and ``n_freq_masks`` × ``freq_mask_param`` frequency bands
+  on the log-spectrogram during ``train()`` only, with one mask drawn
+  per ``(sample × band)`` and broadcast across all electrodes within
+  the band. Implemented with on-device tensor ops (no host syncs).
+  Also adds a ``return_features`` flag to
+  :meth:`braindecode.models.EMG2QwertyNet.forward` so the encoder can
+  drop into downstream wrappers expecting a
+  ``{"features": (B, T_out, num_features), "cls_token": None}`` dict
+  (BIOT / signal-JEPA convention). By `Bruno Aristimunha`_.
+
 - Add :meth:`braindecode.datasets.BaseConcatDataset.set_target` to swap
   any per-window metadata column or per-record description field
   (e.g. a BIDS entity, a participants.tsv extra) into the dataset's

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -3519,3 +3519,86 @@ def test_emg2qwerty_input_validation():
     # by ``floor((T - n_fft) / hop_length) + 1``.
     out = m_floor.compute_output_lengths(torch.tensor([10, 0, 50, 64, 80]))
     assert out.tolist() == [0, 0, 0, 1, 2]
+
+
+def test_emg2qwerty_spec_augment_train_only():
+    """SpecAugment runs only in train mode and is parameter-free.
+
+    Built-in SpecAugment (replaces the old neuralbench callback) must:
+    (1) be a no-op in eval mode so deterministic forwards stay
+    deterministic and inference is unaffected; (2) actually mutate
+    the encoder input under train mode so it acts as augmentation;
+    (3) carry zero parameters / state-dict keys so upstream-checkpoint
+    layout remains untouched; (4) round-trip via ``from_config``.
+    """
+    torch.manual_seed(0)
+    m = _small_emg2qwerty(
+        spec_augment=True,
+        n_time_masks=3,
+        time_mask_param=8,
+        n_freq_masks=2,
+        freq_mask_param=4,
+        spec_augment_prob=1.0,
+    )
+    x = torch.randn(2, 32, 500)
+
+    # Eval mode: deterministic, identical across calls.
+    m.eval()
+    with torch.no_grad():
+        y_eval_a = m(x)
+        y_eval_b = m(x)
+    assert torch.equal(y_eval_a, y_eval_b)
+
+    # Train mode: SpecAugment is stochastic (random number of masks in
+    # ``[0, n_*_masks]``). Seed 1 picks both n_t > 0 and n_f > 0 so the
+    # assertion is deterministic for this specific seed/config. Seed 3
+    # picks a different draw, exercising the stochastic branch.
+    m.train()
+    spec = m.spectrogram(x)
+    torch.manual_seed(1)
+    aug_a = m.spec_augment(spec)
+    torch.manual_seed(3)
+    aug_b = m.spec_augment(spec)
+    assert not torch.equal(aug_a, spec), "SpecAugment must mutate the spectrogram"
+    assert not torch.equal(aug_a, aug_b), "SpecAugment must be stochastic"
+
+    # No new state-dict keys.
+    keys = list(m.state_dict().keys())
+    allowed = ("model.0.", "model.1.", "model.3.", "final_layer.")
+    assert not [k for k in keys if not k.startswith(allowed)]
+
+    # Round-trip via ``get_config`` keeps SpecAugment enabled with the
+    # same kwargs (so reloaded models reproduce the augmentation recipe).
+    cfg = m.get_config()
+    assert cfg["spec_augment"] is True
+    assert cfg["time_mask_param"] == 8
+    m2 = EMG2QwertyNet.from_config(cfg)
+    assert isinstance(m2.spec_augment, type(m.spec_augment))
+
+
+def test_emg2qwerty_spec_augment_disabled_default():
+    """Default ``spec_augment=False`` builds an Identity passthrough.
+
+    The default model must be backward-compatible: SpecAugment off, no
+    new state-dict keys, and forward in train mode is deterministic
+    modulo BatchNorm running stats (which we sidestep by checking
+    ``spec_augment`` directly).
+    """
+    m = _small_emg2qwerty()
+    assert isinstance(m.spec_augment, torch.nn.Identity)
+
+    m.train()
+    x = torch.randn(2, 32, 500)
+    spec = m.spectrogram(x)
+    out = m.spec_augment(spec)
+    assert torch.equal(out, spec)
+
+
+def test_emg2qwerty_spec_augment_validation():
+    """SpecAugment constructor rejects out-of-range parameters."""
+    with pytest.raises(ValueError, match="n_time_masks"):
+        _small_emg2qwerty(spec_augment=True, n_time_masks=-1)
+    with pytest.raises(ValueError, match="time_mask_param"):
+        _small_emg2qwerty(spec_augment=True, time_mask_param=-1)
+    with pytest.raises(ValueError, match="prob"):
+        _small_emg2qwerty(spec_augment=True, spec_augment_prob=1.5)

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -11,6 +11,7 @@
 
 from collections import OrderedDict
 from functools import partial
+from unittest import mock
 
 import mne
 import numpy as np
@@ -3550,17 +3551,49 @@ def test_emg2qwerty_spec_augment_train_only():
     assert torch.equal(y_eval_a, y_eval_b)
 
     # Train mode: SpecAugment is stochastic (random number of masks in
-    # ``[0, n_*_masks]``). Seed 1 picks both n_t > 0 and n_f > 0 so the
-    # assertion is deterministic for this specific seed/config. Seed 3
-    # picks a different draw, exercising the stochastic branch.
+    # ``[0, n_*_masks]``). Force the mask-count draws so the assertion is
+    # deterministic regardless of the global RNG / torchaudio versions —
+    # ``forward`` calls ``torch.randint(n+1, ())`` exactly twice (time
+    # then frequency); both must come back ``>= 1``.
     m.train()
     spec = m.spectrogram(x)
-    torch.manual_seed(1)
-    aug_a = m.spec_augment(spec)
-    torch.manual_seed(3)
-    aug_b = m.spec_augment(spec)
+    real_randint = torch.randint
+
+    def force_nonzero_count(*args, **kwargs):
+        size = kwargs.get("size", args[1] if len(args) >= 2 else None)
+        if size == ():
+            return torch.tensor(2, dtype=torch.long)
+            # ``2`` is in [0, 3] (n_time_masks=3) and [0, 2] (n_freq_masks=2),
+            # so the spec_augment forward applies two time masks and two freq
+            # masks per call.
+        return real_randint(*args, **kwargs)
+
+    with mock.patch("torch.randint", side_effect=force_nonzero_count):
+        aug_a = m.spec_augment(spec)
+        aug_b = m.spec_augment(spec)
     assert not torch.equal(aug_a, spec), "SpecAugment must mutate the spectrogram"
     assert not torch.equal(aug_a, aug_b), "SpecAugment must be stochastic"
+
+    # Band-sharing contract: every electrode within a (sample, band) pair
+    # must see the same mask pattern. ``masked_fill`` with mean ≈ original
+    # values would mask invisibly, so build a tensor whose elements are all
+    # distinct integers — any change is then exact-detectable.
+    contiguous_spec = torch.arange(spec.numel(), dtype=spec.dtype).reshape(spec.shape)
+    with mock.patch("torch.randint", side_effect=force_nonzero_count):
+        contiguous_aug = m.spec_augment(contiguous_spec)
+    changed = contiguous_aug != contiguous_spec  # (T, B, num_bands, electrodes, freq)
+    # Reduce over (T, freq) to a (B, num_bands, electrodes) "did electrode e
+    # see ANY mask?" tensor; band-shared masking ⇒ all electrodes within a
+    # (b, band) row share the per-(T, freq) pattern.
+    n_electrodes = changed.shape[-2]
+    for b in range(changed.shape[1]):
+        for band in range(changed.shape[2]):
+            ref = changed[:, b, band, 0, :]
+            for e in range(1, n_electrodes):
+                assert torch.equal(changed[:, b, band, e, :], ref), (
+                    f"electrode {e} mask differs from electrode 0 in "
+                    f"(B={b}, band={band}) — masking is not band-shared"
+                )
 
     # No new state-dict keys.
     keys = list(m.state_dict().keys())

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -3574,26 +3574,36 @@ def test_emg2qwerty_spec_augment_train_only():
     assert not torch.equal(aug_a, spec), "SpecAugment must mutate the spectrogram"
     assert not torch.equal(aug_a, aug_b), "SpecAugment must be stochastic"
 
-    # Band-sharing contract: every electrode within a (sample, band) pair
-    # must see the same mask pattern. ``masked_fill`` with mean ≈ original
-    # values would mask invisibly, so build a tensor whose elements are all
-    # distinct integers — any change is then exact-detectable.
+    # Per-(sample × band × electrode) independence contract — matches
+    # upstream ``emg2qwerty.transforms.SpecAugment`` (Sivakumar et al.
+    # Sec 5.2), which applies torchaudio ``iid_masks=True`` on a 4-D
+    # ``(bands, electrodes, freq, T)`` sample and so draws one mask
+    # per ``(band, electrode)`` pair. On a uniquely-valued tensor, at
+    # least one ``(B, band)`` row must show different mask patterns
+    # across its electrodes — i.e. masking must NOT be band-shared.
     contiguous_spec = torch.arange(spec.numel(), dtype=spec.dtype).reshape(spec.shape)
     with mock.patch("torch.randint", side_effect=force_nonzero_count):
         contiguous_aug = m.spec_augment(contiguous_spec)
     changed = contiguous_aug != contiguous_spec  # (T, B, num_bands, electrodes, freq)
-    # Reduce over (T, freq) to a (B, num_bands, electrodes) "did electrode e
-    # see ANY mask?" tensor; band-shared masking ⇒ all electrodes within a
-    # (b, band) row share the per-(T, freq) pattern.
     n_electrodes = changed.shape[-2]
+    found_per_electrode_diff = False
     for b in range(changed.shape[1]):
         for band in range(changed.shape[2]):
             ref = changed[:, b, band, 0, :]
             for e in range(1, n_electrodes):
-                assert torch.equal(changed[:, b, band, e, :], ref), (
-                    f"electrode {e} mask differs from electrode 0 in "
-                    f"(B={b}, band={band}) — masking is not band-shared"
-                )
+                if not torch.equal(changed[:, b, band, e, :], ref):
+                    found_per_electrode_diff = True
+                    break
+            if found_per_electrode_diff:
+                break
+        if found_per_electrode_diff:
+            break
+    assert found_per_electrode_diff, (
+        "SpecAugment must produce per-(B, band, electrode) independent "
+        "masks (matches upstream emg2qwerty); every (B, band) row "
+        "showing identical masks across all electrodes indicates "
+        "band-shared masking, which is a regression."
+    )
 
     # No new state-dict keys.
     keys = list(m.state_dict().keys())
@@ -3673,3 +3683,53 @@ def test_emg2qwerty_return_features_dict_layout():
     # the head reproduces the emissions tensor up to log-softmax).
     head_out = m.final_layer(feats)
     assert torch.allclose(head_out, emissions, atol=1e-5)
+
+
+def test_emg2qwerty_return_feature_init_tuple():
+    """``return_feature=True`` (init kwarg) yields a BIOT-style tuple.
+
+    Configuration-driven downstream wrappers (neuroai's
+    ``DownstreamWrapperModel`` with ``model_output_key=1``) call
+    ``model(**dummy_batch)`` without runtime kwargs, so the model has to
+    expose the encoder representation through its default forward path
+    too. Mirrors :class:`braindecode.models.BIOT`'s legacy
+    ``return_feature=True`` init flag: ``forward(x)`` returns
+    ``(emissions, features)``. Runtime ``return_features=True`` (dict)
+    keeps winning when both are set.
+    """
+    torch.manual_seed(0)
+    mlp_features = (48,)
+    num_bands = 2
+    expected_num_features = num_bands * mlp_features[-1]
+
+    m = _small_emg2qwerty(mlp_features=mlp_features, return_feature=True).eval()
+    x = torch.randn(2, 32, 500)
+
+    with torch.no_grad():
+        out = m(x)
+    assert isinstance(out, tuple) and len(out) == 2
+    emissions, features = out
+    assert emissions.shape[0] == 2 and emissions.shape[2] == 99
+    assert features.shape == (2, emissions.shape[1], expected_num_features)
+    # Same content invariant as the dict path.
+    assert torch.allclose(m.final_layer(features), emissions, atol=1e-5)
+
+    # Runtime dict flag wins over init tuple flag.
+    with torch.no_grad():
+        bundle = m(x, return_features=True)
+    assert isinstance(bundle, dict)
+    assert torch.equal(bundle["features"], features)
+
+    # Round-trip: ``return_feature`` survives ``get_config`` so reloaded
+    # models keep the same wrapper-compatible output shape.
+    cfg = m.get_config()
+    assert cfg["return_feature"] is True
+    m2 = EMG2QwertyNet.from_config(cfg)
+    with torch.no_grad():
+        out2 = m2(x)
+    assert isinstance(out2, tuple) and len(out2) == 2
+
+    # ``get_output_shape`` must keep reporting the emissions shape, not
+    # the tuple itself, so braindecode's introspection helpers don't
+    # break for callers who flip this flag.
+    assert m.get_output_shape() == (1, emissions.shape[1], 99)

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -3602,3 +3602,41 @@ def test_emg2qwerty_spec_augment_validation():
         _small_emg2qwerty(spec_augment=True, time_mask_param=-1)
     with pytest.raises(ValueError, match="prob"):
         _small_emg2qwerty(spec_augment=True, spec_augment_prob=1.5)
+
+
+def test_emg2qwerty_return_features_dict_layout():
+    """``forward(x, return_features=True)`` matches BIOT/signal-JEPA convention.
+
+    The downstream feature-extraction path used by neuroai's
+    ``DownstreamWrapperModel(model_output_key="features")``: the model
+    returns a dict with a batch-first ``(B, T_out, num_features)``
+    tensor under ``"features"`` and a placeholder ``"cls_token": None``.
+    Default ``return_features=False`` must still return the emissions
+    tensor unchanged for backward compatibility.
+    """
+    torch.manual_seed(0)
+    mlp_features = (48,)
+    num_bands = 2
+    expected_num_features = num_bands * mlp_features[-1]
+
+    m = _small_emg2qwerty(mlp_features=mlp_features).eval()
+    x = torch.randn(2, 32, 500)
+    with torch.no_grad():
+        emissions = m(x)
+        bundle = m(x, return_features=True)
+
+    # Default branch: tensor of emissions, unchanged.
+    assert isinstance(emissions, torch.Tensor)
+    assert emissions.shape[0] == 2 and emissions.shape[2] == 99
+
+    # Feature branch: dict with the expected key set and the encoder
+    # representation pre-final_layer (so it does *not* match emissions).
+    assert isinstance(bundle, dict)
+    assert set(bundle.keys()) == {"features", "cls_token"}
+    assert bundle["cls_token"] is None
+    feats = bundle["features"]
+    assert feats.shape == (2, emissions.shape[1], expected_num_features)
+    # Sanity: features must be the input to ``final_layer`` (so applying
+    # the head reproduces the emissions tensor up to log-softmax).
+    head_out = m.final_layer(feats)
+    assert torch.allclose(head_out, emissions, atol=1e-5)

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -3522,214 +3522,120 @@ def test_emg2qwerty_input_validation():
     assert out.tolist() == [0, 0, 0, 1, 2]
 
 
-def test_emg2qwerty_spec_augment_train_only():
-    """SpecAugment runs only in train mode and is parameter-free.
+def _force_two_randint():
+    """Monkeypatch helper: force every size-`()` ``torch.randint`` to draw 2.
 
-    Built-in SpecAugment (replaces the old neuralbench callback) must:
-    (1) be a no-op in eval mode so deterministic forwards stay
-    deterministic and inference is unaffected; (2) actually mutate
-    the encoder input under train mode so it acts as augmentation;
-    (3) carry zero parameters / state-dict keys so upstream-checkpoint
-    layout remains untouched; (4) round-trip via ``from_config``.
+    ``_SpecAugment.forward`` samples its mask counts via two
+    ``torch.randint(n+1, ())`` calls (time then frequency); freezing
+    them at 2 makes the augmentation deterministic without depending
+    on the global RNG or torchaudio's internal RNG sequence (which
+    can shift across versions and silently turn the test into a flake).
+
+    Returns a ``mock.patch`` context manager rebinding ``torch.randint``;
+    captures the real ``torch.randint`` in a closure so the patched
+    function can still delegate non-`()` calls.
     """
-    torch.manual_seed(0)
-    m = _small_emg2qwerty(
-        spec_augment=True,
-        n_time_masks=3,
-        time_mask_param=8,
-        n_freq_masks=2,
-        freq_mask_param=4,
-        spec_augment_prob=1.0,
-    )
-    x = torch.randn(2, 32, 500)
+    real = torch.randint
 
-    # Eval mode: deterministic, identical across calls.
-    m.eval()
-    with torch.no_grad():
-        y_eval_a = m(x)
-        y_eval_b = m(x)
-    assert torch.equal(y_eval_a, y_eval_b)
-
-    # Train mode: SpecAugment is stochastic (random number of masks in
-    # ``[0, n_*_masks]``). Force the mask-count draws so the assertion is
-    # deterministic regardless of the global RNG / torchaudio versions —
-    # ``forward`` calls ``torch.randint(n+1, ())`` exactly twice (time
-    # then frequency); both must come back ``>= 1``.
-    m.train()
-    spec = m.spectrogram(x)
-    real_randint = torch.randint
-
-    def force_nonzero_count(*args, **kwargs):
+    def patched(*args, **kwargs):
         size = kwargs.get("size", args[1] if len(args) >= 2 else None)
         if size == ():
             return torch.tensor(2, dtype=torch.long)
-            # ``2`` is in [0, 3] (n_time_masks=3) and [0, 2] (n_freq_masks=2),
-            # so the spec_augment forward applies two time masks and two freq
-            # masks per call.
-        return real_randint(*args, **kwargs)
+        return real(*args, **kwargs)
 
-    with mock.patch("torch.randint", side_effect=force_nonzero_count):
-        aug_a = m.spec_augment(spec)
-        aug_b = m.spec_augment(spec)
-    assert not torch.equal(aug_a, spec), "SpecAugment must mutate the spectrogram"
-    assert not torch.equal(aug_a, aug_b), "SpecAugment must be stochastic"
+    return mock.patch("torch.randint", side_effect=patched)
 
-    # Per-(sample × band × electrode) independence contract — matches
-    # upstream ``emg2qwerty.transforms.SpecAugment`` (Sivakumar et al.
-    # Sec 5.2), which applies torchaudio ``iid_masks=True`` on a 4-D
-    # ``(bands, electrodes, freq, T)`` sample and so draws one mask
-    # per ``(band, electrode)`` pair. On a uniquely-valued tensor, at
-    # least one ``(B, band)`` row must show different mask patterns
-    # across its electrodes — i.e. masking must NOT be band-shared.
-    contiguous_spec = torch.arange(spec.numel(), dtype=spec.dtype).reshape(spec.shape)
-    with mock.patch("torch.randint", side_effect=force_nonzero_count):
-        contiguous_aug = m.spec_augment(contiguous_spec)
-    changed = contiguous_aug != contiguous_spec  # (T, B, num_bands, electrodes, freq)
-    n_electrodes = changed.shape[-2]
-    found_per_electrode_diff = False
-    for b in range(changed.shape[1]):
-        for band in range(changed.shape[2]):
-            ref = changed[:, b, band, 0, :]
-            for e in range(1, n_electrodes):
-                if not torch.equal(changed[:, b, band, e, :], ref):
-                    found_per_electrode_diff = True
-                    break
-            if found_per_electrode_diff:
-                break
-        if found_per_electrode_diff:
-            break
-    assert found_per_electrode_diff, (
-        "SpecAugment must produce per-(B, band, electrode) independent "
-        "masks (matches upstream emg2qwerty); every (B, band) row "
-        "showing identical masks across all electrodes indicates "
-        "band-shared masking, which is a regression."
+
+def test_emg2qwerty_spec_augment_contract():
+    """Built-in SpecAugment: train-only, per-electrode iid, parameter-free, round-trips."""
+    # ``spec_augment=False`` is the back-compat default and must wire an
+    # ``nn.Identity`` so existing checkpoints keep loading bit-for-bit.
+    assert isinstance(_small_emg2qwerty().spec_augment, torch.nn.Identity)
+
+    # Bad knobs rejected at construction time.
+    for bad in (
+        {"n_time_masks": -1},
+        {"time_mask_param": -1},
+        {"spec_augment_prob": 1.5},
+    ):
+        with pytest.raises(ValueError):
+            _small_emg2qwerty(spec_augment=True, **bad)
+
+    torch.manual_seed(0)
+    m = _small_emg2qwerty(
+        spec_augment=True, n_time_masks=3, time_mask_param=8,
+        n_freq_masks=2, freq_mask_param=4, spec_augment_prob=1.0,
+    )
+    x = torch.randn(2, 32, 500)
+
+    # Eval is deterministic (no SpecAugment sampling).
+    m.eval()
+    with torch.no_grad():
+        assert torch.equal(m(x), m(x))
+
+    # Train mutates the spectrogram and is stochastic between calls.
+    m.train()
+    spec = m.spectrogram(x)
+    with _force_two_randint():
+        aug_a, aug_b = m.spec_augment(spec), m.spec_augment(spec)
+    assert not torch.equal(aug_a, spec) and not torch.equal(aug_a, aug_b)
+
+    # Per-(B, band, electrode) iid masking: on a uniquely-valued tensor
+    # at least one (B, band) row must show distinct mask patterns across
+    # its electrodes — pinning the upstream ``emg2qwerty.transforms``
+    # recipe and guarding against any future band-shared regression.
+    distinct = torch.arange(spec.numel(), dtype=spec.dtype).reshape(spec.shape)
+    with _force_two_randint():
+        aug = m.spec_augment(distinct)
+    # ``changed`` shape: (B, num_bands, electrodes, freq*T_spec) after
+    # moving time-axis to the trailing flatten. Compare each electrode's
+    # bool grid against electrode-0 within the same (B, band) row.
+    changed = (aug != distinct).movedim(0, -1).flatten(start_dim=3)
+    same_as_e0 = (changed == changed[:, :, :1]).all(dim=-1)
+    assert not same_as_e0.all(), "SpecAugment masking must not be band-shared"
+
+    # Parameter-free (no new state-dict keys) and round-trips via
+    # ``from_config`` so reloaded models reproduce the augmentation recipe.
+    allowed = ("model.0.", "model.1.", "model.3.", "final_layer.")
+    assert all(k.startswith(allowed) for k in m.state_dict())
+    cfg = m.get_config()
+    assert cfg["spec_augment"] and cfg["time_mask_param"] == 8
+    assert isinstance(
+        EMG2QwertyNet.from_config(cfg).spec_augment, type(m.spec_augment)
     )
 
-    # No new state-dict keys.
-    keys = list(m.state_dict().keys())
-    allowed = ("model.0.", "model.1.", "model.3.", "final_layer.")
-    assert not [k for k in keys if not k.startswith(allowed)]
 
-    # Round-trip via ``get_config`` keeps SpecAugment enabled with the
-    # same kwargs (so reloaded models reproduce the augmentation recipe).
-    cfg = m.get_config()
-    assert cfg["spec_augment"] is True
-    assert cfg["time_mask_param"] == 8
-    m2 = EMG2QwertyNet.from_config(cfg)
-    assert isinstance(m2.spec_augment, type(m.spec_augment))
-
-
-def test_emg2qwerty_spec_augment_disabled_default():
-    """Default ``spec_augment=False`` builds an Identity passthrough.
-
-    The default model must be backward-compatible: SpecAugment off, no
-    new state-dict keys, and forward in train mode is deterministic
-    modulo BatchNorm running stats (which we sidestep by checking
-    ``spec_augment`` directly).
-    """
-    m = _small_emg2qwerty()
-    assert isinstance(m.spec_augment, torch.nn.Identity)
-
-    m.train()
-    x = torch.randn(2, 32, 500)
-    spec = m.spectrogram(x)
-    out = m.spec_augment(spec)
-    assert torch.equal(out, spec)
-
-
-def test_emg2qwerty_spec_augment_validation():
-    """SpecAugment constructor rejects out-of-range parameters."""
-    with pytest.raises(ValueError, match="n_time_masks"):
-        _small_emg2qwerty(spec_augment=True, n_time_masks=-1)
-    with pytest.raises(ValueError, match="time_mask_param"):
-        _small_emg2qwerty(spec_augment=True, time_mask_param=-1)
-    with pytest.raises(ValueError, match="prob"):
-        _small_emg2qwerty(spec_augment=True, spec_augment_prob=1.5)
-
-
-def test_emg2qwerty_return_features_dict_layout():
-    """``forward(x, return_features=True)`` matches BIOT/signal-JEPA convention.
-
-    The downstream feature-extraction path used by neuroai's
-    ``DownstreamWrapperModel(model_output_key="features")``: the model
-    returns a dict with a batch-first ``(B, T_out, num_features)``
-    tensor under ``"features"`` and a placeholder ``"cls_token": None``.
-    Default ``return_features=False`` must still return the emissions
-    tensor unchanged for backward compatibility.
-    """
-    torch.manual_seed(0)
+def test_emg2qwerty_feature_flags():
+    """Three forward paths: default emissions tensor, runtime dict, init tuple."""
     mlp_features = (48,)
-    num_bands = 2
-    expected_num_features = num_bands * mlp_features[-1]
-
-    m = _small_emg2qwerty(mlp_features=mlp_features).eval()
+    num_features = 2 * mlp_features[-1]  # num_bands × mlp_features[-1]
     x = torch.randn(2, 32, 500)
+
+    # Default: emissions tensor, ``(B, T_out, n_outputs)``.
+    m = _small_emg2qwerty(mlp_features=mlp_features).eval()
     with torch.no_grad():
         emissions = m(x)
         bundle = m(x, return_features=True)
+    assert isinstance(emissions, torch.Tensor) and emissions.shape[2] == 99
 
-    # Default branch: tensor of emissions, unchanged.
-    assert isinstance(emissions, torch.Tensor)
-    assert emissions.shape[0] == 2 and emissions.shape[2] == 99
-
-    # Feature branch: dict with the expected key set and the encoder
-    # representation pre-final_layer (so it does *not* match emissions).
-    assert isinstance(bundle, dict)
-    assert set(bundle.keys()) == {"features", "cls_token"}
-    assert bundle["cls_token"] is None
+    # Runtime ``return_features=True`` → dict (BIOT / signal-JEPA convention).
+    # ``features`` must be the pre-classifier representation, so applying
+    # ``final_layer`` to it reproduces the emissions tensor.
+    assert set(bundle) == {"features", "cls_token"} and bundle["cls_token"] is None
     feats = bundle["features"]
-    assert feats.shape == (2, emissions.shape[1], expected_num_features)
-    # Sanity: features must be the input to ``final_layer`` (so applying
-    # the head reproduces the emissions tensor up to log-softmax).
-    head_out = m.final_layer(feats)
-    assert torch.allclose(head_out, emissions, atol=1e-5)
+    assert feats.shape == (2, emissions.shape[1], num_features)
+    assert torch.allclose(m.final_layer(feats), emissions, atol=1e-5)
 
-
-def test_emg2qwerty_return_feature_init_tuple():
-    """``return_feature=True`` (init kwarg) yields a BIOT-style tuple.
-
-    Configuration-driven downstream wrappers (neuroai's
-    ``DownstreamWrapperModel`` with ``model_output_key=1``) call
-    ``model(**dummy_batch)`` without runtime kwargs, so the model has to
-    expose the encoder representation through its default forward path
-    too. Mirrors :class:`braindecode.models.BIOT`'s legacy
-    ``return_feature=True`` init flag: ``forward(x)`` returns
-    ``(emissions, features)``. Runtime ``return_features=True`` (dict)
-    keeps winning when both are set.
-    """
-    torch.manual_seed(0)
-    mlp_features = (48,)
-    num_bands = 2
-    expected_num_features = num_bands * mlp_features[-1]
-
-    m = _small_emg2qwerty(mlp_features=mlp_features, return_feature=True).eval()
-    x = torch.randn(2, 32, 500)
-
+    # Init ``return_feature=True`` → ``(emissions, features)`` tuple — the
+    # config-driven path neuroai's ``DownstreamWrapperModel`` uses with
+    # ``model_output_key=1``. Runtime dict flag still wins, ``get_config``
+    # round-trips, and ``get_output_shape`` keeps reporting the emissions
+    # shape regardless of the flag.
+    m_t = _small_emg2qwerty(mlp_features=mlp_features, return_feature=True).eval()
     with torch.no_grad():
-        out = m(x)
-    assert isinstance(out, tuple) and len(out) == 2
-    emissions, features = out
-    assert emissions.shape[0] == 2 and emissions.shape[2] == 99
-    assert features.shape == (2, emissions.shape[1], expected_num_features)
-    # Same content invariant as the dict path.
-    assert torch.allclose(m.final_layer(features), emissions, atol=1e-5)
-
-    # Runtime dict flag wins over init tuple flag.
-    with torch.no_grad():
-        bundle = m(x, return_features=True)
-    assert isinstance(bundle, dict)
-    assert torch.equal(bundle["features"], features)
-
-    # Round-trip: ``return_feature`` survives ``get_config`` so reloaded
-    # models keep the same wrapper-compatible output shape.
-    cfg = m.get_config()
-    assert cfg["return_feature"] is True
-    m2 = EMG2QwertyNet.from_config(cfg)
-    with torch.no_grad():
-        out2 = m2(x)
-    assert isinstance(out2, tuple) and len(out2) == 2
-
-    # ``get_output_shape`` must keep reporting the emissions shape, not
-    # the tuple itself, so braindecode's introspection helpers don't
-    # break for callers who flip this flag.
-    assert m.get_output_shape() == (1, emissions.shape[1], 99)
+        out_t = m_t(x)
+        bundle_t = m_t(x, return_features=True)
+    assert isinstance(out_t, tuple) and out_t[1].shape == feats.shape
+    assert isinstance(bundle_t, dict) and torch.equal(bundle_t["features"], out_t[1])
+    assert m_t.get_config()["return_feature"] is True
+    assert m_t.get_output_shape() == (1, emissions.shape[1], 99)


### PR DESCRIPTION
## Summary

Move emg2qwerty's SpecAugment from a Lightning callback into `EMG2QwertyNet` itself, and expose the encoder representation through two BIOT-style feature-extraction flags so downstream wrappers (e.g. neuroai's `DownstreamWrapperModel`) can drop in without a custom hook.

- **`spec_augment` (init kwarg, default `False`)** — installs a parameter-free `_SpecAugment` submodule between the log-spectrogram and BatchNorm. Active only in `train()`; default builds an `nn.Identity`, so state-dict layout and existing checkpoints are bit-identical. Knobs match the paper (Sivakumar et al. NeurIPS 2024, Sec 5.2): `n_time_masks=3`, `time_mask_param=25`, `n_freq_masks=2`, `freq_mask_param=4`, `spec_augment_prob=1.0`. Per-`(sample × band × electrode)` IID masking via `torchaudio.transforms.{Time,Frequency}Masking(iid_masks=True)` on the 5-D `(B, num_bands, electrodes, freq, T_spec)` tensor — same recipe as the upstream `emg2qwerty/transforms.py:SpecAugment` dataset transform. `mask_value` stays a 0-D on-device tensor (no host sync on GPU).
- **`return_features=True` (runtime kwarg)** → `{"features": (B, T_out, num_features), "cls_token": None}` dict, BIOT / signal-JEPA convention.
- **`return_feature=True` (init kwarg, BIOT legacy)** → default forward returns `(emissions, features)` tuple, so YAML-driven wrappers can pick up features via `model_output_key=1` without runtime kwargs.

## Test plan

`pytest test/unit_tests/models/test_models.py -k emg2qwerty` — 6 passing (4 pre-existing + 2 new):

- `test_emg2qwerty_spec_augment_contract` — eval determinism, train mutation + stochasticity, per-`(B, band, electrode)` IID (NOT band-shared, regression guard), zero state-dict footprint, constructor validation, `from_config` round-trip.
- `test_emg2qwerty_feature_flags` — all three forward paths (default tensor / runtime dict / init tuple), runtime-wins-over-init, `get_config` round-trip, `get_output_shape` invariant.

## Notes for reviewers

- All review comments resolved (5 threads). Codex's "band-shared masking" P2 was reverted after re-auditing upstream `emg2qwerty/transforms.py` — the paper recipe is per-electrode IID; band-shared was a 16× under-augmentation regression.
- `_SpecAugment` is `_`-prefixed and intentionally not re-exported — only the constructor flag is public, mirroring `_LogSpectrogram` / `_SpectrogramNorm`.
- No new dependencies; reuses `torchaudio.transforms` already imported for the STFT.