### PR TITLE
docs: fix broken contributor link

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1143,7 +1143,7 @@ Authors
 .. _Kuntal Kokate: https://github.com/Kkuntal990
 .. _GalAshkenazi1: https://github.com/GalAshkenazi1
 .. _Matthew Chen: https://github.com/MatthewChen37
-.. _Jonathan Dan: https://github.com/danjjl
+.. _Jonathan Dan: https://github.com/jon-dan
 .. _Jonathan Lys: https://github.com/jonathanlys01
 .. _Thorir Mar Ingolfsson: https://github.com/Thoriri
 .. _Aniela Bulicz: https://github.com/AryaDro


### PR DESCRIPTION
Summary
- Updates the `Jonathan Dan` contributor reference in `docs/whats_new.rst` from a 404 GitHub profile URL to the active `jon-dan` profile.
- Keeps the existing release note attribution and changes only the broken target URL.
- Addresses the single 404 reported in #1017.

Validation
- `git diff --check` passed.
- `Invoke-WebRequest -Method Head https://github.com/jon-dan` returned HTTP 200.
- `Invoke-WebRequest -Method Head https://github.com/danjjl` returned HTTP 404, matching the reported broken link.
- `lychee --version` was not available locally, so the full project link-check workflow was not run on this machine.

Notes
- Related issue: #1017.
- No runtime code or compatibility impact.
- No follow-up work expected for this one-link fix.