### PR TITLE
Add InterpolatedEEGPT model

### DIFF
--- a/braindecode/models/__init__.py
+++ b/braindecode/models/__init__.py
@@ -21,7 +21,7 @@ from .eegitnet import EEGITNet
 from .eegminer import EEGMiner
 from .eegnet import EEGNet, EEGNetv4
 from .eegnex import EEGNeX
-from .eegpt import EEGPT
+from .eegpt import EEGPT, InterpolatedEEGPT
 from .eegsimpleconv import EEGSimpleConv
 from .eegsym import EEGSym
 from .eegtcnet import EEGTCNet
@@ -85,6 +85,7 @@ __all__ = [
     "BrainModule",
     "EEGConformer",
     "EEGPT",
+    "InterpolatedEEGPT",
     "EEGInceptionERP",
     "EEGInceptionMI",
     "EEGITNet",

--- a/braindecode/models/eegpt.py
+++ b/braindecode/models/eegpt.py
@@ -1435,3 +1435,32 @@ class _EEGTransformer(nn.Module):
         )
 
         return x
+
+
+# -----------------------------------------------------------------------------
+# InterpolatedEEGPT — experimental channel-interpolation variant of EEGPT
+# -----------------------------------------------------------------------------
+# A :func:`~braindecode.models.interpolated.InterpolatedModel` wrapper around
+# :class:`EEGPT` whose target channel set is the canonical ``EEGPT_CHANNELS``.
+# Accepts arbitrary user ``chs_info``; projects to the canonical channels via an
+# MNE-backed (frozen by default) interpolation matrix.
+
+from mne.channels import make_standard_montage  # noqa: E402
+
+from braindecode.models.interpolated import InterpolatedModel  # noqa: E402
+
+montage = make_standard_montage("standard_1020")
+ch_pos = {
+    ch.upper(): (ch, loc) for ch, loc in montage.get_positions()["ch_pos"].items()
+}
+_EEGPT_TARGET_CHS_INFO = [
+    {
+        "ch_name": ch_pos[ch.upper()][0],
+        "kind": "eeg",
+        "loc": ch_pos[ch.upper()][1],
+    }
+    for ch in EEGPT_CHANNELS
+]
+InterpolatedEEGPT = InterpolatedModel(
+    EEGPT, _EEGPT_TARGET_CHS_INFO, name="InterpolatedEEGPT"
+)

--- a/braindecode/models/summary.csv
+++ b/braindecode/models/summary.csv
@@ -53,5 +53,6 @@ REVE,General,Classification,200,"n_outputs, n_times, n_chans",69481476,"REVE(n_t
 DGCNN,Emotion Recognition,Classification,128,"n_chans, n_outputs, n_times, chs_info",1037385,"DGCNN(n_chans=62, n_outputs=4, n_times=128)","Graph Neural Network,Channel"
 InterpolatedBENDR,General,"Classification,Embedding",250,"chs_info, n_outputs, n_times",157143101,"InterpolatedBENDR(chs_info=<user>, n_outputs=4, n_times=1000)","Foundation Model,Convolution,Channel"
 InterpolatedBIOT,"Sleep Staging, Epilepsy",Classification,200,"chs_info, n_outputs, n_times, sfreq",3184101,"InterpolatedBIOT(chs_info=<user>, n_outputs=5, sfreq=200, n_times=6000)","Foundation Model,Channel"
