### PR TITLE
Remove deprecated aliases overdue since v1.4 (EEGNetv4, SleepStagerEldele2021, TSceptionV1, BNCI2014001)

### DIFF
--- a/braindecode/datasets/moabb.py
+++ b/braindecode/datasets/moabb.py
@@ -15,7 +15,6 @@ from typing import Any
 
 import mne
 import pandas as pd
-from mne.utils import deprecated
 
 from braindecode.util import _update_moabb_docstring
 
@@ -208,12 +207,3 @@ class HGD(MOABBDataset):
 
     def __init__(self, subject_ids):
         super().__init__("Schirrmeister2017", subject_ids=subject_ids)
-
-
-@deprecated(
-    "`BNCI2014001` was renamed to `BNCI2014_001` in v1.13; this alias will be removed in v1.14."
-)
-class BNCI2014001(BNCI2014_001):
-    """Deprecated alias for BNCI2014001."""
-
-    pass

--- a/braindecode/models/__init__.py
+++ b/braindecode/models/__init__.py
@@ -19,7 +19,7 @@ from .eeginception_erp import EEGInceptionERP
 from .eeginception_mi import EEGInceptionMI
 from .eegitnet import EEGITNet
 from .eegminer import EEGMiner
-from .eegnet import EEGNet, EEGNetv4
+from .eegnet import EEGNet
 from .eegnex import EEGNeX
 from .eegpt import EEGPT, InterpolatedEEGPT
 from .eegsimpleconv import EEGSimpleConv
