### PR TITLE
[FIX] Align EEGTCNet, SSTDPN & ATCNet with original source implementations

### DIFF
--- a/braindecode/models/atcnet.py
+++ b/braindecode/models/atcnet.py
@@ -489,9 +489,12 @@ class ATCNet(EEGModuleMixin, nn.Module):
         The official Keras implementation applies ``L2`` weight decay only to the
         convolution / TCN kernels (``conv_weightDecay = 0.009``) and to the final
         dense layer (``dense_weightDecay = 0.5``); biases, BatchNorm and attention
-        weights are left undecayed. PyTorch's ``weight_decay`` plays the role of
-        Keras' ``L2`` penalty, so passing these groups to an optimizer reproduces
-        the source regularization.
+        weights are left undecayed. This reproduces the Keras ``L2`` kernel penalty
+        only for optimizers that implement ``weight_decay`` as a coupled L2 term,
+        e.g. :class:`torch.optim.SGD` or :class:`torch.optim.Adam` (as used by the
+        official code). For decoupled-weight-decay optimizers such as
+        :class:`torch.optim.AdamW`, ``weight_decay`` is *not* equivalent to a Keras
+        ``L2`` penalty.
 
         Parameters
         ----------

--- a/braindecode/models/atcnet.py
+++ b/braindecode/models/atcnet.py
@@ -2,14 +2,21 @@
 #
 # License: BSD (3-clause)
 import math
+from typing import Optional
 
 import torch
 from einops.layers.torch import Rearrange
 from mne.utils import warn
 from torch import nn
+from torch.nn.utils.parametrize import is_parametrized, register_parametrization
 
 from braindecode.models.base import EEGModuleMixin
-from braindecode.modules import CausalConv1d, Ensure4d, MaxNormLinear
+from braindecode.modules import (
+    CausalConv1d,
+    Ensure4d,
+    MaxNormLinear,
+    MaxNormParametrize,
+)
 
 
 class ATCNet(EEGModuleMixin, nn.Module):
@@ -213,6 +220,16 @@ class ATCNet(EEGModuleMixin, nn.Module):
     max_norm_const : float
         Maximum L2-norm constraint imposed on weights of the last
         fully-connected layer. Defaults to 0.25.
+    conv_max_norm_const : float | None
+        If not ``None``, applies a max-norm constraint (via a weight
+        parametrization) to the convolution kernels of :class:`_ConvBlock` and
+        :class:`_TCNResidualBlock`, matching the official implementation which
+        uses ``0.6``. When ``None`` (default), no constraint is applied to those
+        layers, preserving the previous behavior. The complementary ``L2``
+        weight decay of the official code can be obtained from
+        :meth:`source_optimizer_param_groups`.
+
+        .. versionadded:: 1.6.1
 
     Notes
     -----
@@ -257,6 +274,7 @@ class ATCNet(EEGModuleMixin, nn.Module):
         tcn_activation: type[nn.Module] = nn.ELU,
         concat=False,
         max_norm_const=0.25,
+        conv_max_norm_const: Optional[float] = None,
         chs_info=None,
         n_times=None,
     ):
@@ -325,6 +343,7 @@ class ATCNet(EEGModuleMixin, nn.Module):
         self.tcn_activation = tcn_activation
         self.concat = concat
         self.max_norm_const = max_norm_const
+        self.conv_max_norm_const = conv_max_norm_const
         self.tcn_n_filters = int(self.conv_block_depth_mult * self.conv_block_n_filters)
         map = dict()
         for w in range(self.n_windows):
@@ -346,6 +365,7 @@ class ATCNet(EEGModuleMixin, nn.Module):
             pool_size_2=conv_block_pool_size_2,
             depth_mult=conv_block_depth_mult,
             dropout=conv_block_dropout,
+            conv_max_norm=self.conv_max_norm_const,
         )
 
         self.F2 = int(conv_block_depth_mult * conv_block_n_filters)
@@ -375,6 +395,7 @@ class ATCNet(EEGModuleMixin, nn.Module):
                             dropout=self.tcn_dropout,
                             activation=self.tcn_activation,
                             dilation=2**i,
