### PR TITLE
fix pydantic serialize_as_any config dumps

### DIFF
--- a/braindecode/models/config.py
+++ b/braindecode/models/config.py
@@ -1,6 +1,6 @@
 # Authors: Sarthak Tayal <sarthaktayal2@gmail.com>
 from collections.abc import Callable
-from inspect import signature
+from inspect import isbuiltin, isfunction, signature
 from types import UnionType
 from typing import Annotated, Any, Literal, Union, get_args, get_origin
 
@@ -63,6 +63,14 @@ SIGNAL_ARGS_TYPES = {
 
 class BaseBraindecodeModelConfig(pydantic.BaseModel):
     """Base class for braindecode model pydantic configs."""
+
+    @pydantic.field_serializer("*", mode="wrap", when_used="json", check_fields=False)
+    def _serialize_import_strings(
+        self, value: Any, handler: Callable[[Any], Any]
+    ) -> Any:
+        if isinstance(value, type) or isbuiltin(value) or isfunction(value):
+            return f"{value.__module__}.{value.__qualname__}"
+        return handler(value)
 
     def create_instance(self) -> EEGModuleMixin:
         if self.model_name_ not in models_dict:

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -50,6 +50,11 @@ Requirements
 Bug fixes
 ==========
 
+- Fix JSON serialization of the braindecode model pydantic configs: type,
+  function, and builtin field values (such as ``activation``) are now dumped
+  as importable dotted paths (e.g. ``"torch.nn.modules.activation.ELU"``) so
+  that ``model_dump(mode="json", serialize_as_any=True)`` round-trips back
+  through ``model_validate`` (:gh:`1039` by `Sarthak Tayal`_)
 - Fix :class:`~braindecode.models.ContraWR`,
   :class:`~braindecode.models.DeepSleepNet`, and
   :class:`~braindecode.models.EEGMiner` raising a confusing

--- a/test/unit_tests/models/test_config.py
+++ b/test/unit_tests/models/test_config.py
@@ -62,6 +62,19 @@ def test_make_model_config_json_serialization(model_name, required, signal_param
         )
 
 
+def test_make_model_config_json_serialization_as_any():
+    from braindecode.models.config import EEGNetConfig
+
+    cfg = EEGNetConfig(n_times=1000, n_chans=26, n_outputs=4)
+    serialized = cfg.model_dump(mode="json", serialize_as_any=True)
+    cfg_from_serialized = EEGNetConfig.model_validate(serialized)
+
+    assert serialized["activation"] == "torch.nn.modules.activation.ELU"
+    np.testing.assert_equal(
+        cfg_from_serialized.model_dump(mode="python"), cfg.model_dump(mode="python")
+    )
+
+
 @pytest.mark.parametrize(
     "n_times, input_window_seconds, sfreq",
     [


### PR DESCRIPTION
summary

fixes #892 

pydantic json dumps with serialize_as_any=true failed when model configs held torch activation classes. importstring handled normal json mode, serialize_as_any exposed the raw type value.

adds a json wrap serializer on base braindecode config. importable classes and functions dump as dotted paths. other fields still go through pydantic's default handler.

closes #892 