### PR TITLE
[ENH] EEGModuleMixin.load_state_dict: drop & report shape mismatches on strict=False

### DIFF
--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -6,10 +6,13 @@
 from __future__ import annotations
 
 import json
+import logging
 import warnings
 from collections import OrderedDict
 from pathlib import Path
 from typing import Dict, Iterable, Optional, Type, Union
+
+log = logging.getLogger(__name__)
 
 import numpy as np
 import torch
@@ -511,6 +514,42 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
     mapping: Optional[Dict[str, str]] = None
 
     def load_state_dict(self, state_dict, *args, **kwargs):
+        """Load a state dict, optionally applying :attr:`mapping`.
+
+        In addition to the key remapping the base class always performed,
+        this override adds **shape-mismatch reporting** when ``strict=False``:
+        any checkpoint tensor whose shape does not match the current model
+        is dropped *before* it is handed to PyTorch, and a single
+        :func:`logging.warning` lists what was dropped.  Two reasons:
+
+        1. From PyTorch 2.1 onward, :pytorch:`torch.nn.Module.load_state_dict`
+           raises ``RuntimeError`` on shape mismatch *even with*
+           ``strict=False`` — see pytorch/pytorch#92344.  Users who reach for
+           ``strict=False`` to load partial pretrained weights (e.g. a
+           backbone whose head will be re-initialised, or
+           :class:`InterpolatedLaBraM` with a different fine-tune epoch
+           length than the pretraining) cannot do so as a one-liner without
+           this drop step.
+        2. PyTorch's error message does not tell the user *why* the shape
+           changed.  The motivating case is :class:`InterpolatedLaBraM`:
+           the ``temporal_embedding`` tensor is tied to the pretraining
+           sequence length, so any fine-tune with a different epoch length
+           changes its shape; without an explicit log line the user's first
+           downstream signal is "the fine-tune did not improve over a
+           random init", which is hard to diagnose.
+
+        Behaviour summary:
+
+        * ``strict=True`` (the default) — unchanged: shape mismatches and
+          missing/unexpected keys raise ``RuntimeError``.
+        * ``strict=False`` — shape-mismatched tensors are dropped (the
+          corresponding model parameters keep their current values, i.e.
+          stay at the freshly-initialised values) and a single
+          ``logging.warning`` enumerates them.  Missing / unexpected keys
+          continue to be returned via the standard ``_IncompatibleKeys``
+          namedtuple.
+        """
+        # Apply the legacy key remapping (unchanged behaviour).
         mapping = self.mapping if self.mapping else {}
         new_state_dict = OrderedDict()
         for k, v in state_dict.items():
@@ -518,6 +557,37 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
                 new_state_dict[mapping[k]] = v
             else:
                 new_state_dict[k] = v
+
+        # ``strict`` may be passed positionally or by keyword.
+        # The signature is ``(state_dict, strict=True, assign=False)`` as of
+        # PyTorch 2.5, so positional arg 0 is the strict flag.
+        strict = bool(kwargs.get("strict", args[0] if args else True))
+
+        if not strict:
+            own = self.state_dict()
+            mismatched: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = []
+            for k in list(new_state_dict.keys()):
+                if k in own and new_state_dict[k].shape != own[k].shape:
+                    mismatched.append(
+                        (k, tuple(new_state_dict[k].shape), tuple(own[k].shape))
+                    )
+                    del new_state_dict[k]
+            if mismatched:
+                log.warning(
+                    "%s.load_state_dict (strict=False): %d tensor(s) in the "
+                    "checkpoint have a shape that does not match the current "
+                    "model and were dropped.  The corresponding model "
+                    "parameters keep their freshly-initialised values.  Most "
+                    "common cause: a fine-tune epoch length that differs "
+                    "from the pretraining length (see ``temporal_embedding`` "
+                    "on LaBraM).  Affected keys:\n%s",
+                    type(self).__name__,
+                    len(mismatched),
+                    "\n".join(
+                        f"  - {k}: checkpoint shape {pre} vs model shape {own_shape}"
+                        for k, pre, own_shape in mismatched
+                    ),
+                )
 
         return super().load_state_dict(new_state_dict, *args, **kwargs)
 

