### PR TITLE
Add monthly automated PyPI stable release workflow

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -1,39 +1,19 @@
 name: Monthly stable release to PyPI
 
-# Cuts a stable braindecode release on the first of every month, in addition
-# to the per-push ``.devN`` releases produced by ``.github/workflows/release.yml``.
+# Cuts a stable braindecode release on the 1st of every month, alongside the
+# per-push ``.devN`` releases produced by ``.github/workflows/release.yml``.
+# Pushes commits + tag atomically BEFORE publishing to PyPI so a push failure
+# can never leave PyPI ahead of git.
 #
-# Flow on each run:
-#   1. Compute the planned release + next-dev versions from ``braindecode/version.py``.
-#   2. Bail out early if no commits landed on master since the last ``v*`` tag.
-#   3. Strip the ``dev0`` suffix, mark the ``whats_new.rst`` heading with today's
-#      date, commit ``release: vX.Y.0``, and create an annotated tag.
-#   4. Build sdist + wheel, ``twine check``, publish to PyPI.
-#   5. Bump ``version.py`` to the next ``dev0`` cycle and add a fresh
-#      ``Current X.Y.Z (GitHub)`` section to the changelog.
-#   6. Push both commits and the tag, then cut a GitHub Release.
-#
-# The companion dev-release workflow (``release.yml``) carries a defensive
-# guard that skips publishing ``X.Y.Z.devN`` when the head commit message
-# starts with ``release: v``. In the normal flow that guard is unreachable
-# because by GitHub Actions policy a push authenticated with the default
-# ``GITHUB_TOKEN`` does NOT trigger another workflow run (anti-recursion
-# safeguard) — so neither the release commit nor the bump commit will fire
-# ``release.yml`` at all. The first ``.devN`` of the new cycle will appear
-# the next time a human (or a PAT-authenticated bot) pushes to master.
-# If you want the bump commit to immediately seed the next dev cycle on PyPI,
-# replace ``token: ${{ secrets.GITHUB_TOKEN }}`` in the checkout step with a
-# PAT (``RELEASE_PUSH_TOKEN``), which DOES trigger downstream workflows.
-#
-# Requirements on the repository side:
-#   - ``PYPI_API_TOKEN`` secret (already used by the dev-release workflow). The
-#     long-term plan is to migrate to PyPI Trusted Publishing (OIDC) by adding
-#     a publisher on PyPI and removing the ``password`` argument below; the
-#     ``id-token: write`` permission is already declared for that day.
+# Requirements:
+#   - ``PYPI_API_TOKEN`` secret (shared with the dev-release workflow).
 #   - The default ``GITHUB_TOKEN`` must be allowed to push to ``master``. If
-#     branch protection blocks bot pushes, either add ``github-actions[bot]``
-#     to the bypass list or swap ``token`` in the checkout step for a PAT
+#     branch protection blocks bot pushes, add ``github-actions[bot]`` to the
+#     bypass list, or replace ``token:`` in the checkout step with a PAT
 #     stored as ``RELEASE_PUSH_TOKEN``.
+#   - Note: pushes authenticated with the default ``GITHUB_TOKEN`` do NOT
+#     trigger ``release.yml``, so the first ``.devN`` of the new cycle lands
+#     only on the next human push (use a PAT to opt in to immediate seeding).
 
 on:
   schedule:
@@ -109,15 +89,6 @@ jobs:
           python scripts/monthly_release.py compute --bump "$BUMP" \
             | tee -a "$GITHUB_OUTPUT"
 
-      - name: Print release plan
-        run: |
-          echo "Current dev:  ${{ steps.ver.outputs.current_version }}"
-          echo "Release:      ${{ steps.ver.outputs.release_version }}"
-          echo "Tag:          ${{ steps.ver.outputs.release_tag }}"
-          echo "Next dev:     ${{ steps.ver.outputs.next_dev_version }}"
-          echo "Bump:         ${BUMP}"
-          echo "Dry run:      ${DRY_RUN}"
-
       - name: Skip if no commits since last tag
         id: changes
         shell: bash
@@ -176,23 +147,16 @@ jobs:
           git add braindecode/version.py docs/whats_new.rst
           git commit -m "chore: bump version to ${{ steps.ver.outputs.next_dev_version }}"
 
