### PR TITLE
Fix monthly-release workflow parse error (empty expression in comment)

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -194,7 +194,9 @@ jobs:
           git commit -m "chore: bump version to ${{ steps.ver.outputs.next_dev_version }} after ${{ steps.ver.outputs.release_tag }}"
           git push -u origin "$BRANCH" --force-with-lease
           # Body via a quoted heredoc so backticks stay literal and newlines
-          # render. The ${{ }} placeholders are substituted by Actions first.
+          # render. The double-brace placeholders are substituted by Actions
+          # before bash runs (do not write an empty expression here -- Actions
+          # parses expressions even inside shell comments and heredocs).
           cat > /tmp/pr_body.md <<'BODY'
           Automated post-release housekeeping for ${{ steps.ver.outputs.release_tag }} (published to PyPI).
 


### PR DESCRIPTION
Hotfix for #1031. The monthly-release workflow was undispatchable — `gh workflow run` returned `HTTP 422 ... An expression was expected (Line 187)`.

Cause: a shell comment inside the `Open version-bump pull request` step literally contained an empty `${{ }}`. GitHub Actions parses `${{ }}` expressions **everywhere** in a workflow file — including inside bash comments and heredocs — and an empty expression is a parse error.

Fix: reword the comment so it no longer contains a literal empty expression. No behavior change.

CI-plumbing only; no changelog entry.