@@ -91,7 +91,6 @@ __all__ = [
     "EEGITNet",
     "EEGMiner",
     "EEGNet",
-    "EEGNetv4",
     "EEGNeX",
     "EEGSym",
     "EEGSimpleConv",

--- a/braindecode/models/attn_sleep.py
+++ b/braindecode/models/attn_sleep.py
@@ -8,7 +8,6 @@ from copy import deepcopy
 
 import torch
 import torch.nn.functional as F
-from mne.utils import deprecated
 from torch import nn
 
 from braindecode.models.base import EEGModuleMixin
@@ -538,12 +537,3 @@ class _PositionwiseFeedForward(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Implements FFN equation."""
         return self.w_2(self.dropout(self.activate(self.w_1(x))))
-
-
-@deprecated(
-    "`SleepStagerEldele2021` was renamed to `AttnSleep` in v1.12 to follow original author's name; this alias will be removed in v1.14."
-)
-class SleepStagerEldele2021(AttnSleep):
-    r"""Deprecated alias for SleepStagerEldele2021."""
-
-    pass

--- a/braindecode/models/eegnet.py
+++ b/braindecode/models/eegnet.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Dict, Optional
 
 from einops.layers.torch import Rearrange
-from mne.utils import deprecated, warn
+from mne.utils import warn
 from torch import nn
 
 from braindecode.functional import glorot_weight_zero_bias
@@ -348,12 +348,3 @@ class EEGNet(EEGModuleMixin, nn.Sequential):
         self.add_module("final_layer", module)
 
         glorot_weight_zero_bias(self)
-
-
-@deprecated(
-    "`EEGNetv4` was renamed to `EEGNet` in v1.12; this alias will be removed in v1.14."
-)
-class EEGNetv4(EEGNet):
-    r"""Deprecated alias for EEGNet."""
-
-    pass

--- a/braindecode/models/tsinception.py
+++ b/braindecode/models/tsinception.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 from einops.layers.torch import Rearrange
-from mne.utils import deprecated, warn
+from mne.utils import warn
 
 from braindecode.models.base import EEGModuleMixin
 
@@ -283,13 +283,3 @@ class TSception(EEGModuleMixin, nn.Module):
             activation(),
             nn.AvgPool2d(kernel_size=(1, pool_size), stride=(1, pool_size)),
         )
-
-
-@deprecated(
-    "`TSceptionV1` was renamed to `TSception` in v1.12; "
-    "this alias will be removed in v1.14."
-)
-class TSceptionV1(TSception):
-    r"""Deprecated alias for TSception."""
-
-    pass

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -189,8 +189,6 @@ def _init_models_dict():
             issubclass(m[1], models.base.EEGModuleMixin)
             and m[1] != models.base.EEGModuleMixin
         ):
-            if m[1].__name__ == "EEGNetv4":
-                continue
             models_dict[m[0]] = m[1]
 
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -45,7 +45,7 @@ API and behavior changes
   :class:`braindecode.models.EEGNet`), ``SleepStagerEldele2021`` (use
   :class:`braindecode.models.AttnSleep`), ``TSceptionV1`` (use
   :class:`braindecode.models.TSception`), and ``BNCI2014001`` (use
-  :class:`braindecode.datasets.BNCI2014_001`).
+  :class:`braindecode.datasets.BNCI2014_001`). (:gh:`1045` by `Bhargav Kowshik`_)
 
 Requirements
 ============
@@ -1248,3 +1248,4 @@ Authors
 .. _Léo Burgund: https://github.com/leob000
 .. _Adam Mounir: https://github.com/adammounir
 .. _Yiheng Li: https://github.com/YihengLi-1
+.. _Bhargav Kowshik: https://github.com/bkowshik

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -40,7 +40,12 @@ Enhancements
 API and behavior changes
 ========================
 
-- None yet
+- Removed the deprecated aliases that were scheduled for removal after their
+  deprecation in v1.2/v1.3: ``EEGNetv4`` (use
+  :class:`braindecode.models.EEGNet`), ``SleepStagerEldele2021`` (use
+  :class:`braindecode.models.AttnSleep`), ``TSceptionV1`` (use
+  :class:`braindecode.models.TSception`), and ``BNCI2014001`` (use
+  :class:`braindecode.datasets.BNCI2014_001`).
 
 Requirements
 ============

--- a/test/unit_tests/models/test_config.py
+++ b/test/unit_tests/models/test_config.py
@@ -77,9 +77,9 @@ def test_fractional_input_window_seconds_config(n_times, input_window_seconds, s
     This test validates the fix for the bug where int() truncation rejected
     valid configurations in the pydantic validator.
     """
-    from braindecode.models import EEGNetv4
+    from braindecode.models import EEGNet
 
-    ModelConfig = make_model_config(EEGNetv4, ["n_chans", "n_outputs", "n_times"])
+    ModelConfig = make_model_config(EEGNet, ["n_chans", "n_outputs", "n_times"])
 
     # Should not raise ValueError
     cfg = ModelConfig(
@@ -111,9 +111,9 @@ def test_fractional_input_window_seconds_inference_config(
     This test validates that the pydantic validator uses round() instead of int()
     when inferring n_times.
     """
-    from braindecode.models import EEGNetv4
+    from braindecode.models import EEGNet
 
-    ModelConfig = make_model_config(EEGNetv4, ["n_chans", "n_outputs", "n_times"])
+    ModelConfig = make_model_config(EEGNet, ["n_chans", "n_outputs", "n_times"])
 
     cfg = ModelConfig(
         n_chans=22,

--- a/test/unit_tests/models/test_util.py
+++ b/test/unit_tests/models/test_util.py
@@ -89,7 +89,6 @@ def test_models_dict():
             inspect.isclass(m)
             and issubclass(m, models.base.EEGModuleMixin)
             and m != models.base.EEGModuleMixin
-            and m.__name__ != "EEGNetv4"
         )
     ]
     models_list = list(models_dict.items())


### PR DESCRIPTION
## Summary

Removes four public deprecated aliases that were scheduled for removal in **v1.4**. The development tree is now `1.6.1dev0` (latest release v1.5.1), so these are two minor versions past their planned removal.

| Removed alias | Use instead | Deprecated in | Where it lived |
|---|---|---|---|
| `EEGNetv4` | `EEGNet` | v1.2 (#775) | `braindecode.models` (exported) |
| `SleepStagerEldele2021` | `AttnSleep` | v1.2 (#775) | `braindecode.models.attn_sleep` |
| `TSceptionV1` | `TSception` | v1.2 (#775) | `braindecode.models.tsinception` |
| `BNCI2014001` | `BNCI2014_001` | v1.3 (#826) | `braindecode.datasets.moabb` |

## Why now

Each deprecation message advertised removal in `v1.14` (and rename in `v1.12` / `v1.13`), which made the removal look far in the future. Those version strings are typos — an extra `1` was inserted after `v1.`:

- The three model renames actually landed in **v1.2.0** — `version.py` at the rename commit read `1.2.0`, and they're documented under the "Current 1.2" section of `whats_new.rst`.
- The `BNCI2014001` rename actually landed in **v1.3.0** (#826).
- The intended removal version was therefore **v1.4**, not `v1.14`.

Read correctly, these aliases were due for removal in v1.4. They have now been deprecated for four-plus releases, which is an ample deprecation window, so this PR finishes the job (and removes the misleading version strings in the process).

## Migration

```python
# before
from braindecode.models import EEGNetv4
from braindecode.models.attn_sleep import SleepStagerEldele2021
from braindecode.models.tsinception import TSceptionV1
from braindecode.datasets.moabb import BNCI2014001

# after
from braindecode.models import EEGNet, AttnSleep, TSception
from braindecode.datasets import BNCI2014_001
```

Note: only `EEGNetv4` was re-exported at the package level (in `braindecode.models.__all__`); the other three were only reachable from their submodules.

## Changes

- Remove the four alias classes and their now-unused `from mne.utils import deprecated` imports (kept `warn` where it is still used in the same module).
- `braindecode/models/__init__.py`: drop `EEGNetv4` from the import and from `__all__`.
- `braindecode/models/util.py`: remove the `EEGNetv4` special-case in `_init_models_dict()` — it existed only to hide the alias from the model registry.
- `test/unit_tests/models/test_util.py`: drop the matching `EEGNetv4` exclusion in `test_models_dict` so the registry/`models_dict` equality check stays exact.
- `test/unit_tests/models/test_config.py`: use `EEGNet` instead of `EEGNetv4`.
- `docs/whats_new.rst`: add an entry under "API and behavior changes" for the current release cycle. Historical changelog entries that mention the old names are left untouched as a record.

## Testing

- `pytest test/unit_tests/models/test_util.py test/unit_tests/models/test_config.py` → **136 passed**.
- `ruff check` is clean on all modified files (no unused imports, no undefined names).
- No remaining references to the removed names in `.py` sources.

## Notes

This is a backward-incompatible removal of public API. Happy to retarget it to a specific release if you prefer to batch breaking changes for a particular version.