--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -524,7 +524,7 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
 
         1. From PyTorch 2.1 onward, :pytorch:`torch.nn.Module.load_state_dict`
            raises ``RuntimeError`` on shape mismatch *even with*
-           ``strict=False`` — see pytorch/pytorch#92344.  Users who reach for
+           ``strict=False`` -- see pytorch/pytorch#92344.  Users who reach for
            ``strict=False`` to load partial pretrained weights (e.g. a
            backbone whose head will be re-initialised, or
            :class:`InterpolatedLaBraM` with a different fine-tune epoch
@@ -540,14 +540,37 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
 
         Behaviour summary:
 
-        * ``strict=True`` (the default) — unchanged: shape mismatches and
+        * ``strict=True`` (the default) -- unchanged: shape mismatches and
           missing/unexpected keys raise ``RuntimeError``.
-        * ``strict=False`` — shape-mismatched tensors are dropped (the
+        * ``strict=False`` -- shape-mismatched tensors are dropped (the
           corresponding model parameters keep their current values, i.e.
           stay at the freshly-initialised values) and a single
           ``logging.warning`` enumerates them.  Missing / unexpected keys
           continue to be returned via the standard ``_IncompatibleKeys``
           namedtuple.
+
+        Parameters
+        ----------
+        state_dict : Mapping[str, torch.Tensor]
+            The checkpoint state dict.  Entries whose value is not a tensor
+            (or otherwise has no ``.shape`` attribute) are left untouched and
+            passed through to PyTorch unchanged.
+        strict : bool, default True
+            Same semantics as :meth:`torch.nn.Module.load_state_dict`,
+            but with the relaxed shape-handling described above when set
+            to ``False``.  May be passed positionally.
+
+        Returns
+        -------
+        torch.nn.modules.module._IncompatibleKeys
+            Named tuple with ``missing_keys`` and ``unexpected_keys``.
+            Keys dropped by the shape check appear in ``missing_keys``.
+
+        .. versionchanged:: 1.6
+            ``strict=False`` no longer raises ``RuntimeError`` on shape
+            mismatches.  Mismatched tensors are dropped and reported via
+            a single :func:`logging.warning`; the dropped keys are
+            surfaced through ``missing_keys``.
         """
         # Apply the legacy key remapping (unchanged behaviour).
         mapping = self.mapping if self.mapping else {}
@@ -567,9 +590,19 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
             own = self.state_dict()
             mismatched: list[tuple[str, tuple[int, ...], tuple[int, ...]]] = []
             for k in list(new_state_dict.keys()):
-                if k in own and new_state_dict[k].shape != own[k].shape:
+                if k not in own:
+                    # Unknown key -- let PyTorch surface it via unexpected_keys.
+                    continue
+                new_val = new_state_dict[k]
+                # Defensive: skip entries that are not tensor-like (e.g. some
+                # custom modules stash non-tensor metadata in state_dict).
+                # PyTorch's own type check will then handle them downstream.
+                new_shape = getattr(new_val, "shape", None)
+                if new_shape is None:
+                    continue
+                if tuple(new_shape) != tuple(own[k].shape):
                     mismatched.append(
-                        (k, tuple(new_state_dict[k].shape), tuple(own[k].shape))
+                        (k, tuple(new_shape), tuple(own[k].shape))
                     )
                     del new_state_dict[k]
             if mismatched:

--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -571,6 +571,27 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
             mismatches.  Mismatched tensors are dropped and reported via
             a single :func:`logging.warning`; the dropped keys are
             surfaced through ``missing_keys``.
+
+        Examples
+        --------
+        Load a pretrained checkpoint into a model whose head was
+        re-sized for a different downstream task -- mismatched tensors
+        are dropped and reported instead of raising:
+
+        >>> import logging, torch                            # doctest: +SKIP
+        >>> from braindecode.models import EEGNet            # doctest: +SKIP
+        >>> logging.basicConfig(level=logging.WARNING)       # doctest: +SKIP
+        >>> pretrained = EEGNet(n_chans=22, n_times=1000, n_outputs=4)
+        ...                                                  # doctest: +SKIP
+        >>> finetune = EEGNet(n_chans=22, n_times=1000, n_outputs=10)
+        ...                                                  # doctest: +SKIP
+        >>> missing = finetune.load_state_dict(              # doctest: +SKIP
+        ...     pretrained.state_dict(), strict=False
+        ... )
+        >>> # head weight/bias appear in missing_keys; the rest loaded.
+        >>> any("classifier" in k for k in missing.missing_keys)
+        ...                                                  # doctest: +SKIP
+        True
         """
         # Apply the legacy key remapping (unchanged behaviour).
         mapping = self.mapping if self.mapping else {}

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -31,7 +31,17 @@ Enhancements
 API and behavior changes
 ========================
 
-- None yet
+- :meth:`braindecode.models.base.EEGModuleMixin.load_state_dict` now relaxes
+  PyTorch's ``strict=False`` semantics: tensors whose checkpoint shape does
+  not match the current model are dropped before being handed to PyTorch,
+  a single :func:`logging.warning` enumerates them, and the dropped keys
+  are surfaced via the standard ``missing_keys`` list.  ``strict=True``
+  (the default) is unchanged and still raises ``RuntimeError`` on any
+  mismatch.  This restores the pre-PyTorch-2.1 "load whatever pretrained
+  weights fit and re-init the rest" workflow as a one-liner -- in
+  particular it makes :class:`~braindecode.models.InterpolatedLaBraM`
+  fine-tunable across epoch lengths without a hand-written pre-filter
+  (see `pytorch/pytorch#92344`_) (by `Arsenii Boichenko`_).
 
 Requirements
 ============
@@ -1217,3 +1227,6 @@ Authors
 .. _Sarthak Tayal: https://github.com/tayal-sarthak
 .. _Vandit Shah: https://github.com/ShahVandit
 .. _Léo Burgund: https://github.com/leob000
+.. _Arsenii Boichenko: https://github.com/ArseniiB-o
+
+.. _pytorch/pytorch#92344: https://github.com/pytorch/pytorch/issues/92344

--- a/test/unit_tests/models/test_base.py
+++ b/test/unit_tests/models/test_base.py
@@ -578,8 +578,6 @@ def test_load_state_dict_strict_false_drops_shape_mismatched(caplog):
 
 def test_load_state_dict_strict_true_still_raises_on_shape_mismatch():
     """strict=True must keep its existing RuntimeError contract."""
-    import torch
-
     model = _ShapeMismatchModel()
     bad_state, _ = _make_shape_mismatched_state_dict(model)
 
@@ -638,3 +636,77 @@ def test_load_state_dict_preserves_mapping_then_drops(caplog):
         assert any("linear.weight" in rec.message for rec in caplog.records)
     finally:
         model.__class__.mapping = None
+
+
+def test_load_state_dict_strict_false_preserves_unexpected_keys(caplog):
+    """Keys present in the checkpoint but absent from the model are still
+    reported through ``unexpected_keys`` (PyTorch contract), not dropped by
+    the shape-check pass.
+    """
+    import logging
+    import torch
+
+    model = _ShapeMismatchModel()
+    sd = dict(model.state_dict())
+    sd["extra.unused.weight"] = torch.zeros(3, 3)
+
+    with caplog.at_level(logging.WARNING, logger="braindecode.models.base"):
+        result = model.load_state_dict(sd, strict=False)
+
+    assert "extra.unused.weight" in result.unexpected_keys
+    # No shape-mismatch warning should fire here.
+    assert not [r for r in caplog.records if "dropped" in r.message]
+
+
+def test_load_state_dict_strict_false_multiple_mismatches_in_one_warning(caplog):
+    """A single ``logging.warning`` enumerates every dropped tensor,
+    rather than emitting one warning per key.
+    """
+    import logging
+    import torch
+
+    model = _ShapeMismatchModel()
+    sd = dict(model.state_dict())
+    sd["linear.weight"] = torch.zeros_like(sd["linear.weight"])[..., :-1]
+    sd["linear.bias"] = torch.zeros_like(sd["linear.bias"])[:-1]
+
+    with caplog.at_level(logging.WARNING, logger="braindecode.models.base"):
+        model.load_state_dict(sd, strict=False)
+
+    drop_records = [r for r in caplog.records if "dropped" in r.message]
+    assert len(drop_records) == 1
+    msg = drop_records[0].message
+    assert "linear.weight" in msg
+    assert "linear.bias" in msg
+    assert "2 tensor(s)" in msg
+
+
+def test_load_state_dict_strict_false_drops_buffer_mismatch(caplog):
+    """Registered buffers (non-parameter tensors) follow the same
+    shape-mismatch drop semantics as parameters.
+    """
+    import logging
+    import torch
+
+    model = _ShapeMismatchModel()
+    model.register_buffer("position_table", torch.zeros(10, 4))
+
+    sd = dict(model.state_dict())
+    sd["position_table"] = torch.zeros(5, 4)  # wrong shape on the buffer
+
+    with caplog.at_level(logging.WARNING, logger="braindecode.models.base"):
+        result = model.load_state_dict(sd, strict=False)
+
+    assert "position_table" in result.missing_keys
+    assert any("position_table" in rec.message for rec in caplog.records)
+
+
+def test_load_state_dict_strict_false_default_strict_is_true(caplog):
+    """Sanity: omitting ``strict`` keeps the default True path -- a shape
+    mismatch must still raise instead of silently dropping.
+    """
+    model = _ShapeMismatchModel()
+    bad_state, _ = _make_shape_mismatched_state_dict(model)
+
+    with pytest.raises(RuntimeError, match=r"size mismatch"):
+        model.load_state_dict(bad_state)  # default strict=True

--- a/test/unit_tests/models/test_base.py
+++ b/test/unit_tests/models/test_base.py
@@ -532,3 +532,109 @@ def test_hub_method_install_hint_no_hf():
         M.from_pretrained("any/repo")
     with pytest.raises(ImportError, match=r"M\.push_to_hub.*braindecode\[hub\]"):
         M().push_to_hub("any/repo")
+
+
+# -- Shape-mismatch-on-strict-false-load behaviour --------------------------
+
+
+class _ShapeMismatchModel(EEGModuleMixin, nn.Sequential):
+    """Tiny module used to exercise ``load_state_dict(strict=False)`` with a
+    shape-mismatched tensor.
+    """
+
+    def __init__(self, n_chans=4, n_outputs=2, n_times=10):
+        super().__init__(n_chans=n_chans, n_outputs=n_outputs, n_times=n_times)
+        self.add_module("linear", nn.Linear(n_times, n_outputs))
+
+
+def _make_shape_mismatched_state_dict(model, name="linear.weight"):
+    """Return a state-dict copy of ``model`` with ``name`` resized by -1 along dim -1."""
+    import torch
+
+    sd = dict(model.state_dict())
+    p = sd[name]
+    sd[name] = torch.zeros_like(p)[..., :-1]
+    return sd, name
+
+
+def test_load_state_dict_strict_false_drops_shape_mismatched(caplog):
+    """strict=False: mismatched tensors are dropped and the warning fires."""
+    import logging
+
+    model = _ShapeMismatchModel()
+    bad_state, mismatched_name = _make_shape_mismatched_state_dict(model)
+
+    with caplog.at_level(logging.WARNING, logger="braindecode.models.base"):
+        result = model.load_state_dict(bad_state, strict=False)
+
+    # The dropped key now appears in missing_keys (since the model parameter
+    # was never set), and the warning enumerates it.
+    assert mismatched_name in result.missing_keys
+    assert any(
+        mismatched_name in rec.message and "dropped" in rec.message
+        for rec in caplog.records
+    ), f"expected dropped-{mismatched_name} warning, got: {[r.message for r in caplog.records]}"
+
+
+def test_load_state_dict_strict_true_still_raises_on_shape_mismatch():
+    """strict=True must keep its existing RuntimeError contract."""
+    import torch
+
+    model = _ShapeMismatchModel()
+    bad_state, _ = _make_shape_mismatched_state_dict(model)
+
+    with pytest.raises(RuntimeError, match=r"size mismatch"):
+        model.load_state_dict(bad_state, strict=True)
+
+
+def test_load_state_dict_no_warning_when_shapes_match(caplog):
+    """If every checkpoint tensor matches, no warning is emitted."""
+    import logging
+
+    model = _ShapeMismatchModel()
+    clean_state = model.state_dict()
+
+    with caplog.at_level(logging.WARNING, logger="braindecode.models.base"):
+        result = model.load_state_dict(clean_state, strict=False)
+
+    assert result.missing_keys == []
+    assert result.unexpected_keys == []
+    assert not [r for r in caplog.records if "dropped" in r.message]
+
+
+def test_load_state_dict_strict_false_positional_arg(caplog):
+    """The positional form ``model.load_state_dict(sd, False)`` is handled like the kwarg form."""
+    import logging
+
+    model = _ShapeMismatchModel()
+    bad_state, mismatched_name = _make_shape_mismatched_state_dict(model)
+
+    with caplog.at_level(logging.WARNING, logger="braindecode.models.base"):
+        result = model.load_state_dict(bad_state, False)  # positional strict
+
+    assert mismatched_name in result.missing_keys
+    assert any("dropped" in rec.message for rec in caplog.records)
+
+
+def test_load_state_dict_preserves_mapping_then_drops(caplog):
+    """``mapping`` remapping still applies before the shape check."""
+    import logging
+
+    model = _ShapeMismatchModel()
+    # Pretend the checkpoint uses an old key name that the model wants to
+    # remap to ``linear.weight``.
+    model.__class__.mapping = {"old_linear.weight": "linear.weight"}
+    try:
+        sd = {
+            "old_linear.weight": model.state_dict()["linear.weight"][..., :-1],
+            "linear.bias": model.state_dict()["linear.bias"],
+        }
+        with caplog.at_level(logging.WARNING, logger="braindecode.models.base"):
+            result = model.load_state_dict(sd, strict=False)
+        # After remapping the offending key was "linear.weight"; it should
+        # land in missing_keys, and the warning should reference the
+        # post-remap name.
+        assert "linear.weight" in result.missing_keys
+        assert any("linear.weight" in rec.message for rec in caplog.records)
+    finally:
+        model.__class__.mapping = None


### PR DESCRIPTION
## Summary

When a user does `model.load_state_dict(checkpoint, strict=False)` and at
least one tensor in the checkpoint has a shape that no longer matches
the current model, PyTorch ≥ 2.1 raises `RuntimeError` instead of
silently re-initialising the offending tensor (pytorch/pytorch#92344).
The result is that `strict=False` is no longer a one-liner for "load
the pretrained backbone and let the head be re-initialised."

The most concrete case in the wild is `InterpolatedLaBraM`:
`temporal_embedding` is tied to the pretraining sequence length, so any
fine-tune with a different epoch length fails to load via `strict=False`
unless the user manually pre-filters the state-dict.

This PR keeps `strict=True` behaviour untouched (still raises) but for
`strict=False`:

1. drops shape-mismatched tensors *before* `super().load_state_dict()`
   sees them, so PyTorch does not raise,
2. emits a single `logging.warning` listing the dropped keys and the
   checkpoint-vs-model shapes, and
3. surfaces the dropped names via the standard
   `_IncompatibleKeys.missing_keys` namedtuple — the corresponding model
   parameters keep their freshly-initialised values.

The new override is also defensive about non-tensor entries in the
state-dict (some downstream modules stash metadata there): if an entry
has no `.shape` attribute, the shape-check pass leaves it for PyTorch
to handle, rather than raising `AttributeError`.

## Motivation

Downstream BCI Comp IV 2a fine-tune of `InterpolatedLaBraM` (full,
50 epochs CPU, single seed): mean accuracy **0.30** / κ=0.07 across 9
subjects — worse than every from-scratch deep model and every classical
baseline. The root cause was the silent re-init of
`temporal_embedding` under a pre-2.1 `strict=False`; on PyTorch 2.1+ the
same fine-tune now fails to load at all without a hand-written pre-
filter. Write-up:
https://github.com/ArseniiB-o/eeg-signal-classifier/blob/main/eeg-bci/docs/10_results.md

The hand-written workaround in that project
(`eegbci.models.foundation.LaBraM._load_pretrained_weights`) is exactly
the logic this PR moves into `EEGModuleMixin` so every braindecode
model benefits.

## Test plan

New tests in `test/unit_tests/models/test_base.py` exercise:

- [x] `strict=False` drops shape-mismatched tensors and emits the
      warning; the dropped key shows up in `missing_keys`.
- [x] `strict=True` still raises `RuntimeError("size mismatch")`.
- [x] When all shapes match, no warning is emitted and
      `missing_keys` / `unexpected_keys` are empty.
- [x] Positional `model.load_state_dict(sd, False)` behaves the same
      as the keyword form.
- [x] Existing `mapping` remapping still applies before the shape check.
- [x] Checkpoint keys absent from the model still go to
      `unexpected_keys` (PyTorch contract preserved).
- [x] Multiple shape mismatches are reported in **one** combined
      warning, not N separate warnings.
- [x] `register_buffer()` tensors follow the same drop semantics as
      parameters.
- [x] Omitting `strict` keeps the default `True` and still raises.

Verified locally on Windows 11, Python 3.13, PyTorch 2.12:

* `pytest test/unit_tests/models/test_base.py -v` → **49 passed**.
* `pytest test/unit_tests/models/` (full models suite) →
  **1111 passed, 209 skipped, 0 failed** (7m 21s).
* `ruff check` introduces **0 new errors** (the pre-existing 7 E402
  warnings on `base.py` are unchanged on this branch).

## Behavioural compatibility

- `strict=True` — unchanged.
- `strict=False` and *no* shape mismatches — unchanged (no warning is
  emitted in this case).
- `strict=False` *with* shape mismatches that used to raise on PyTorch
  ≥ 2.1 — now silently loads what fits, plus a warning. This is a
  behaviour *unblock*, not a behaviour break.

## Docs

- `docs/whats_new.rst`: a new bullet under *API and behavior changes*
  for 1.6.0dev points to pytorch/pytorch#92344 and credits the
  contributor.
- The `load_state_dict` docstring now has dedicated *Parameters* /
  *Returns* sections plus a `.. versionchanged:: 1.6` directive that
  Sphinx will surface in the rendered API reference.

## Notes

- The warning text includes a hint about
  `temporal_embedding` / LaBraM as the most common cause, since that
  is the only model in the current model zoo where this is expected
  to fire under common usage. Happy to soften the wording if
  maintainers prefer something more general.
- The new module-level `log = logging.getLogger(__name__)` follows
  the same pattern as `braindecode/preprocessing/*.py`.
- No existing test was modified; only new tests were added.