+                            conv_max_norm=self.conv_max_norm_const,
                         )
                         for i in range(self.tcn_depth)
                     ]
@@ -458,6 +479,90 @@ class ATCNet(EEGModuleMixin, nn.Module):
 
         return self.out_fun(sw_concat_agg)
 
+    def source_optimizer_param_groups(
+        self,
+        conv_weight_decay: float = 0.009,
+        dense_weight_decay: float = 0.5,
+    ) -> list[dict]:
+        r"""Source-faithful optimizer parameter groups for ATCNet.
+
+        The official Keras implementation applies ``L2`` weight decay only to the
+        convolution / TCN kernels (``conv_weightDecay = 0.009``) and to the final
+        dense layer (``dense_weightDecay = 0.5``); biases, BatchNorm and attention
+        weights are left undecayed. PyTorch's ``weight_decay`` plays the role of
+        Keras' ``L2`` penalty, so passing these groups to an optimizer reproduces
+        the source regularization.
+
+        Parameters
+        ----------
+        conv_weight_decay : float
+            Weight decay applied to the convolution and TCN kernels. Defaults to
+            ``0.009`` as in the official code.
+        dense_weight_decay : float
+            Weight decay applied to the final (dense) layer weights. Defaults to
+            ``0.5`` as in the official code.
+
+        Returns
+        -------
+        list of dict
+            Parameter groups ready to be passed to a ``torch.optim`` optimizer:
+            convolution/TCN kernels, final dense weights, and everything else
+            (no decay).
+
+        Examples
+        --------
+        >>> model = ATCNet(n_chans=22, n_outputs=4, n_times=1125)  # doctest: +SKIP
+        >>> opt = torch.optim.Adam(model.source_optimizer_param_groups())  # doctest: +SKIP
+        """
+
+        def weight_leaf(module):
+            # Return the leaf weight Parameter, accounting for a registered
+            # max-norm parametrization (``conv_max_norm_const`` / MaxNormLinear).
+            if is_parametrized(module, "weight"):
+                return module.parametrizations.weight.original
+            return module.weight
+
+        conv_weights: list[nn.Parameter] = []
+        dense_weights: list[nn.Parameter] = []
+        decayed_ids: set[int] = set()
+
+        # Convolution / TCN kernels (Keras L2 = 0.009).
+        for parent in (self.conv_block, self.temporal_conv_nets):
+            for module in parent.modules():
+                if isinstance(module, (nn.Conv1d, nn.Conv2d)):
+                    weight = weight_leaf(module)
+                    conv_weights.append(weight)
+                    decayed_ids.add(id(weight))
+
+        # Final dense / readout weights (Keras L2 = 0.5).
+        for module in self.final_layer.modules():
+            if isinstance(module, nn.Linear):
+                weight = weight_leaf(module)
+                dense_weights.append(weight)
+                decayed_ids.add(id(weight))
+
+        # Everything else (biases, BatchNorm, attention) is left undecayed.
+        other = [p for p in self.parameters() if id(p) not in decayed_ids]
+
+        return [
+            {"params": conv_weights, "weight_decay": conv_weight_decay},
+            {"params": dense_weights, "weight_decay": dense_weight_decay},
+            {"params": other, "weight_decay": 0.0},
+        ]
+
+
+def _register_max_norm(max_norm, *convs):
+    """Register a max-norm weight parametrization on each given convolution.
+
+    No-op when ``max_norm`` is ``None`` or a passed layer is not a convolution
+    (e.g. an ``nn.Identity`` residual shortcut).
+    """
+    if max_norm is None:
+        return
+    for conv in convs:
+        if isinstance(conv, (nn.Conv1d, nn.Conv2d)):
+            register_parametrization(conv, "weight", MaxNormParametrize(max_norm))
+
 
 class _ConvBlock(nn.Module):
     r"""Convolutional block proposed in ATCNet [1]_, inspired by the EEGNet.
@@ -487,6 +592,7 @@ class _ConvBlock(nn.Module):
         pool_size_2=7,
         depth_mult=2,
         dropout=0.3,
+        conv_max_norm: Optional[float] = None,
     ):
         super().__init__()
 
@@ -533,6 +639,9 @@ class _ConvBlock(nn.Module):
         self.pool3 = nn.AvgPool2d(kernel_size=(pool_size_2, 1))
 
         self.drop3 = nn.Dropout2d(dropout)
+
+        # Optional source-faithful max-norm constraint on the conv kernels.
+        _register_max_norm(conv_max_norm, self.conv1, self.conv2, self.conv3)
 
     def forward(self, X):
         # ----- Temporal convolution -----
@@ -662,6 +771,7 @@ class _TCNResidualBlock(nn.Module):
         dropout=0.3,
         activation: type[nn.Module] = nn.ELU,
         dilation=1,
+        conv_max_norm: Optional[float] = None,
     ):
         super().__init__()
         self.activation = activation()
@@ -705,6 +815,10 @@ class _TCNResidualBlock(nn.Module):
             )
         else:
             self.reshaping_conv = nn.Identity()
+
+        # Optional source-faithful max-norm constraint on the conv kernels
+        # (reshaping_conv may be nn.Identity, which the helper skips).
+        _register_max_norm(conv_max_norm, self.conv1, self.conv2, self.reshaping_conv)
 
     def forward(self, X):
         # Dimension: (batch_size, F2, Tw)

--- a/braindecode/models/eegtcnet.py
+++ b/braindecode/models/eegtcnet.py
@@ -33,8 +33,10 @@ class EEGTCNet(EEGModuleMixin, nn.Module):
         Number of temporal filters in the first convolutional layer. Default is 8.
     kern_length : int, optional
         Length of the temporal kernel in the first convolutional layer. Default is 64.
-    dropout : float, optional
-        Dropout rate. Default is 0.5.
+    drop_prob : float, optional
+        Default dropout rate, used for both the EEGNet front-end and the TCN
+        block unless overridden by ``drop_prob_eeg`` / ``drop_prob_tcn``.
+        Default is 0.5.
     depth : int, optional
         Number of residual blocks in the TCN. Default is 2.
     kernel_size : int, optional
@@ -44,6 +46,20 @@ class EEGTCNet(EEGModuleMixin, nn.Module):
     max_norm_const : float
         Maximum L2-norm constraint imposed on weights of the last
         fully-connected layer. Defaults to 0.25.
+    drop_prob_eeg : float | None, optional
+        Dropout rate for the EEGNet front-end. If ``None`` (default), falls back
+        to ``drop_prob``. The source/paper uses ``0.2`` for BCI IV 2a.
+    drop_prob_tcn : float | None, optional
+        Dropout rate for the TCN block. If ``None`` (default), falls back to
+        ``drop_prob``. The source/paper uses ``0.3`` for BCI IV 2a.
+    tcn_batch_norm : bool, optional
+        If ``True`` (default), insert a :class:`~torch.nn.BatchNorm1d` after each
+        TCN convolution and use a bias in the residual ``1x1`` downsample, matching
+        the original Keras source. Set to ``False`` to recover the previous
+        braindecode architecture (e.g. to load checkpoints trained before this
+        change). Default is ``True``.
+
+        .. versionadded:: 1.6.1
 
     References
     ----------
@@ -72,6 +88,9 @@ class EEGTCNet(EEGModuleMixin, nn.Module):
         kernel_size: int = 4,
         filters: int = 12,
         max_norm_const: float = 0.25,
+        drop_prob_eeg: float | None = None,
+        drop_prob_tcn: float | None = None,
+        tcn_batch_norm: bool = True,
     ):
         super().__init__(
             n_outputs=n_outputs,
@@ -85,6 +104,11 @@ class EEGTCNet(EEGModuleMixin, nn.Module):
 
         self.activation = activation
         self.drop_prob = drop_prob
+        # Separate dropout rates for the EEGNet front-end and the TCN block;
+        # fall back to ``drop_prob`` when not explicitly set.
+        self.drop_prob_eeg = drop_prob if drop_prob_eeg is None else drop_prob_eeg
+        self.drop_prob_tcn = drop_prob if drop_prob_tcn is None else drop_prob_tcn
+        self.tcn_batch_norm = tcn_batch_norm
         self.depth_multiplier = depth_multiplier
         self.filter_1 = filter_1
         self.kern_length = kern_length
@@ -103,7 +127,7 @@ class EEGTCNet(EEGModuleMixin, nn.Module):
             filter_1=self.filter_1,
             kern_length=self.kern_length,
             depth_multiplier=self.depth_multiplier,
-            drop_prob=self.drop_prob,
+            drop_prob=self.drop_prob_eeg,
             activation=self.activation,
         )
         self.arrange_dim_eegnet = Rearrange(
@@ -116,8 +140,9 @@ class EEGTCNet(EEGModuleMixin, nn.Module):
             depth=self.depth,
             kernel_size=self.kernel_size,
             filters=self.filters,
-            drop_prob=self.drop_prob,
+            drop_prob=self.drop_prob_tcn,
             activation=self.activation,
+            batch_norm=self.tcn_batch_norm,
         )
 
         # Classification Block
@@ -277,6 +302,7 @@ class _TCNBlock(nn.Module):
         filters: int,
         drop_prob: float,
         activation: type[nn.Module] = nn.ELU,
+        batch_norm: bool = True,
     ):
         super().__init__()
         self.activation = activation()
@@ -284,10 +310,15 @@ class _TCNBlock(nn.Module):
         self.depth = depth
         self.filters = filters
         self.kernel_size = kernel_size
+        self.batch_norm = batch_norm
 
         self.layers = nn.ModuleList()
+        # The Keras source uses a bias on the residual 1x1 downsample, paired
+        # with the per-conv BatchNorm; the previous braindecode default omitted
+        # both. Keeping them on the same flag makes ``batch_norm=False`` reproduce
+        # the legacy architecture exactly.
         self.downsample = (
-            nn.Conv1d(input_dimension, filters, kernel_size=1, bias=False)
+            nn.Conv1d(input_dimension, filters, kernel_size=1, bias=batch_norm)
             if input_dimension != filters
             else None
         )
@@ -295,31 +326,33 @@ class _TCNBlock(nn.Module):
         for i in range(depth):
             dilation = 2**i
             padding = (kernel_size - 1) * dilation
+            in_dim = input_dimension if i == 0 else filters
             conv_block = nn.Sequential(
-                nn.Conv1d(
-                    in_channels=input_dimension if i == 0 else filters,
-                    out_channels=filters,
-                    kernel_size=kernel_size,
-                    dilation=dilation,
-                    padding=padding,
-                    bias=False,
-                ),
-                Chomp1d(padding),
-                self.activation,
-                nn.Dropout(self.drop_prob),
-                nn.Conv1d(
-                    in_channels=filters,
-                    out_channels=filters,
-                    kernel_size=kernel_size,
-                    dilation=dilation,
-                    padding=padding,
-                    bias=False,
-                ),
-                Chomp1d(padding),
-                self.activation,
-                nn.Dropout(self.drop_prob),
+                *self._conv_unit(in_dim, dilation, padding),
+                *self._conv_unit(filters, dilation, padding),
             )
             self.layers.append(conv_block)
+
+    def _conv_unit(self, in_channels: int, dilation: int, padding: int):
+        # Conv -> Chomp -> [BatchNorm] -> activation -> Dropout, as in the
+        # original EEG-TCNet Keras implementation.
+        unit = [
+            nn.Conv1d(
+                in_channels=in_channels,
+                out_channels=self.filters,
+                kernel_size=self.kernel_size,
+                dilation=dilation,
+                padding=padding,
+                bias=False,
+            ),
+            Chomp1d(padding),
+        ]
+        if self.batch_norm:
+            # Keras BatchNormalization defaults: momentum=0.99 (-> 0.01 in
+            # PyTorch convention) and epsilon=1e-3.
+            unit.append(nn.BatchNorm1d(self.filters, momentum=0.01, eps=1e-3))
+        unit += [self.activation, nn.Dropout(self.drop_prob)]
+        return unit
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # x shape: (batch_size, time_steps, input_dimension)

--- a/braindecode/models/eegtcnet.py
+++ b/braindecode/models/eegtcnet.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 from einops.layers.torch import Rearrange
 
 from braindecode.models.base import EEGModuleMixin
+from braindecode.models.util import _disable_batch_norm_training_if_batch_size_one
 from braindecode.modules import Chomp1d, MaxNormLinear
 
 
@@ -152,6 +153,7 @@ class EEGTCNet(EEGModuleMixin, nn.Module):
             max_norm_val=self.max_norm_const,
         )
 
+    @_disable_batch_norm_training_if_batch_size_one
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Forward pass of the EEGTCNet model.

--- a/braindecode/models/sstdpn.py
+++ b/braindecode/models/sstdpn.py
@@ -183,7 +183,11 @@ class SSTDPN(EEGModuleMixin, nn.Module):
         This constraint acts as an implicit force to push features away from the origin. Default is 1.0.
 
     proto_cpt_std : float, optional
-        Standard deviation for Intra-class Compactness Prototype initialization. Default is 0.01.
+        Standard deviation for Intra-class Compactness Prototype initialization. Default is 1.0,
+        matching the source ``torch.randn`` initialization.
+
+        .. versionchanged:: 1.6.1
+            Default changed from ``0.01`` to ``1.0`` to match the original implementation.
 
     spt_attn_global_context_kernel : int, optional
         Kernel size for global context embedding in Spatial-Spectral Attention module.
@@ -231,7 +235,7 @@ class SSTDPN(EEGModuleMixin, nn.Module):
         mvp_kernel_sizes: Optional[List[int]] = None,
         return_features: bool = False,
         proto_sep_maxnorm: float = 1.0,
-        proto_cpt_std: float = 0.01,
+        proto_cpt_std: float = 1.0,
         spt_attn_global_context_kernel: int = 250,
         spt_attn_epsilon: float = 1e-5,
         spt_attn_mode: str = "var",
@@ -327,9 +331,11 @@ class SSTDPN(EEGModuleMixin, nn.Module):
         """
 
         features = self.encoder(x)  # (b, feat_dim)