+InterpolatedEEGPT,General,Classification,256,"chs_info, n_outputs, n_times",25323137,"InterpolatedEEGPT(chs_info=<user>, n_outputs=4, n_times=1024)","Foundation Model,Attention/Transformer,Channel"
 InterpolatedLaBraM,General,"Classification, Embedding",200,"chs_info, n_outputs, n_times",5866196,"InterpolatedLaBraM(chs_info=<user>, n_outputs=4, n_times=1000)","Convolution,Foundation Model,Channel"
 InterpolatedSignalJEPA,"Motor Imagery, ERP, SSVEP",Embedding,128,"chs_info",3456882,"InterpolatedSignalJEPA(chs_info=<user>)","Convolution,Channel,Foundation Model"

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -309,6 +309,11 @@ models_mandatory_parameters: list[
     ("EEGITNet", ["n_chans", "n_outputs", "n_times"], None),
     ("EEGNet", ["n_chans", "n_outputs", "n_times"], None),
     ("EEGPT", ["n_chans", "n_outputs", "n_times", "chs_info"], None),
+    (
+        "InterpolatedEEGPT",
+        ["chs_info", "n_outputs", "n_times"],
+        {"chs_info": _chs_info_4ch},  # MNE interpolation needs >=4 channels
+    ),
     ("ShallowFBCSPNet", ["n_chans", "n_outputs", "n_times"], None),
     (
         "SleepStagerBlanco2020",

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -160,6 +160,7 @@ interface for all EEG models and can derive variable names when needed.
      IFNet
      InterpolatedBENDR
      InterpolatedBIOT
+     InterpolatedEEGPT
      InterpolatedLaBraM
      InterpolatedModel
      InterpolatedSignalJEPA

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,6 +32,10 @@ Enhancements
   :meth:`braindecode.datasets.BaseConcatDataset.pull_from_hub` so callers can
   pin dataset downloads to a specific branch, tag, or commit on the Hugging
   Face Hub.
+- Add :class:`braindecode.models.InterpolatedEEGPT`, a channel-interpolation
+  variant of :class:`braindecode.models.EEGPT` built with
+  :func:`~braindecode.models.interpolated.InterpolatedModel`.
+  By `Pierre Guetschel`_.
 
 API and behavior changes
 ========================

--- a/test/unit_tests/models/test_integration.py
+++ b/test/unit_tests/models/test_integration.py
@@ -31,6 +31,7 @@ from braindecode.models import (
     FBMSNet,
     InterpolatedBENDR,
     InterpolatedBIOT,
+    InterpolatedEEGPT,
     InterpolatedLaBraM,
     InterpolatedSignalJEPA,
     SyncNet,
@@ -311,6 +312,7 @@ def test_model_has_activation_parameter(model_class):
         EEGPT,
         InterpolatedBENDR,
         InterpolatedBIOT,
+        InterpolatedEEGPT,
         InterpolatedLaBraM,
         InterpolatedSignalJEPA,
     ]:
@@ -380,6 +382,7 @@ def test_model_has_drop_prob_parameter(model_class):
         REVE,
         InterpolatedBENDR,
         InterpolatedBIOT,
+        InterpolatedEEGPT,
         InterpolatedLaBraM,
         InterpolatedSignalJEPA,
     ]:
@@ -527,6 +530,7 @@ def test_model_torch_script(model):
         "SignalJEPA_PreLocal",
         "InterpolatedBENDR",
         "InterpolatedBIOT",
+        "InterpolatedEEGPT",
         "InterpolatedLaBraM",
         "InterpolatedSignalJEPA",
     ]

--- a/test/unit_tests/models/test_interpolated.py
+++ b/test/unit_tests/models/test_interpolated.py
@@ -256,6 +256,32 @@ def test_interpolated_bendr_accepts_arbitrary_user_channels():
     assert y.shape == (1, 2)
 
 
+def test_interpolated_eegpt_is_shipped():
+    from braindecode.models import EEGPT, InterpolatedEEGPT
+
+    assert issubclass(InterpolatedEEGPT, EEGPT)
+    assert not hasattr(EEGPT, "_TARGET_CHS_INFO")
+    assert hasattr(InterpolatedEEGPT, "_TARGET_CHS_INFO")
+    assert len(InterpolatedEEGPT._TARGET_CHS_INFO) == 62
+
+
+def test_interpolated_eegpt_accepts_arbitrary_user_channels():
+    from braindecode.models import InterpolatedEEGPT
+
+    user = _target_5ch()  # 5 real EEG channels (Fz, Cz, Pz, C3, C4)
+    model = InterpolatedEEGPT(
+        chs_info=user,
+        n_outputs=2,
+        n_times=1024,
+        interpolation_mode="always",
+    )
+    assert model.n_chans == 5
+    # Backbone still sees the 62 canonical EEGPT channels.
+    assert model.interpolation_layer.matrix.shape == (62, 5)
+    y = model(torch.zeros(1, 5, 1024))
+    assert y.shape == (1, 2)
+
+
 def test_bendr_rejects_non_canonical_chs():
     from braindecode.models import BENDR
 


### PR DESCRIPTION
Ships `InterpolatedEEGPT`, a channel-interpolation variant of `EEGPT`. Follow-up of #993, which introduced `InterpolatedModel`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0153qGJezqNxCKCUXMn6Qbs3)_