### PR TITLE
[MAINT] Silence drop_last small-trainset warning in signal-arg tests

### DIFF
--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -104,7 +104,7 @@ Code health
   (:gh:`1053`) in the ``test_eegneuralnet`` signal-argument tests, which
   intentionally fit tiny mock data to check argument propagation rather than
   to train. Keeps the warning meaningful by not emitting it on every CI run.
-  (:gh:`PLACEHOLDER_PR` by `Adam Mounir`_)
+  (:gh:`1056` by `Adam Mounir`_)
 
 - Install CPU-only PyTorch wheels in the ``tests`` and ``docs`` CI
   workflows via ``UV_TORCH_BACKEND=cpu``. GitHub runners have no GPU, so

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -100,6 +100,12 @@ Bug fixes
 Code health
 ============
 
+- Silence the new "training set smaller than ``batch_size``" warning
+  (:gh:`1053`) in the ``test_eegneuralnet`` signal-argument tests, which
+  intentionally fit tiny mock data to check argument propagation rather than
+  to train. Keeps the warning meaningful by not emitting it on every CI run.
+  (:gh:`PLACEHOLDER_PR` by `Adam Mounir`_)
+
 - Install CPU-only PyTorch wheels in the ``tests`` and ``docs`` CI
   workflows via ``UV_TORCH_BACKEND=cpu``. GitHub runners have no GPU, so
   the default CUDA build pulled ~1.8 GiB of unused ``nvidia-*`` wheels and

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -274,6 +274,7 @@ def test_clonable(eegneuralnet_cls, preds):
     clone(eegneuralnet)
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_set_signal_params_numpy(eegneuralnet_cls, preds, Xy):
     X, y = Xy
     net = eegneuralnet_cls(
@@ -291,6 +292,7 @@ def test_set_signal_params_numpy(eegneuralnet_cls, preds, Xy):
     assert net.module_.n_outputs == (1 if isinstance(net, EEGRegressor) else 4)
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_set_signal_params_epochs(eegneuralnet_cls, preds, epochs):
     y = epochs.metadata.target.values
     net = eegneuralnet_cls(
@@ -311,6 +313,7 @@ def test_set_signal_params_epochs(eegneuralnet_cls, preds, epochs):
     assert net.module_.sfreq == 10
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_set_signal_params_torch_ds(eegneuralnet_cls, preds):
     n_outputs = 1 if eegneuralnet_cls == EEGRegressor else 4
     net = eegneuralnet_cls(
@@ -329,6 +332,7 @@ def test_set_signal_params_torch_ds(eegneuralnet_cls, preds):
     assert net.module_.n_outputs == n_outputs
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_set_signal_params_windows_ds_metadata(
     eegneuralnet_cls, preds, windows_dataset_metadata
 ):
@@ -348,6 +352,7 @@ def test_set_signal_params_windows_ds_metadata(
     assert net.module_.n_outputs == n_outputs
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_set_signal_params_windows_ds_channels(
     eegneuralnet_cls, preds, windows_dataset_channels
 ):
@@ -368,6 +373,7 @@ def test_set_signal_params_windows_ds_channels(
     assert net.module_.n_outputs == n_outputs
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_set_signal_params_concat_ds_metadata(
     eegneuralnet_cls, preds, concat_dataset_metadata
 ):
@@ -387,6 +393,7 @@ def test_set_signal_params_concat_ds_metadata(
     assert net.module_.n_outputs == n_outputs
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_set_signal_params_concat_ds_channels(
     eegneuralnet_cls, preds, concat_dataset_channels
 ):
@@ -407,6 +414,7 @@ def test_set_signal_params_concat_ds_channels(
     assert net.module_.n_outputs == n_outputs
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_initialized_module(eegneuralnet_cls, preds, caplog, Xy):
     X, y = Xy
     module = MockModuleReturnMockedPreds(
@@ -523,6 +531,7 @@ def test_cropped_trial_epoch_scoring(net):
     assert valid_scoring.name == "valid_accuracy"
 
 
+@pytest.mark.filterwarnings("ignore:The training set has")
 def test_set_signal_params_slice_dataset(eegneuralnet_cls, preds, slice_dataset):
     if eegneuralnet_cls != EEGClassifier:
         n_outputs = 1


### PR DESCRIPTION
Follow-up to #1053. That PR added a UserWarning when `iterator_train__drop_last` drops every training batch on small datasets. It surfaced that several `test_eegneuralnet` signal-argument tests were silently no-op-training — they fit 5–10 mock samples at `batch_size=32/128` only to check that `n_chans`/`n_times`/`n_outputs` propagate, not to actually train.

This scopes a `@pytest.mark.filterwarnings("ignore:The training set has")` to those 9 tests (×2 estimators) so the warning no longer spams CI logs, while staying active everywhere else. The test that asserts the warning fires is untouched.

Not using `drop_last=False` here on purpose: forcing real training on the mock modules surfaces unrelated canned-prediction shape mismatches.