### PR TITLE
ci: cap pytest below 9.1 to keep pytest_cases working

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -45,7 +45,11 @@ API and behavior changes
 Requirements
 ============
 
-- None yet
+- Cap the test dependency to ``pytest<9.1`` in the ``tests`` extra. ``pytest``
+  9.1.0 changed the ``IdMaker`` constructor signature, which breaks
+  ``pytest_cases`` 3.10.1 and makes the whole test suite crash at collection
+  time. The cap can be lifted once ``pytest_cases`` supports ``pytest>=9.1``.
+  By `Adam Mounir`_.
 
 Bug fixes
 ==========

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ eegprep = ["eegprep[eeglabio]>=0.2.23"]
 hub = ["huggingface_hub[torch]>=0.20.0", "zarr>=3.0"]
 viz = ["captum>=0.7.0"]
 tests = [
-    'pytest',
+    'pytest<9.1',  # pytest 9.1.0 changed IdMaker's signature, which breaks pytest_cases 3.10.1 (crash at collection time). Remove the cap once pytest_cases supports pytest >=9.1.
     'pytest-cov',
     'codecov',
     'pytest_cases',


### PR DESCRIPTION
## Problem

CI is currently red on **basically every open PR**, and it's not the PRs' fault.

`pytest` **9.1.0** (released a few days ago) changed the `IdMaker` constructor signature, which breaks `pytest_cases` **3.10.1** (the latest release). The suite now crashes at **collection time**, before any test runs:

```
TypeError: IdMaker.__init__() takes 7 positional arguments but 8 were given
    (pytest_cases/common_pytest.py)
```

We don't cap `pytest` in the `tests` extra, so fresh CI jobs pull 9.1.0 and die instantly. Any green checks still visible are stale results from before 9.1.0 dropped.

## Confirmation (A/B, same code & pytest_cases 3.10.1)

| pytest | result |
|--------|--------|
| 9.0.3  | 123 collected → 109 passed / 14 skipped |
| 9.1.0  | crash at collection (`IdMaker` TypeError) |

So it's **9.1.0 specifically** — `pytest 9.0.x` is fine.

## Fix

Cap `pytest<9.1` in the `tests` extra until `pytest_cases` supports pytest >= 9.1. This PR's own CI validates the fix (green = cap works).

## Follow-up

Once merged, open PRs (incl. #1037) just need `master` merged in ("Update branch") to pick up the cap and go green.