-      # IMPORTANT — order matters: the push must succeed BEFORE we touch PyPI.
-      # PyPI uploads are irrevocable. If we published first and the push then
-      # failed (branch protection, concurrent master push, etc.), PyPI would
-      # be permanently ahead of git: next month would recompute the same
-      # release version and twine would reject with 'File already exists'.
-      # Pushing first means a push failure stops the workflow before any
-      # PyPI side effect, and a publish failure leaves git already in the
-      # finalized state so the publish can be retried from the uploaded
-      # ``dist-*`` artifact via ``twine upload`` without further git surgery.
+      # Push BEFORE PyPI publish: PyPI uploads are irrevocable, so any push
+      # rejection (branch protection, concurrent master push) must stop the
+      # workflow before PyPI is touched. A publish failure after a successful
+      # push leaves git already finalized and the dist artifact uploaded, so
+      # ``twine upload`` from the artifact recovers without git surgery.
       - name: Push commits and tag
         if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          # Push the bump commit + the underlying release commit, then the tag.
-          # ``--atomic`` makes the branch update reject if it conflicts with
-          # someone else's master push, instead of leaving the tag detached.
           git push --atomic origin HEAD:master "${{ steps.ver.outputs.release_tag }}"
 
       - name: Publish to PyPI

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -73,8 +73,8 @@ jobs:
       cancel-in-progress: false
 
     env:
