### PR TITLE
Make monthly release tag-only with a version-bump PR

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -2,18 +2,31 @@ name: Monthly stable release to PyPI
 
 # Cuts a stable braindecode release on the 1st of every month, alongside the
 # per-push ``.devN`` releases produced by ``.github/workflows/release.yml``.
-# Pushes commits + tag atomically BEFORE publishing to PyPI so a push failure
-# can never leave PyPI ahead of git.
+#
+# ``master`` is protected by a ruleset that requires all changes to go through
+# a pull request, and the GitHub Actions app cannot be granted a ruleset
+# bypass on this org-owned repo. So this workflow never pushes to ``master``.
+# Instead it:
+#   1. Finalizes the version in the runner's working tree (no master push).
+#   2. Pushes ONLY the annotated tag ``vX.Y.Z`` (tags are not covered by the
+#      branch ruleset) — this is the source-of-truth for the release.
+#   3. Builds + ``twine check`` + publishes the sdist/wheel to PyPI.
+#   4. Creates a GitHub Release on the tag.
+#   5. Opens a pull request that bumps ``version.py`` to the next ``dev0``
+#      cycle and dates the changelog heading, for a maintainer to merge.
+#
+# The tag is pushed BEFORE the PyPI publish: PyPI uploads are irrevocable, so
+# a tag-push failure must stop the run before any PyPI side effect. A publish
+# failure after a successful tag push is recoverable via ``twine upload`` from
+# the uploaded ``dist-*`` artifact.
 #
 # Requirements:
 #   - ``PYPI_API_TOKEN`` secret (shared with the dev-release workflow).
-#   - The default ``GITHUB_TOKEN`` must be allowed to push to ``master``. If
-#     branch protection blocks bot pushes, add ``github-actions[bot]`` to the
-#     bypass list, or replace ``token:`` in the checkout step with a PAT
-#     stored as ``RELEASE_PUSH_TOKEN``.
-#   - Note: pushes authenticated with the default ``GITHUB_TOKEN`` do NOT
-#     trigger ``release.yml``, so the first ``.devN`` of the new cycle lands
-#     only on the next human push (use a PAT to opt in to immediate seeding).
+#   - Note: the bump PR is opened with the default ``GITHUB_TOKEN``, so by
+#     GitHub policy its ``pull_request`` event does NOT trigger the PR CI
+#     workflows (tests, whats-new check). A maintainer can kick CI by pushing
+#     an empty commit to the PR branch (or just merge it — no status check is
+#     required by the ruleset).
 
 on:
   schedule:
@@ -31,14 +44,15 @@ on:
           - patch
           - major
       dry_run:
-        description: "Build everything but do not publish, push, or tag"
+        description: "Build everything but do not publish, tag, or open the bump PR"
         required: false
         type: boolean
         default: false
 
 permissions:
-  contents: write   # commit, tag, push, create GitHub Release
-  id-token: write   # reserved for future PyPI Trusted Publishing migration
+  contents: write        # push the tag, create the GitHub Release
+  pull-requests: write   # open the version-bump PR
+  id-token: write        # reserved for future PyPI Trusted Publishing migration
 
 jobs:
   release:
@@ -55,6 +69,7 @@ jobs:
     env:
       BUMP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump || 'minor' }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && 'true' || 'false' }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Check out master
@@ -62,8 +77,6 @@ jobs:
         with:
           ref: master
           fetch-depth: 0
-          # Default GITHUB_TOKEN; replace with ``secrets.RELEASE_PUSH_TOKEN``
-          # if branch protection blocks the github-actions[bot] from pushing.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Configure Git identity
@@ -121,6 +134,9 @@ jobs:
           python scripts/monthly_release.py finalize
           git add braindecode/version.py docs/whats_new.rst
           git commit -m "release: ${{ steps.ver.outputs.release_tag }}"
+          # Annotated tag on the finalized commit. The commit lives only at the
+          # tag (it is never pushed to master); the version-bump PR carries the
+          # equivalent changelog/version housekeeping onto master separately.
           git tag -a "${{ steps.ver.outputs.release_tag }}" \
             -m "braindecode ${{ steps.ver.outputs.release_version }}"
 
@@ -138,26 +154,14 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-      - name: Bump to next dev version
-        if: steps.changes.outputs.skip != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          python scripts/monthly_release.py next-dev --bump "$BUMP"
-          git add braindecode/version.py docs/whats_new.rst
-          git commit -m "chore: bump version to ${{ steps.ver.outputs.next_dev_version }}"
-
-      # Push BEFORE PyPI publish: PyPI uploads are irrevocable, so any push
-      # rejection (branch protection, concurrent master push) must stop the
-      # workflow before PyPI is touched. A publish failure after a successful
-      # push leaves git already finalized and the dist artifact uploaded, so
-      # ``twine upload`` from the artifact recovers without git surgery.
-      - name: Push commits and tag
+      # Push the tag BEFORE PyPI publish (see header). Tags are not covered by
+      # the branch ruleset, so this succeeds with the default GITHUB_TOKEN.
+      - name: Push release tag
         if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          git push --atomic origin HEAD:master "${{ steps.ver.outputs.release_tag }}"