-        # Renormalize inter-class separation prototypes
+        # Renormalize inter-class separation prototypes. ``proto_sep`` has shape
+        # (n_outputs, feat_dim); the source constrains each class-row prototype
+        # vector (``||s_i|| <= S``), i.e. renorm along dim=0.
         self.proto_sep.data = torch.renorm(
-            self.proto_sep.data, p=2, dim=1, maxnorm=self.proto_sep_maxnorm
+            self.proto_sep.data, p=2, dim=0, maxnorm=self.proto_sep_maxnorm
         )
         logits = torch.einsum("bd,cd->bc", features, self.proto_sep)  # (b, n_outputs)
         logits = self.final_layer(logits)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -38,6 +38,17 @@ Enhancements
   By `Pierre Guetschel`_.
 - Add :class:`braindecode.models.EEGDINO`, the EEG-DINO self-distillation
   foundation model (Small/Medium/Large) with pretrained S/M weights. By `Bruno Aristimunha`_.
+- Add separate EEGNet and TCN dropout rates to
+  :class:`braindecode.models.EEGTCNet` via the new ``drop_prob_eeg`` and
+  ``drop_prob_tcn`` arguments, enabling the source/paper configuration
+  (``p_eeg=0.2``, ``p_tcn=0.3``). Both default to ``drop_prob``, so existing
+  behavior is unchanged. (:gh:`1060` by `Bruno Aristimunha`_)
+- Add an opt-in ``conv_max_norm_const`` argument and a
+  :meth:`~braindecode.models.ATCNet.source_optimizer_param_groups` helper to
+  :class:`braindecode.models.ATCNet`, exposing the official implementation's
+  convolution/TCN max-norm constraint (``0.6``) and ``L2`` weight-decay groups
+  (conv/TCN ``0.009``, dense ``0.5``). Defaults preserve current behavior.
+  (:gh:`1061` by `Bruno Aristimunha`_)
 
 API and behavior changes
 ========================