-      BUMP: ${{ inputs.bump || 'minor' }}
-      DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+      BUMP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump || 'minor' }}
+      DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && 'true' || 'false' }}
 
     steps:
       - name: Check out master

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -1,0 +1,229 @@
+name: Monthly stable release to PyPI
+
+# Cuts a stable braindecode release on the first of every month, in addition
+# to the per-push ``.devN`` releases produced by ``.github/workflows/release.yml``.
+#
+# Flow on each run:
+#   1. Compute the planned release + next-dev versions from ``braindecode/version.py``.
+#   2. Bail out early if no commits landed on master since the last ``v*`` tag.
+#   3. Strip the ``dev0`` suffix, mark the ``whats_new.rst`` heading with today's
+#      date, commit ``release: vX.Y.0``, and create an annotated tag.
+#   4. Build sdist + wheel, ``twine check``, publish to PyPI.
+#   5. Bump ``version.py`` to the next ``dev0`` cycle and add a fresh
+#      ``Current X.Y.Z (GitHub)`` section to the changelog.
+#   6. Push both commits and the tag, then cut a GitHub Release.
+#
+# The companion dev-release workflow (``release.yml``) carries a defensive
+# guard that skips publishing ``X.Y.Z.devN`` when the head commit message
+# starts with ``release: v``. In the normal flow that guard is unreachable
+# because by GitHub Actions policy a push authenticated with the default
+# ``GITHUB_TOKEN`` does NOT trigger another workflow run (anti-recursion
+# safeguard) — so neither the release commit nor the bump commit will fire
+# ``release.yml`` at all. The first ``.devN`` of the new cycle will appear
+# the next time a human (or a PAT-authenticated bot) pushes to master.
+# If you want the bump commit to immediately seed the next dev cycle on PyPI,
+# replace ``token: ${{ secrets.GITHUB_TOKEN }}`` in the checkout step with a
+# PAT (``RELEASE_PUSH_TOKEN``), which DOES trigger downstream workflows.
+#
+# Requirements on the repository side:
+#   - ``PYPI_API_TOKEN`` secret (already used by the dev-release workflow). The
+#     long-term plan is to migrate to PyPI Trusted Publishing (OIDC) by adding
+#     a publisher on PyPI and removing the ``password`` argument below; the
+#     ``id-token: write`` permission is already declared for that day.
+#   - The default ``GITHUB_TOKEN`` must be allowed to push to ``master``. If
+#     branch protection blocks bot pushes, either add ``github-actions[bot]``
+#     to the bypass list or swap ``token`` in the checkout step for a PAT
+#     stored as ``RELEASE_PUSH_TOKEN``.
+
+on:
+  schedule:
+    # 09:00 UTC on the 1st of every month. Adjust freely; cron is in UTC.
+    - cron: "0 9 1 * *"
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump for the next dev cycle"
+        required: true
+        type: choice
+        default: minor
+        options:
+          - minor
+          - patch
+          - major
+      dry_run:
+        description: "Build everything but do not publish, push, or tag"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write   # commit, tag, push, create GitHub Release
+  id-token: write   # reserved for future PyPI Trusted Publishing migration
+
+jobs:
+  release:
+    # Belt-and-suspenders so a fork running this on schedule does not try to
+    # publish to the official PyPI project.
+    if: github.repository == 'braindecode/braindecode'
+    runs-on: ubuntu-latest
+    # Share the lock with the dev-release workflow so the two cannot
+    # interleave a ``.devN`` publish in the middle of a stable cut.
+    concurrency:
+      group: pypi-publish
+      cancel-in-progress: false
+
+    env:
+      BUMP: ${{ inputs.bump || 'minor' }}
+      DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+
+    steps:
+      - name: Check out master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+          # Default GITHUB_TOKEN; replace with ``secrets.RELEASE_PUSH_TOKEN``
+          # if branch protection blocks the github-actions[bot] from pushing.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build packaging twine
+
+      - name: Compute planned versions
+        id: ver
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/monthly_release.py compute --bump "$BUMP" \
+            | tee -a "$GITHUB_OUTPUT"
+
+      - name: Print release plan
+        run: |
+          echo "Current dev:  ${{ steps.ver.outputs.current_version }}"
+          echo "Release:      ${{ steps.ver.outputs.release_version }}"
+          echo "Tag:          ${{ steps.ver.outputs.release_tag }}"
+          echo "Next dev:     ${{ steps.ver.outputs.next_dev_version }}"
+          echo "Bump:         ${BUMP}"
+          echo "Dry run:      ${DRY_RUN}"
+
+      - name: Skip if no commits since last tag
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Match only ``vMAJOR.MINOR.PATCH`` style tags so that scratch
+          # tags (``v9.9.9-test``) and pre-releases (``v2.0.0rc1``) cannot
+          # become the comparison base and corrupt the skip decision.
+          LAST_TAG="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1 || true)"
+          if [[ -z "$LAST_TAG" ]]; then
+            echo "no previous v* tag found; proceeding with first release"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          COMMITS_AHEAD="$(git rev-list "${LAST_TAG}..HEAD" --count)"
+          echo "${COMMITS_AHEAD} commits since ${LAST_TAG}"
+          if [[ "${COMMITS_AHEAD}" -eq 0 ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Finalize release in tree
+        if: steps.changes.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # ``finalize`` does not take ``--bump``: the release version is
+          # derived from the current dev seed and is independent of bump kind.
+          python scripts/monthly_release.py finalize
+          git add braindecode/version.py docs/whats_new.rst
+          git commit -m "release: ${{ steps.ver.outputs.release_tag }}"
+          git tag -a "${{ steps.ver.outputs.release_tag }}" \
+            -m "braindecode ${{ steps.ver.outputs.release_version }}"
+
+      - name: Build sdist and wheel
+        if: steps.changes.outputs.skip != 'true'
+        run: |
+          python -m build
+          python -m twine check --strict dist/*
+
+      - name: Upload built artifacts
+        if: steps.changes.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ steps.ver.outputs.release_version }}
+          path: dist/
+          if-no-files-found: error
+
+      - name: Bump to next dev version
+        if: steps.changes.outputs.skip != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/monthly_release.py next-dev --bump "$BUMP"
+          git add braindecode/version.py docs/whats_new.rst
+          git commit -m "chore: bump version to ${{ steps.ver.outputs.next_dev_version }}"
+
+      # IMPORTANT — order matters: the push must succeed BEFORE we touch PyPI.
+      # PyPI uploads are irrevocable. If we published first and the push then
+      # failed (branch protection, concurrent master push, etc.), PyPI would
+      # be permanently ahead of git: next month would recompute the same
+      # release version and twine would reject with 'File already exists'.
+      # Pushing first means a push failure stops the workflow before any
+      # PyPI side effect, and a publish failure leaves git already in the
+      # finalized state so the publish can be retried from the uploaded
+      # ``dist-*`` artifact via ``twine upload`` without further git surgery.
+      - name: Push commits and tag
+        if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Push the bump commit + the underlying release commit, then the tag.
+          # ``--atomic`` makes the branch update reject if it conflicts with
+          # someone else's master push, instead of leaving the tag detached.
+          git push --atomic origin HEAD:master "${{ steps.ver.outputs.release_tag }}"
+
+      - name: Publish to PyPI
+        if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.release_tag }}
+          name: braindecode ${{ steps.ver.outputs.release_version }}
+          generate_release_notes: true
+          files: dist/*
+
+      - name: Summarize run
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "## Monthly release summary"
+            echo ""
+            echo "| Field | Value |"
+            echo "| ----- | ----- |"
+            echo "| Current dev | \`${{ steps.ver.outputs.current_version || 'n/a' }}\` |"
+            echo "| Released    | \`${{ steps.ver.outputs.release_version || 'n/a' }}\` |"
+            echo "| Tag         | \`${{ steps.ver.outputs.release_tag || 'n/a' }}\` |"
+            echo "| Next dev    | \`${{ steps.ver.outputs.next_dev_version || 'n/a' }}\` |"
+            echo "| Bump        | \`${BUMP}\` |"
+            echo "| Dry run     | \`${DRY_RUN}\` |"
+            echo "| Skipped     | \`${{ steps.changes.outputs.skip || 'n/a' }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,13 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Skip the per-commit ``.devN`` publish when the head commit is the stable
+    # release commit produced by ``.github/workflows/monthly-release.yml``.
+    # At that commit, ``braindecode/version.py`` is ``X.Y.Z`` (no ``.dev``),
+    # and running this job would otherwise push ``X.Y.Z.devN`` to PyPI right
+    # after the stable ``X.Y.Z``. The companion ``chore: bump version`` commit
+    # is intentionally NOT excluded — it kicks off the next dev cycle.
+    if: "${{ !startsWith(github.event.head_commit.message, 'release: v') }}"
     concurrency:
       group: pypi-publish
       cancel-in-progress: false

--- a/braindecode/version.py
+++ b/braindecode/version.py
@@ -1,1 +1,1 @@
-__version__ = "1.6.0dev0"
+__version__ = "1.6.1dev0"

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -58,7 +58,18 @@ Bug fixes
 Code health
 ============
 
-- None yet
+- Add a scheduled ``.github/workflows/monthly-release.yml`` that cuts a
+  stable PyPI release on the 1st of every month (and on
+  ``workflow_dispatch``) in addition to the per-push ``.devN`` pipeline.
+  The workflow finalizes ``braindecode/version.py``, dates the matching
+  ``Current X.Y.Z (GitHub)`` heading, commits, tags, pushes commits and
+  tag atomically before publishing to PyPI, then seeds the next
+  development cycle. A new ``scripts/monthly_release.py`` helper exposes
+  the ``compute``, ``finalize``, and ``next-dev`` subcommands and
+  hard-fails on missing changelog heading, already-stable
+  ``version.py``, or mismatched quote literals. The companion
+  ``release.yml`` gains a defensive guard against ``release: v*`` head
+  commits. (:gh:`1030` by `Bruno Aristimunha`_)
 
 
 Current 1.5.1 (stable)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -22,7 +22,7 @@
 .. _current:
 
 
-Current 1.6.0 (GitHub)
+Current 1.6.1 (GitHub)
 ===============================
 
 Enhancements

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -58,18 +58,9 @@ Bug fixes
 Code health
 ============
 
-- Add a scheduled ``.github/workflows/monthly-release.yml`` that cuts a
-  stable PyPI release on the 1st of every month (and on
-  ``workflow_dispatch``) in addition to the per-push ``.devN`` pipeline.
-  The workflow finalizes ``braindecode/version.py``, dates the matching
-  ``Current X.Y.Z (GitHub)`` heading, commits, tags, pushes commits and
-  tag atomically before publishing to PyPI, then seeds the next
-  development cycle. A new ``scripts/monthly_release.py`` helper exposes
-  the ``compute``, ``finalize``, and ``next-dev`` subcommands and
-  hard-fails on missing changelog heading, already-stable
-  ``version.py``, or mismatched quote literals. The companion
-  ``release.yml`` gains a defensive guard against ``release: v*`` head
-  commits. (:gh:`1030` by `Bruno Aristimunha`_)
+- Add a monthly scheduled workflow that cuts a stable PyPI release on
+  the 1st of every month, complementing the existing per-push ``.devN``
+  pipeline. (:gh:`1030` by `Bruno Aristimunha`_)
 
 
 Current 1.5.1 (stable)

--- a/scripts/monthly_release.py
+++ b/scripts/monthly_release.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Monthly stable release helper for braindecode.
+
+Three subcommands, used by ``.github/workflows/monthly-release.yml``:
+
+``compute``
+    Print ``current_version``, ``release_version``, ``next_dev_version``,
+    ``release_tag`` and ``next_dev_base`` as ``key=value`` lines that the
+    workflow can redirect into ``$GITHUB_OUTPUT``.
+
+``finalize``
+    Rewrite ``braindecode/version.py`` to the release version (drop the
+    ``.devN`` / ``devN`` suffix) and flip the matching
+    ``Current X.Y.Z (GitHub)`` heading in ``docs/whats_new.rst`` to
+    ``Current X.Y.Z (YYYY-MM-DD)``.
+
+``next-dev``
+    Rewrite ``braindecode/version.py`` to the next dev seed (e.g.
+    ``1.7.0dev0`` for a minor bump after ``1.6.0``) and insert a fresh
+    ``Current X.Y.Z (GitHub)`` section at the top of ``docs/whats_new.rst``.
+
+Bumping rules (``--bump``)
+    ``minor`` (default): ``1.6.0`` -> next dev ``1.7.0dev0``.
+    ``patch``:           ``1.6.0`` -> next dev ``1.6.1dev0``.
+    ``major``:           ``1.6.0`` -> next dev ``2.0.0dev0``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from packaging.version import Version
+except ImportError:  # pragma: no cover - exercised on CI bootstrap
+    print(
+        "ERROR: 'packaging' is required. Install with: pip install packaging",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
+
+# Capture ``prefix`` (``__version__ = ``), the actual opening quote, the
+# version literal and require the closing quote to match the opening one so
+# corrupt input like ``__version__ = "1.6.0'`` is rejected upfront instead of
+# silently round-tripped.
+VERSION_RE = re.compile(
+    r"(?P<prefix>__version__\s*=\s*)(?P<q>['\"])(?P<ver>[^'\"]+)(?P=q)"
+)
+
+# Matches: ``Current X.Y[.Z] (GitHub)`` exactly. Captures the version string.
+GITHUB_HEADING_RE_TEMPLATE = r"^Current {version} \(GitHub\)[ \t]*$"
+
+# Matches any heading that opens a section for the given version, regardless
+# of the suffix (``(GitHub)``, ``(in development)``, dated stable, etc.).
+# Used by ``insert_next_dev_section`` to stay idempotent even when a
+# maintainer pre-edited the heading.
+ANY_HEADING_RE_TEMPLATE = r"^Current {version}\b"
+
+# The skeleton of an empty "what's new" section we drop in for the next dev
+# cycle. It mirrors the existing braindecode style in ``docs/whats_new.rst``:
+# section title underlined by ``===``, blank line, list with ``- None yet``.
+EMPTY_SECTION_TEMPLATE = """\
+Current {base} (GitHub)
+===============================
+
+Enhancements
+============
+
+- None yet
+
+API and behavior changes
+========================
+
+- None yet
+
+Requirements
+============
+
+- None yet
+
+Bug fixes
+==========
+
+- None yet
+
+Code health
+============
+
+- None yet
+
+
+"""
+
+
+def read_version(path: Path) -> str:
+    """Return the ``__version__`` string declared in ``path``."""
+    text = path.read_text(encoding="utf-8")
+    m = VERSION_RE.search(text)
+    if not m:
+        raise SystemExit(f"__version__ assignment not found in {path}")
+    return m.group("ver")
+
+
+def write_version(path: Path, new_version: str) -> None:
+    """Replace the ``__version__`` literal in ``path`` with ``new_version``."""
+    text = path.read_text(encoding="utf-8")
+    new_text, n = VERSION_RE.subn(
+        lambda m: f"{m.group('prefix')}{m.group('q')}{new_version}{m.group('q')}",
+        text,
+        count=1,
+    )
+    if n != 1:
+        raise SystemExit(f"could not rewrite __version__ in {path}")
+    path.write_text(new_text, encoding="utf-8")
+
+
+def release_from_current(current: str) -> str:
+    """Return the PEP 440 release segment of ``current`` as ``X.Y.Z``.
+
+    ``1.6.0dev0`` -> ``1.6.0``; ``1.6`` -> ``1.6.0``; ``1.6.0.dev17`` -> ``1.6.0``.
+    """
+    release_parts = list(Version(current).release)
+    while len(release_parts) < 3:
+        release_parts.append(0)
+    major, minor, patch = release_parts[:3]
+    return f"{major}.{minor}.{patch}"
+
+
+def compute_versions(current: str, bump: str) -> dict[str, str]:
+    """Return the planned ``release`` and ``next_dev`` versions."""
+    release_version = release_from_current(current)
+    major, minor, patch = map(int, release_version.split("."))
+
+    if bump == "major":
+        next_base = f"{major + 1}.0.0"
+    elif bump == "minor":
+        next_base = f"{major}.{minor + 1}.0"
+    elif bump == "patch":
+        next_base = f"{major}.{minor}.{patch + 1}"
+    else:  # pragma: no cover - argparse restricts choices
+        raise SystemExit(f"unknown bump: {bump}")
+
+    next_dev = f"{next_base}dev0"
+
+    return {
+        "current_version": current,
+        "release_version": release_version,
+        "release_tag": f"v{release_version}",
+        "next_dev_version": next_dev,
+        "next_dev_base": next_base,
+    }
+
+
+def _find_github_heading(text: str, version: str) -> re.Match[str] | None:
+    pat = re.compile(
+        GITHUB_HEADING_RE_TEMPLATE.format(version=re.escape(version)),
+        re.M,
+    )
+    return pat.search(text)
+
+
+def finalize_changelog(changelog: Path, release_version: str) -> None:
+    """Rename ``Current X.Y.Z (GitHub)`` heading to a dated stable heading.
+
+    Uses UTC date so the same line is produced regardless of runner timezone.
+    Hard-fails when the expected heading is absent: shipping a stable release
+    with a stale ``(GitHub)`` (or missing) heading would be a silent docs bug
+    that the workflow cannot recover from after PyPI upload.
+    """
+    text = changelog.read_text(encoding="utf-8")
+    today = datetime.now(timezone.utc).date().isoformat()
+
+    m = _find_github_heading(text, release_version)
+    if not m:
+        raise SystemExit(
+            f"ERROR: no 'Current {release_version} (GitHub)' heading found in "
+            f"{changelog}. Refusing to finalize a release with an unfinalized "
+            "changelog. Add the heading (or correct the version) and re-run."
+        )
+
+    new_heading = f"Current {release_version} ({today})"
+    new_text = text[: m.start()] + new_heading + text[m.end() :]
+    changelog.write_text(new_text, encoding="utf-8")
+
+
+def insert_next_dev_section(changelog: Path, next_dev_base: str) -> None:
+    """Insert a fresh ``Current X.Y.Z (GitHub)`` section after ``.. _current:``."""
+    text = changelog.read_text(encoding="utf-8")
+
+    # Idempotent: any pre-existing ``Current <next> ...`` heading (regardless
+    # of suffix — ``(GitHub)``, ``(in development)``, dated stable, etc.) is
+    # treated as "already there" so a re-run does not append a duplicate
+    # section above a maintainer-edited variant.
+    any_existing = re.compile(
+        ANY_HEADING_RE_TEMPLATE.format(version=re.escape(next_dev_base)),
+        re.M,
+    )
+    if any_existing.search(text):
+        return
+
+    anchor_re = re.compile(r"^\.\. _current:[ \t]*\n", re.M)
+    m = anchor_re.search(text)
+    if m:
+        # Skip any blank lines after the anchor so the new section sits flush
+        # against the existing structure.
+        insert_at = m.end()
+        while insert_at < len(text) and text[insert_at] == "\n":
+            insert_at += 1
+    else:
+        # Fall back to inserting before the first existing "Current X.Y.Z"
+        # heading.
+        m2 = re.search(r"^Current \d", text, re.M)
+        if not m2:
+            raise SystemExit(
+                f"Could not find an insertion point in {changelog}: "
+                "no '.. _current:' anchor and no 'Current X.Y.Z' heading."
+            )
+        insert_at = m2.start()
+
+    section = EMPTY_SECTION_TEMPLATE.format(base=next_dev_base)
+    changelog.write_text(text[:insert_at] + section + text[insert_at:], encoding="utf-8")
+
+
+def cmd_compute(args: argparse.Namespace) -> int:
+    current = read_version(args.init_file)
+    info = compute_versions(current, args.bump)
+    for key, value in info.items():
+        print(f"{key}={value}")
+    return 0
+
+
+def cmd_finalize(args: argparse.Namespace) -> int:
+    # ``--bump`` is intentionally not consulted here: the release version is
+    # always the PEP 440 release segment of the current dev seed, independent
+    # of the bump kind (which only governs the *next* dev cycle).
+    current = read_version(args.init_file)
+    release_version = release_from_current(current)
+    if current == release_version:
+        raise SystemExit(
+            f"ERROR: __version__ is already '{release_version}' (no .dev suffix). "
+            "Refusing to re-finalize. If a previous run partially succeeded, "
+            "drop the orphan release commit/tag or bump version.py back to "
+            f"'{release_version}dev0' before re-running."
+        )
+    write_version(args.init_file, release_version)
+    finalize_changelog(args.changelog, release_version)
+    print(f"{args.init_file} -> {release_version}")
+    return 0
+
+
+def cmd_next_dev(args: argparse.Namespace) -> int:
+    current = read_version(args.init_file)
+    info = compute_versions(current, args.bump)
+    write_version(args.init_file, info["next_dev_version"])
+    insert_next_dev_section(args.changelog, info["next_dev_base"])
+    print(f"{args.init_file} -> {info['next_dev_version']}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    paths = argparse.ArgumentParser(add_help=False)
+    paths.add_argument(
+        "--init-file",
+        default=Path("braindecode/version.py"),
+        type=Path,
+        help="Path to the file holding the __version__ literal.",
+    )
+    paths.add_argument(
+        "--changelog",
+        default=Path("docs/whats_new.rst"),
+        type=Path,
+        help="Path to the RST changelog.",
+    )
+
+    # ``--bump`` governs the next dev cycle, so it is wired only into the
+    # ``compute`` and ``next-dev`` subcommands. ``finalize`` is independent
+    # of bump kind and accepting the flag there would be a silent footgun.
+    bump = argparse.ArgumentParser(add_help=False)
+    bump.add_argument(
+        "--bump",
+        default="minor",
+        choices=("major", "minor", "patch"),
+        help="How to bump the version for the next development cycle.",
+    )
+
+    # Guard against ``python -OO`` (or any caller that strips docstrings):
+    # ``__doc__`` is ``None`` in that case and ``None.split(...)`` crashes.
+    description = (__doc__ or "").split("\n", 1)[0]
+    ap = argparse.ArgumentParser(description=description)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    sub.add_parser(
+        "compute",
+        parents=[paths, bump],
+        help="Print the planned versions as key=value lines.",
+    )
+    sub.add_parser(
+        "finalize",
+        parents=[paths],
+        help="Write the release version to version.py and date the changelog heading.",
+    )
+    sub.add_parser(
+        "next-dev",
+        parents=[paths, bump],
+        help="Write the next .dev0 version and add a blank changelog section.",
+    )
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = build_parser()
+    args = ap.parse_args(argv)
+    if args.cmd == "compute":
+        return cmd_compute(args)
+    if args.cmd == "finalize":
+        return cmd_finalize(args)
+    if args.cmd == "next-dev":
+        return cmd_next_dev(args)
+    ap.error(f"unknown subcommand: {args.cmd}")  # pragma: no cover
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a scheduled workflow that cuts a stable braindecode release to PyPI on the 1st of every month (and on `workflow_dispatch`), in addition to the existing per-push `.devN` pipeline. Minor version is bumped by default; `patch` / `major` are available via `workflow_dispatch`.

## What changes

- **`.github/workflows/monthly-release.yml`** (new): cron `0 9 1 * *` + manual dispatch. Flow on each run:
  1. Compute planned versions from `braindecode/version.py`.
  2. Skip if no commits since the last `v[0-9]*.[0-9]*.[0-9]*` tag.
  3. Strip the `dev0` suffix, date the matching `Current X.Y.Z (GitHub)` heading in `docs/whats_new.rst`, commit `release: vX.Y.Z`, tag.
  4. Build sdist + wheel, run `twine check --strict`, upload as a workflow artifact.
  5. Commit `chore: bump version to X.(Y+1).0dev0` and insert a fresh changelog section.
  6. **Push commits + tag atomically to master**, then publish to PyPI, then create a GitHub Release with auto-generated notes.
- **`.github/workflows/release.yml`** (modified, 7 lines): defensive `if:` guard skips the per-push `.devN` job when the head commit message starts with `release: v` — protects against a manual push of just the release commit republishing `X.Y.Z.devN` over the just-published stable.
- **`scripts/monthly_release.py`** (new): helper exposing `compute`, `finalize`, and `next-dev` subcommands. Hard-fails on missing changelog heading, already-stable `version.py`, mismatched quote literals, and `finalize --bump` misuse.

## Design notes

- **Push before publish.** PyPI uploads are irrevocable; a push rejection (branch protection, concurrent master push) must not leave PyPI ahead of git. With this order, a publish failure leaves git already finalized so the upload is retryable from the uploaded `dist-*` artifact via `twine upload` without further git surgery.
- **`GITHUB_TOKEN` push consequence.** By GitHub Actions design, pushes authenticated with the default `GITHUB_TOKEN` do NOT trigger downstream workflows. So the bump commit pushed by this workflow will not immediately seed a `X.(Y+1).0.devN` on PyPI; the first dev of the new cycle appears on the next human push. If you want immediate seeding, swap `token: ${{ secrets.GITHUB_TOKEN }}` in the checkout step for a PAT (`RELEASE_PUSH_TOKEN`).
- **Tag-pattern filter.** `LAST_TAG` is selected from `v[0-9]*.[0-9]*.[0-9]*` so scratch tags (`v9.9.9-test`) and pre-releases (`v2.0.0rc1`) cannot shift the skip baseline.
- **OIDC-ready.** `id-token: write` is already declared; once you add a PyPI Trusted Publisher pointing at `monthly-release.yml`, drop the `password:` argument and stop rotating the API token.

## One-time setup before next cron

- **`PYPI_API_TOKEN`** secret — already used by `release.yml`. No change.
- **Branch-protection bypass for `github-actions[bot]`** on master, OR provide a PAT as `RELEASE_PUSH_TOKEN` and switch the checkout `token:`. Without this, the atomic push will fail; the workflow comment shows where to switch.
- **Cron timing.** Currently 09:00 UTC on the 1st; adjust freely.

## Test plan

- [x] `yaml.safe_load` parses both workflow files.
- [x] `python scripts/monthly_release.py compute --bump {minor,patch,major}` prints correct `$GITHUB_OUTPUT` lines for the current `1.6.0dev0` state.
- [x] `finalize` then `next-dev` against temp copies produces `1.6.0dev0 -> 1.6.0 (2026-05-27) -> 1.7.0dev0` with a fresh `Current 1.7.0 (GitHub)` section; anchor spacing (`'\n\n\n'`) preserved.
- [x] `finalize --bump minor` rejected by argparse with `unrecognized arguments`.
- [x] `finalize` on already-stable `version.py` exits with actionable recovery message instead of opaque `git commit` failure.
- [x] `finalize` with missing `(GitHub)` heading exits with actionable message.
- [x] Pre-commit hooks (ruff, codespell, isort, yaml-lint, etc.) pass on the diff.
- [ ] **Reviewer-driven**: before merging, set branch-protection bypass and run `workflow_dispatch` with `dry_run: true` to validate end-to-end without touching PyPI.