### PR TITLE
augmentation: Fix AmplitudeScale crashing on default random_state + more

### DIFF
--- a/braindecode/augmentation/functional.py
+++ b/braindecode/augmentation/functional.py
@@ -2,6 +2,7 @@
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Gustavo Rodrigues <gustavenrique01@gmail.com>
 #          Bruna Lopes <brunajaflopes@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -1265,10 +1266,11 @@ def amplitude_scale(
     y : torch.Tensor
         EEG labels for the example or batch.
     scale : tuple of floats
-        Interval from which ypu sample the scaling value
-    random_state : int | numpy.random.Generator, optional
-        Seed to be used to instantiate numpy random number generator instance.
-        Defaults to None.
+        Interval ``(low, high)`` from which the per (sample, channel)
+        scaling value is uniformly sampled.
+    random_state : int | numpy.random.RandomState | None, optional
+        Seed used to instantiate the numpy random number generator that
+        draws the scaling values. Defaults to None.
 
     Returns
     -------
@@ -1285,14 +1287,17 @@ def amplitude_scale(
         Learning Research 136:238-253
     """
 
-    rng = torch.Generator()
-    rng.manual_seed(random_state)
+    # use the same numpy rng path as the rest of this module. the previous
+    # torch.Generator + manual_seed path crashed on None and on the
+    # numpy RandomState that Transform passes in via self.rng.
+    rng = check_random_state(random_state)
     batch_size, n_channels, _ = X.shape
 
-    # Parameter for scaling amplitude / channel / trial
     l, h = scale
-    s = l + (h - l) * torch.rand(
-        batch_size, n_channels, 1, generator=rng, device=X.device, dtype=X.dtype
+    s = torch.as_tensor(
+        rng.uniform(low=l, high=h, size=(batch_size, n_channels, 1)),
+        device=X.device,
+        dtype=X.dtype,
     )
 
     X = s * X

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1143,7 +1143,7 @@ Authors
 .. _Kuntal Kokate: https://github.com/Kkuntal990
 .. _GalAshkenazi1: https://github.com/GalAshkenazi1
 .. _Matthew Chen: https://github.com/MatthewChen37
-.. _Jonathan Dan: https://github.com/danjjl
+.. _Jonathan Dan: https://github.com/jon-dan
 .. _Jonathan Lys: https://github.com/jonathanlys01
 .. _Thorir Mar Ingolfsson: https://github.com/Thoriri
 .. _Aniela Bulicz: https://github.com/AryaDro

--- a/test/unit_tests/augmentation/test_functional.py
+++ b/test/unit_tests/augmentation/test_functional.py
@@ -111,6 +111,25 @@ def test_amplitude_scale():
     assert torch.equal(transformed_X0, torch.zeros_like(X))
 
 
+def test_amplitude_scale_random_state_variants():
+    # regression for None default and numpy RandomState input
+    import numpy as np
+
+    X = torch.rand((3, 4, 50))
+    y = torch.zeros(3)
+    scale = (0.5, 2.0)
+
+    out_none, _ = amplitude_scale(X, y, scale, random_state=None)
+    assert out_none.shape == X.shape
+
+    out_rs, _ = amplitude_scale(X, y, scale, random_state=np.random.RandomState(7))
+    assert out_rs.shape == X.shape
+
+    out_a, _ = amplitude_scale(X, y, scale, random_state=123)
+    out_b, _ = amplitude_scale(X, y, scale, random_state=123)
+    assert torch.equal(out_a, out_b)
+
+
 def test_band_rotation_shape_and_seed_reproducibility():
     # 2 bands × 8 electrodes/band; small T for fast assertions.  Force
     # ``band_offsets=(2,)`` so we get a deterministic non-zero rotation

--- a/test/unit_tests/augmentation/test_transforms.py
+++ b/test/unit_tests/augmentation/test_transforms.py
@@ -1,5 +1,6 @@
 # Authors: Cédric Rommel <cedric.rommel@inria.fr>
 #          Gustavo Rodrigues <gustavenrique01@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 import numpy as np
@@ -19,6 +20,7 @@ from braindecode.augmentation.functional import (
     sensors_rotation,
 )
 from braindecode.augmentation.transforms import (
+    AmplitudeScale,
     BandRotation,
     BandstopFilter,
     ChannelsDropout,
@@ -759,6 +761,23 @@ def test_mask_encoding_transform(
             assert np.sum(sample[0, :].detach().cpu().numpy() == 0) >= segment_length
 
 
+def test_amplitude_scale_transform_runs_with_default_random_state():
+    # class path used to crash in torch.Generator.manual_seed
+    X = torch.randn(4, 8, 50)
+    y = torch.zeros(4)
+
+    out_default, _ = AmplitudeScale(probability=1.0)(X, y)
+    assert out_default.shape == X.shape
+
+    out_seeded, _ = AmplitudeScale(probability=1.0, random_state=42)(X, y)
+    assert out_seeded.shape == X.shape
+
+    out_id, _ = AmplitudeScale(probability=1.0, interval=(1.0, 1.0), random_state=0)(
+        X, y
+    )
+    assert torch.equal(out_id, X)
+
+
 def test_band_rotation_transform_seed_reproducibility():
     """Two ``BandRotation`` instances built with the same seed produce
     bit-identical outputs on the same input."""
@@ -778,6 +797,7 @@ def test_band_rotation_transform_seed_reproducibility():
     "augmentation,kwargs",
     [
         (IdentityTransform, {"probability": 0.5}),
+        (AmplitudeScale, {"probability": 0.5}),
         (
             BandRotation,
             # random_batch is 22 channels → 2 bands × 11 electrodes


### PR DESCRIPTION
There are two unrelated drive-by fixes batched together.

## 1. AmplitudeScale class is dead on arrival

calling AmplitudeScale(probability=1.0) on a batch raises RuntimeError: manual_seed expected a long, but got numpy.random.mtrand.RandomState. the documented random_state=None default also blows up the same way (manual_seed expected a long, but got NoneType).

The root cause sits in amplitude_scale in braindecode/augmentation/functional.py. it builds a torch.Generator and feeds whatever the caller passed into manual_seed, which only accepts a python int. Transform.__init__ wraps random_state via check_random_state which produces a numpy RandomState, and that numpy RandomState gets handed straight in via get_augmentation_params. the class path was never exercised before, which is how the regression slipped in.

repro:

    >>> import torch
    >>> from braindecode.augmentation import AmplitudeScale
    >>> AmplitudeScale(probability=1.0)(torch.rand(4, 8, 100), torch.zeros(4))
    RuntimeError: manual_seed expected a long, but got numpy.random.mtrand.RandomState

The fix swaps the torch.Generator path with check_random_state + rng.uniform + torch.as_tensor, the same idiom used by every sibling function in this file (gaussian_noise, channels_shuffle, sensors_rotation, band_rotation, ...). int seeds keep reproducibility, numpy RandomState works, None works. docstring tightened to match what the function accepts.

## 2. broken 404 author link in docs
(viewable inside of the code for jon-dan Thank you!
closes #1017 