### PR TITLE
docs: fix incorrect import path in CONTRIBUTING.md (model.base -> models.base)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,7 +316,7 @@ Then, we add the following template to the file:
 
 ```python
 from torch import nn
-from braindecode.model.base import EEGModuleMixin
+from braindecode.models.base import EEGModuleMixin
 
 
 class MyNewModel(EEGModuleMixin, nn.Module):
@@ -376,7 +376,7 @@ Explaining the template and internal convention:
    work with `EEGClassifier` or `EEGRegressor`.
 
    ```python
-   from braindecode.model.base import EEGModuleMixin
+   from braindecode.models.base import EEGModuleMixin
    class MyNewModel(EEGModuleMixin, nn.Module):
        # ... (model definition)
    ```

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -59,6 +59,8 @@ Bug fixes
   use running statistics when ``batch_size == 1`` in train mode.
   By `Bruno Aristimunha`_.
 
+- Fix incorrect import path in CONTRIBUTING.md by `Yiheng Li`_
+
 Code health
 ============
 
@@ -1239,3 +1241,6 @@ Authors
 .. _Sarthak Tayal: https://github.com/tayal-sarthak
 .. _Vandit Shah: https://github.com/ShahVandit
 .. _Léo Burgund: https://github.com/leob000
+.. _Adam Mounir: https://github.com/adammounir
+.. _Yiheng Li: https://github.com/YihengLi-1
+

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -1243,4 +1243,3 @@ Authors
 .. _Léo Burgund: https://github.com/leob000
 .. _Adam Mounir: https://github.com/adammounir
 .. _Yiheng Li: https://github.com/YihengLi-1
-


### PR DESCRIPTION
## Summary

The "Adding a model to Braindecode" section of `CONTRIBUTING.md` imports
`EEGModuleMixin` from `braindecode.model.base` (singular `model`). That module
does not exist — `EEGModuleMixin` is defined in `braindecode/models/base.py`
(plural `models`). A new contributor copy-pasting the template currently hits
`ModuleNotFoundError: No module named 'braindecode.model'`.

This PR corrects the two occurrences to the proper `braindecode.models.base`.

## Changes

- `CONTRIBUTING.md`: `braindecode.model.base` → `braindecode.models.base`
  in two places (the model template and the explanation snippet).

## Verification

```python
>>> from braindecode.models.base import EEGModuleMixin   # works
>>> from braindecode.model.base import EEGModuleMixin    # ModuleNotFoundError
```

Docs-only change; no code, API, or tests affected.
