### PR TITLE
docs: fix EEGClassifier typo (EEGClassifer -> EEGClassifier) in cropped decoding example

### DIFF
--- a/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
+++ b/examples/model_building/plot_bcic_iv_2a_moabb_cropped.py
@@ -246,7 +246,7 @@ valid_set = splitted["1test"]  # Session evaluation
 # Training
 # --------
 # In difference to trialwise decoding, we now should supply
-# ``cropped=True`` to the :class:`EEGClassifer
+# ``cropped=True`` to the :class:`EEGClassifier
 # <braindecode.classifier.EEGClassifier>`, and :class:`CroppedLoss
 # <braindecode.training.CroppedLoss>` as the criterion,
 # as well as ``criterion__loss_function`` as the loss function


### PR DESCRIPTION
## Summary

In the cropped-decoding example, the `:class:` cross-reference label for
`EEGClassifier` was misspelled as `EEGClassifer` (missing the second `i`).
This corrects the visible label text in the rendered docs / example gallery.

Note the link *target* (`braindecode.classifier.EEGClassifier`) was already
correct — only the displayed label text was wrong.

## Changes

- `examples/model_building/plot_bcic_iv_2a_moabb_cropped.py` (line 249):
  `:class:`EEGClassifer`` → `:class:`EEGClassifier``

Docs / example-comment change only; no code, API, or behavior affected.