+          git push origin "refs/tags/${{ steps.ver.outputs.release_tag }}"
 
       - name: Publish to PyPI
         if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
@@ -173,6 +177,38 @@ jobs:
           name: braindecode ${{ steps.ver.outputs.release_version }}
           generate_release_notes: true
           files: dist/*
+
+      # master is PR-protected, so the version bump cannot be pushed directly.
+      # Open it as a PR branched fresh from master: date the just-released
+      # changelog heading (finalize) and seed the next dev cycle (next-dev).
+      - name: Open version-bump pull request
+        if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-after-${{ steps.ver.outputs.release_tag }}"
+          git checkout -B "$BRANCH" origin/master
+          python scripts/monthly_release.py finalize
+          python scripts/monthly_release.py next-dev --bump "$BUMP"
+          git add braindecode/version.py docs/whats_new.rst
+          git commit -m "chore: bump version to ${{ steps.ver.outputs.next_dev_version }} after ${{ steps.ver.outputs.release_tag }}"
+          git push -u origin "$BRANCH" --force-with-lease
+          # Body via a quoted heredoc so backticks stay literal and newlines
+          # render. The ${{ }} placeholders are substituted by Actions first.
+          cat > /tmp/pr_body.md <<'BODY'
+          Automated post-release housekeeping for ${{ steps.ver.outputs.release_tag }} (published to PyPI).
+
+          - Date the `Current ${{ steps.ver.outputs.release_version }} (GitHub)` changelog heading.
+          - Seed the next development cycle: `version.py` -> `${{ steps.ver.outputs.next_dev_version }}` plus a fresh `Current ${{ steps.ver.outputs.next_dev_base }} (GitHub)` section.
+
+          Note: opened by GITHUB_TOKEN, so PR CI does not auto-run. Push an empty commit to trigger it, or merge directly (no status check is required by the ruleset).
+          BODY
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore: bump version to ${{ steps.ver.outputs.next_dev_version }} after ${{ steps.ver.outputs.release_tag }}" \
+            --body-file /tmp/pr_body.md \
+            || echo "gh pr create failed (a PR for $BRANCH may already exist); branch is pushed regardless."
 
       - name: Summarize run
         if: always()

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -62,6 +62,10 @@ Code health
   the 1st of every month, complementing the existing per-push ``.devN``
   pipeline. (:gh:`1030` by `Bruno Aristimunha`_)
 
+- Make the monthly release workflow push only the release tag and open a
+  pull request for the version bump, so it never needs to push to the
+  protected ``master`` branch. (:gh:`1031` by `Bruno Aristimunha`_)
+
 
 Current 1.5.1 (stable)
 ===============================


### PR DESCRIPTION
## Summary

Reworks the monthly stable-release workflow (added in #1030) so it **never pushes to `master`**. `master` is protected by the `no-push-main` ruleset (all changes via PR), and the GitHub Actions app cannot be granted a ruleset bypass on this org-owned repo (confirmed via both the REST API and the Settings UI — GitHub Actions is not an available bypass actor). The previous design's atomic push to `master` was therefore rejected.

## New flow

1. Finalize the version in the runner's working tree (no `master` push).
2. Push **only** the annotated tag `vX.Y.Z` — tags aren't covered by the branch ruleset, so the default `GITHUB_TOKEN` can push them.
3. Build → `twine check --strict` → publish sdist/wheel to PyPI.
4. Create a GitHub Release on the tag.
5. Open a PR (branched from `master`) that dates the released changelog heading and seeds the next dev cycle (`version.py` → next `dev0` + fresh `Current X.Y.Z (GitHub)` section), for a maintainer to merge.

The tag is pushed **before** the PyPI publish so a tag-push failure halts the run before any irrevocable upload.

## Notes

- The bump PR is opened with `GITHUB_TOKEN`, so its PR CI doesn't auto-run (GitHub anti-recursion). A maintainer can push an empty commit to trigger CI, or merge directly — the ruleset requires no status check. Merging the bump PR (by a human) also triggers `release.yml`, which seeds `X.Y.0.devN` automatically — so the dev cycle restarts for free.
- This is the security-preserving alternative to granting a branch-protection bypass: `master` stays fully PR-protected, and no new push secret is introduced.

## Test plan

- [x] `yaml.safe_load` parses the workflow.
- [x] Local simulation of the bump-PR branch (finalize → next-dev from `master` state `1.6.1dev0`) yields `1.7.0dev0` with `Current 1.7.0 (GitHub)` / `Current 1.6.1 (<date>)`.
- [x] Local simulation of the release-tag tree (finalize only) yields `1.6.1` + dated `Current 1.6.1 (<date>)` — what gets built/published.
- [x] Heredoc PR-body dedents correctly inside the YAML `run` block (backticks literal, newlines preserved).
- [ ] Reviewer: trigger `workflow_dispatch` to cut `v1.6.1`.