@@ -48,6 +59,16 @@ API and behavior changes
   :class:`braindecode.models.AttnSleep`), ``TSceptionV1`` (use
   :class:`braindecode.models.TSception`), and ``BNCI2014001`` (use
   :class:`braindecode.datasets.BNCI2014_001`). (:gh:`1045` by `Bhargav Kowshik`_)
+- :class:`braindecode.models.EEGTCNet` now inserts a
+  :class:`~torch.nn.BatchNorm1d` after each TCN convolution (and uses a bias in
+  the residual downsample), matching the original Keras implementation. This
+  closes a documented replicability gap but changes the default architecture and
+  parameter count; pass ``tcn_batch_norm=False`` to recover the previous
+  behavior (e.g. to load checkpoints trained before this change). By
+  `Bruno Aristimunha`_.
+- Change the default ``proto_cpt_std`` of :class:`braindecode.models.SSTDPN`
+  from ``0.01`` to ``1.0``, matching the source ``torch.randn`` initialization
+  of the intra-class compactness prototypes. By `Bruno Aristimunha`_.
 
 Requirements
 ============
@@ -60,6 +81,11 @@ Requirements
 
 Bug fixes
 ==========
+
+- Fix :class:`braindecode.models.SSTDPN` renormalizing ``proto_sep`` along the
+  wrong axis: the inter-class separation prototypes are now constrained per
+  class-row (``dim=0``) as in the paper/source (``||s_i|| <= S``), instead of
+  across classes (``dim=1``). (:gh:`1059` by `Bruno Aristimunha`_)
 
 - Fix :class:`~braindecode.models.ContraWR`,
   :class:`~braindecode.models.DeepSleepNet`, and

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -25,6 +25,7 @@ from braindecode.models import (
     BIOT,
     DGCNN,
     EEGPT,
+    SSTDPN,
     TCN,
     ATCNet,
     AttentionBaseNet,
@@ -1880,8 +1881,123 @@ def test_parameters_EEGTCNet():
 
     model = EEGTCNet(n_outputs=4, n_chans=22, n_times=1000)
     n_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
-    # 4.27 K according to the Table V from the original paper.
-    assert np.round(n_params / 1e3, 1) == 4.2
+    # 4.27 K according to Table V from the original paper. With the
+    # source-faithful TCN BatchNorm (default), braindecode reports 4.3 K, which
+    # is closer to the paper than the 4.2 K of the previous (BN-less) variant.
+    assert np.round(n_params / 1e3, 1) == 4.3
+
+
+def test_eegtcnet_tcn_batchnorm():
+    """TCN residual blocks carry source-faithful BatchNorm by default, and the
+    legacy (BN-less) architecture is recoverable with ``tcn_batch_norm=False``."""
+    model = EEGTCNet(n_outputs=4, n_chans=22, n_times=1125)
+    n_bn = sum(
+        isinstance(m, nn.BatchNorm1d) for m in model.tcn_block.modules()
+    )
+    # one BatchNorm per conv, two convs per residual block.
+    assert n_bn == 2 * model.depth
+    # the source uses a bias on the residual 1x1 downsample.
+    assert model.tcn_block.downsample.bias is not None
+
+    legacy = EEGTCNet(n_outputs=4, n_chans=22, n_times=1125, tcn_batch_norm=False)
+    assert not any(
+        isinstance(m, nn.BatchNorm1d) for m in legacy.tcn_block.modules()
+    )
+    assert legacy.tcn_block.downsample.bias is None
+    # both variants still produce valid logits.
+    x = torch.randn(2, 22, 1125)
+    assert model(x).shape == (2, 4)
+    assert legacy(x).shape == (2, 4)
+
+
+def test_eegtcnet_separate_dropout():
+    """EEGNet and TCN dropout rates can be set independently (source uses
+    p_eeg=0.2, p_tcn=0.3)."""
+    model = EEGTCNet(
+        n_outputs=4,
+        n_chans=22,
+        n_times=1125,
+        drop_prob_eeg=0.2,
+        drop_prob_tcn=0.3,
+    )
+    assert model.eegnet_tc.drop1.p == 0.2
+    assert model.eegnet_tc.drop2.p == 0.2
+    tcn_drops = [
+        m.p for m in model.tcn_block.modules() if isinstance(m, nn.Dropout)
+    ]
+    assert tcn_drops == [0.3] * (2 * model.depth)
+
+    # When unset, both fall back to the single ``drop_prob``.
+    default = EEGTCNet(n_outputs=4, n_chans=22, n_times=1125, drop_prob=0.4)
+    assert default.eegnet_tc.drop1.p == 0.4
+    assert all(
+        m.p == 0.4
+        for m in default.tcn_block.modules()
+        if isinstance(m, nn.Dropout)
+    )
+
+
+def test_sstdpn_proto_sep_constrains_class_rows():
+    """``proto_sep`` is renormalized per class-row (dim=0), so each prototype
+    vector has L2 norm <= ``proto_sep_maxnorm`` after a forward pass."""
+    model = SSTDPN(n_outputs=4, n_chans=22, n_times=1000)
+    model.proto_sep.data.fill_(10.0)
+    model(torch.randn(2, 22, 1000))
+    row_norms = model.proto_sep.detach().norm(p=2, dim=1)
+    # float32 renorm leaves a ~1e-6 residual; use a 1e-5 tolerance.
+    assert torch.all(row_norms <= model.proto_sep_maxnorm + 1e-5)
+
+
+def test_sstdpn_proto_cpt_std_default():
+    """ICP prototypes default to the source ``torch.randn`` std (1.0)."""
+    assert SSTDPN(n_outputs=4, n_chans=22, n_times=1000).proto_cpt_std == 1.0
+
+
+def test_atcnet_conv_max_norm():
+    """``conv_max_norm_const`` clamps the conv/TCN kernels per output filter,
+    while the default (``None``) adds no parameters and no constraint."""
+    max_norm = 0.6
+    model = ATCNet(n_chans=22, n_outputs=4, n_times=1125, conv_max_norm_const=max_norm)
+    model(torch.randn(2, 22, 1125))  # apply the parametrization
+
+    def max_filter_norm(weight):
+        return weight.reshape(weight.shape[0], -1).norm(p=2, dim=1).max().item()
+
+    assert max_filter_norm(model.conv_block.conv1.weight) <= max_norm + 1e-5
+    assert max_filter_norm(model.conv_block.conv2.weight) <= max_norm + 1e-5
+    assert (
+        max_filter_norm(model.temporal_conv_nets[0][0].conv1.weight)
+        <= max_norm + 1e-5
+    )
+
+    # Default leaves the architecture (and parameter count) untouched.
+    default = ATCNet(n_chans=22, n_outputs=4, n_times=1125)
+    assert sum(p.numel() for p in default.parameters()) == sum(
+        p.numel() for p in model.parameters()
+    )
+
+
+@pytest.mark.parametrize("conv_max_norm", [None, 0.6])
+def test_atcnet_source_optimizer_param_groups(conv_max_norm):
+    """The helper returns conv/dense/other groups with the source weight
+    decays, covering every parameter exactly once -- including when the conv
+    kernels are max-norm parametrized (``conv_max_norm_const`` set), in which
+    case the grouped entries must be the leaf ``.original`` parameters."""
+    model = ATCNet(
+        n_chans=22, n_outputs=4, n_times=1125, conv_max_norm_const=conv_max_norm
+    )
+    groups = model.source_optimizer_param_groups()
+
+    assert [g["weight_decay"] for g in groups] == [0.009, 0.5, 0.0]
+    grouped = [p for g in groups for p in g["params"]]
+    # every parameter is covered exactly once (compare by identity)...
+    assert {id(p) for p in grouped} == {id(p) for p in model.parameters()}
+    assert len(grouped) == len(list(model.parameters()))
+    # ...and each entry is a real trainable leaf (not a computed parametrized weight).
+    assert all(p.is_leaf and p.requires_grad for p in grouped)
+    assert all(len(g["params"]) > 0 for g in groups)
+    # groups are accepted by a real optimizer.
+    torch.optim.Adam(groups, lr=1e-3)
 
 
 @pytest.mark.parametrize("method", ["plv", "mag", "corr"])

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -1937,6 +1937,17 @@ def test_eegtcnet_separate_dropout():
     )
 
 
+def test_eegtcnet_batch_size_one_train_mode():
+    """Batch-size-1 forward in train mode must not raise even when the TCN
+    sequence collapses to length 1 (small n_times), now that BatchNorm is on by
+    default. With n_times=64 the EEGNet front-end reduces time to a single TCN
+    step, so the (1, filters, 1) tensor would break BatchNorm1d without the
+    batch-size-one guard."""
+    model = EEGTCNet(n_outputs=4, n_chans=22, n_times=64).train()
+    out = model(torch.randn(1, 22, 64))
+    assert out.shape == (1, 4)
+
+
 def test_sstdpn_proto_sep_constrains_class_rows():
     """``proto_sep`` is renormalized per class-row (dim=0), so each prototype
     vector has L2 norm <= ``proto_sep_maxnorm`` after a forward pass."""


### PR DESCRIPTION
## Summary

Reproducing several braindecode models against their authors' original implementations surfaced divergences that hurt source-faithful reproduction. This PR patches three models, closing #1059, #1060, and #1061 (root-caused in [bruAristimunha/eeg-replicatibility#3](https://github.com/bruAristimunha/eeg-replicatibility/issues/3)).

## Changes

### EEGTCNet (#1060)
- **Separate dropout rates** via new `drop_prob_eeg` / `drop_prob_tcn` (default `None` → fall back to `drop_prob`), enabling the paper's `p_eeg=0.2`, `p_tcn=0.3`. *Backward-compatible.*
- **Source-faithful TCN BatchNorm**: the Keras source places a `BatchNormalization` after every TCN convolution (`momentum=0.99` → torch `0.01`, `eps=1e-3`) and uses a biased residual downsample; braindecode omitted both. Added behind `tcn_batch_norm: bool = True`. ⚠️ **Behavior change**: this alters the default architecture and parameter count (4.20K → 4.30K trainable, closer to the paper's reported 4.27K). Pass `tcn_batch_norm=False` to recover the previous architecture (e.g. to load checkpoints trained before this change).

### SSTDPN (#1059)
- **Bug fix**: `proto_sep` was renormalized along `dim=1` (across classes). The paper/source constrains each class-row prototype (`‖s_i‖ ≤ S`), i.e. `dim=0`. Fixed.
- **`proto_cpt_std` default `0.01` → `1.0`** to match the source `torch.randn` initialization. `proto_cpt` is not used in `forward`, so this is init-only.

### ATCNet (#1061)
- **Opt-in `conv_max_norm_const`** (default `None`): applies the official max-norm constraint (`0.6`) to the conv/TCN kernels via a `MaxNormParametrize` weight parametrization. *Backward-compatible.*
- **`source_optimizer_param_groups()`**: returns the official `L2` weight-decay groups (conv/TCN `0.009`, dense `0.5`, everything else `0.0`) for use with any `torch.optim` optimizer.

## Backward compatibility
All additions are opt-in or fall back to prior behavior **except** the EEGTCNet TCN BatchNorm, which is documented under "API and behavior changes" in `whats_new.rst` with the `tcn_batch_norm=False` escape hatch.

## Tests
- New regression tests for each fix (TCN BatchNorm presence + legacy recovery, separate dropout routing, `proto_sep` per-class-row constraint, `proto_cpt_std` default, conv/TCN max-norm clamp, optimizer param-group coverage including the parametrized path).
- Updated `test_parameters_EEGTCNet` to the new 4.3K count.
- All model contract tests pass locally (config/HF round-trip, integration, batch-size-1 train mode, export, `jit.script`).

## Out of scope
The non-model items from eeg-replicatibility#3 (Deep4Net cropped config, CTNet/TIDNet evaluation protocol, SSTDPN dual-optimizer training loop) are training-pipeline concerns rather than model code, and are not addressed here.
