### PR TITLE
feat: opt-in channel positions in the batch for heterogeneous montages

### DIFF
--- a/braindecode/datasets/__init__.py
+++ b/braindecode/datasets/__init__.py
@@ -9,6 +9,7 @@ from .base import (
 )
 from .bcicomp import BCICompetitionIVDataset4
 from .bids import BIDSDataset, BIDSEpochsDataset
+from .collate import pad_channels_collate
 from .chb_mit import CHBMIT
 from .mne import create_from_mne_epochs, create_from_mne_raw
 from .moabb import BNCI2014_001, HGD, MOABBDataset
@@ -42,4 +43,5 @@ __all__ = [
     "SleepPhysionetChallenge2018",
     "create_from_X_y",
     "BCICompetitionIVDataset4",
+    "pad_channels_collate",
 ]

--- a/braindecode/datasets/__init__.py
+++ b/braindecode/datasets/__init__.py
@@ -9,8 +9,8 @@ from .base import (
 )
 from .bcicomp import BCICompetitionIVDataset4
 from .bids import BIDSDataset, BIDSEpochsDataset
-from .collate import pad_channels_collate
 from .chb_mit import CHBMIT
+from .collate import pad_channels_collate
 from .mne import create_from_mne_epochs, create_from_mne_raw
 from .moabb import BNCI2014_001, HGD, MOABBDataset
 from .nmt import NMT

--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -192,6 +192,31 @@ def _channel_info(mne_obj):
     return n_ch, type_str, sfreq
 
 
+def _compute_ch_pos(info, targets_from):
+    """Return ``(n_ch, 3)`` float32 electrode positions aligned to ``X``'s rows.
+
+    Positions are the MNE head-frame coordinates ``info["chs"][i]["loc"][:3]``
+    (meters) -- the same representation braindecode models already consume (see
+    e.g. ``signal_jepa``/``REVE``). When ``targets_from != "metadata"`` the
+    window's misc channels are dropped from ``X`` in ``__getitem__``, so the
+    matching misc rows are dropped here too. Emits a one-time ``UserWarning`` if
+    no channel carries a real position (no montage set).
+    """
+    pos = np.asarray([ch["loc"][:3] for ch in info["chs"]], dtype="float32")
+    if targets_from != "metadata":
+        misc_mask = np.asarray(info.get_channel_types()) == "misc"
+        pos = pos[~misc_mask]
+    has_pos = np.isfinite(pos).all(axis=1) & np.any(pos != 0, axis=1)
+    if pos.size and not has_pos.any():
+        warnings.warn(
+            "Returning channel positions but no montage is set: all positions "
+            "are zero/non-finite. Call ``raw.set_montage(...)`` (or set a "
+            "montage during preprocessing) before enabling ``return_ch_pos``.",
+            UserWarning,
+        )
+    return pos
+
+
 def _window_info(crop_inds, sfreq):
     """Extract window size from crop indices.
 
@@ -448,6 +473,10 @@ class RecordDataset(Dataset[tuple[np.ndarray, int | str, tuple[int, int, int]]])
     ):
         self._description = _create_description(description)
         self.transform = transform
+        # Opt-in: when True, ``__getitem__`` appends channel positions (n_ch, 3).
+        # Default off keeps the public ``(X, y, crop_inds)`` contract intact.
+        self.return_ch_pos = False
+        self._ch_pos = None
 
     @abstractmethod
     def __len__(self) -> int:
@@ -751,6 +780,19 @@ class EEGWindowsDataset(_ZarrMixin, RecordDataset):
     def raw(self, value):
         self._raw = value
 
+    @property
+    def ch_pos(self):
+        """Electrode positions ``(n_ch, 3)`` (x, y, z) aligned to ``X``'s channels.
+
+        Cached MNE head-frame coordinates in meters. Rows match the channels
+        returned by :meth:`__getitem__` (misc target channels excluded when
+        ``targets_from="channels"``). All-zero/NaN when no montage is set.
+        """
+        if self._ch_pos is None:
+            info = self._raw.info if self._raw is not None else self._make_mne_info()
+            self._ch_pos = _compute_ch_pos(info, self.targets_from)
+        return self._ch_pos
+
     def __getitem__(self, index: int):
         """Get a window and its target.
 
@@ -793,6 +835,8 @@ class EEGWindowsDataset(_ZarrMixin, RecordDataset):
                 y = X[misc_mask, :]
             y = y.copy()
             X = X[~misc_mask, :]
+        if self.return_ch_pos:
+            return X, y, crop_inds, self.ch_pos
         return X, y, crop_inds
 
     def __len__(self):
@@ -1017,6 +1061,23 @@ class WindowsDataset(_ZarrMixin, RecordDataset):
     def windows(self, value):
         self._windows = value
 
+    @property
+    def ch_pos(self):
+        """Electrode positions ``(n_ch, 3)`` (x, y, z) aligned to ``X``'s channels.
+
+        Cached MNE head-frame coordinates in meters. Rows match the channels
+        returned by :meth:`__getitem__` (misc target channels excluded when
+        ``targets_from="channels"``). All-zero/NaN when no montage is set.
+        """
+        if self._ch_pos is None:
+            info = (
+                self._windows.info
+                if self._windows is not None
+                else self._make_mne_info()
+            )
+            self._ch_pos = _compute_ch_pos(info, self.targets_from)
+        return self._ch_pos
+
     @staticmethod
     def _can_use_fast_get_epoch_from_raw(epochs: mne.BaseEpochs) -> bool:
         """Check if we can use the fast _get_epoch_from_raw method,
@@ -1068,6 +1129,8 @@ class WindowsDataset(_ZarrMixin, RecordDataset):
         # necessary to cast as list to get list of three tensors from batch,
         # otherwise get single 2d-tensor...
         crop_inds = self.crop_inds[index].tolist()
+        if self.return_ch_pos:
+            return X, y, crop_inds, self.ch_pos
         return X, y, crop_inds
 
     def __len__(self) -> int:
@@ -1457,6 +1520,43 @@ class BaseConcatDataset(ConcatDataset, HubDatasetMixin, Generic[T]):
                     f"or RawDataset; datasets[{i}] is {type(ds).__name__}."
                 )
         return self
+
+    def set_return_ch_pos(self, value: bool = True) -> "BaseConcatDataset":
+        """Toggle returning electrode positions from every subdataset.
+
+        When enabled, each windowed subdataset's ``__getitem__`` appends a
+        ``(n_ch, 3)`` array of electrode positions (x, y, z), so a batch yields
+        ``(X, y, crop_inds, ch_pos)``. Heterogeneous (variable-channel)
+        collections additionally need
+        :func:`braindecode.datasets.pad_channels_collate` as the DataLoader
+        ``collate_fn``. Default-off: leaves the ``(X, y, crop_inds)`` contract
+        untouched.
+
+        Parameters
+        ----------
+        value : bool
+            Whether to return channel positions (default ``True``).
+
+        Returns
+        -------
+        self : BaseConcatDataset
+        """
+        for ds in self.datasets:
+            ds.return_ch_pos = value
+        return self
+
+    @property
+    def ch_pos(self):
+        """Electrode positions ``(n_ch, 3)`` from the first recording.
+
+        Convenience accessor mirroring how the repr reports channel info "from
+        first recording". For per-sample positions in a heterogeneous
+        collection, enable :meth:`set_return_ch_pos` and read them from the
+        batch instead.
+        """
+        if not self.datasets:
+            raise ValueError("Empty BaseConcatDataset has no channel positions.")
+        return self.datasets[0].ch_pos
 
     def _outdated_save(self, path, overwrite=False):
         """This is a copy of the old saving function, that had inconsistent.

--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -779,6 +779,7 @@ class EEGWindowsDataset(_ZarrMixin, RecordDataset):
     @raw.setter
     def raw(self, value):
         self._raw = value
+        self._ch_pos = None  # invalidate cached positions
 
     @property
     def ch_pos(self):
@@ -1060,6 +1061,7 @@ class WindowsDataset(_ZarrMixin, RecordDataset):
     @windows.setter
     def windows(self, value):
         self._windows = value
+        self._ch_pos = None  # invalidate cached positions
 
     @property
     def ch_pos(self):
@@ -1556,7 +1558,14 @@ class BaseConcatDataset(ConcatDataset, HubDatasetMixin, Generic[T]):
         """
         if not self.datasets:
             raise ValueError("Empty BaseConcatDataset has no channel positions.")
-        return self.datasets[0].ch_pos
+        first = self.datasets[0]
+        if not hasattr(first, "ch_pos"):
+            raise AttributeError(
+                f"{type(first).__name__} does not expose channel positions; "
+                "ch_pos is available on windowed datasets (EEGWindowsDataset / "
+                "WindowsDataset)."
+            )
+        return first.ch_pos
 
     def _outdated_save(self, path, overwrite=False):
         """This is a copy of the old saving function, that had inconsistent.

--- a/braindecode/datasets/collate.py
+++ b/braindecode/datasets/collate.py
@@ -1,0 +1,105 @@
+"""Collate functions for braindecode datasets.
+
+:func:`pad_channels_collate` makes a :class:`~braindecode.datasets.BaseConcatDataset`
+that mixes recordings with *different channel sets* (heterogeneous montages)
+batchable: it pads every sample's channels to the batch maximum and emits a
+boolean channel mask. Pair it with ``set_return_ch_pos(True)`` so each sample
+carries its electrode positions -- channel identity is then encoded by the
+positions, not by row index, which is exactly what position-aware models
+(e.g. ``REVE``) consume.
+"""
+
+# Authors: The braindecode developers
+#
+# License: BSD (3-clause)
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+from torch.utils.data._utils.collate import default_collate
+
+__all__ = ["pad_channels_collate"]
+
+
+def pad_channels_collate(batch, pad_value: float = 0.0, pos_pad_value: float = 0.0):
+    """Collate variable-channel windows by padding channels to the batch maximum.
+
+    Each item of ``batch`` is the tuple returned by a windowed dataset's
+    ``__getitem__``: either ``(X, y, crop_inds)`` or, when
+    ``return_ch_pos=True`` (see
+    :meth:`braindecode.datasets.BaseConcatDataset.set_return_ch_pos`),
+    ``(X, y, crop_inds, ch_pos)``. Signals with different numbers of channels
+    are zero-padded along the channel axis to ``max_ch`` (the largest channel
+    count in the batch) so they can be stacked into a single tensor, and a
+    boolean ``ch_mask`` marks the real (non-padded) channels.
+
+    The time dimension is assumed uniform (fixed-length windows); a
+    :class:`ValueError` is raised otherwise.
+
+    This makes a heterogeneous collection **batchable**. *Consuming* the result
+    (so a model ignores padded channels) requires a position/channel-aware
+    model; fixed-geometry models (e.g. ``ShallowFBCSPNet``) structurally need a
+    constant channel count and cannot use variable batches.
+
+    Parameters
+    ----------
+    batch : list of tuple
+        Samples from a windowed dataset (see above).
+    pad_value : float
+        Value used to pad the signal ``X`` channel rows (default ``0.0``).
+    pos_pad_value : float
+        Value used to pad the position ``ch_pos`` rows (default ``0.0``).
+
+    Returns
+    -------
+    X : torch.Tensor
+        Padded signals, shape ``(batch, max_ch, n_times)``.
+    y : torch.Tensor
+        Targets, collated with ``default_collate``.
+    crop_inds : list
+        Crop indices, collated with ``default_collate``.
+    ch_pos : torch.Tensor
+        Only when the samples include positions. Padded positions, shape
+        ``(batch, max_ch, 3)``.
+    ch_mask : torch.Tensor
+        Boolean mask, shape ``(batch, max_ch)``; ``True`` for real channels,
+        ``False`` for padding.
+    """
+    if len(batch) == 0:
+        raise ValueError("pad_channels_collate received an empty batch.")
+
+    has_pos = len(batch[0]) >= 4
+    Xs = [np.asarray(item[0]) for item in batch]
+
+    n_times = Xs[0].shape[1]
+    if any(x.shape[1] != n_times for x in Xs):
+        raise ValueError(
+            "pad_channels_collate only pads the channel axis; all windows must "
+            f"share the same number of time samples, got {sorted({x.shape[1] for x in Xs})}."
+        )
+
+    bsz = len(batch)
+    max_ch = max(x.shape[0] for x in Xs)
+
+    X_out = torch.full((bsz, max_ch, n_times), pad_value, dtype=torch.float32)
+    ch_mask = torch.zeros((bsz, max_ch), dtype=torch.bool)
+    pos_out = (
+        torch.full((bsz, max_ch, 3), pos_pad_value, dtype=torch.float32)
+        if has_pos
+        else None
+    )
+    for i, (item, x) in enumerate(zip(batch, Xs)):
+        c = x.shape[0]
+        X_out[i, :c] = torch.as_tensor(x, dtype=torch.float32)
+        ch_mask[i, :c] = True
+        if has_pos:
+            pos_out[i, :c] = torch.as_tensor(np.asarray(item[3]), dtype=torch.float32)
+
+    # y and crop_inds carry no channel axis -> standard collation.
+    y = default_collate([item[1] for item in batch])
+    crop_inds = default_collate([item[2] for item in batch])
+
+    if has_pos:
+        return X_out, y, crop_inds, pos_out, ch_mask
+    return X_out, y, crop_inds, ch_mask

--- a/braindecode/datasets/collate.py
+++ b/braindecode/datasets/collate.py
@@ -93,13 +93,13 @@ def pad_channels_collate(batch, pad_value: float = 0.0, pos_pad_value: float = 0
         c = x.shape[0]
         X_out[i, :c] = torch.as_tensor(x, dtype=torch.float32)
         ch_mask[i, :c] = True
-        if has_pos:
+        if pos_out is not None:
             pos_out[i, :c] = torch.as_tensor(np.asarray(item[3]), dtype=torch.float32)
 
     # y and crop_inds carry no channel axis -> standard collation.
     y = default_collate([item[1] for item in batch])
     crop_inds = default_collate([item[2] for item in batch])
 
-    if has_pos:
+    if pos_out is not None:
         return X_out, y, crop_inds, pos_out, ch_mask
     return X_out, y, crop_inds, ch_mask

--- a/braindecode/eegneuralnet.py
+++ b/braindecode/eegneuralnet.py
@@ -134,7 +134,10 @@ class _EEGNeuralNet(NeuralNet, abc.ABC):
         i_window_in_trials = []
         i_window_stops = []
         window_ys = []
-        for X, y, i in self.get_iterator(dataset, drop_index=False):
+        for batch in self.get_iterator(dataset, drop_index=False):
+            # Tolerate extended batches (e.g. with channel positions): the
+            # window indices are always the third element.
+            X, y, i = batch[0], batch[1], batch[2]
             i_window_in_trials.append(i[0].cpu().numpy())
             i_window_stops.append(i[2].cpu().numpy())
             with torch.no_grad():

--- a/braindecode/eegneuralnet.py
+++ b/braindecode/eegneuralnet.py
@@ -135,8 +135,12 @@ class _EEGNeuralNet(NeuralNet, abc.ABC):
         i_window_stops = []
         window_ys = []
         for batch in self.get_iterator(dataset, drop_index=False):
-            # Tolerate extended batches (e.g. with channel positions): the
-            # window indices are always the third element.
+            if len(batch) > 3:
+                raise ValueError(
+                    "Cropped prediction does not support channel positions; "
+                    "disable return_ch_pos (set_return_ch_pos(False)) for cropped "
+                    "evaluation."
+                )
             X, y, i = batch[0], batch[1], batch[2]
             i_window_in_trials.append(i[0].cpu().numpy())
             i_window_stops.append(i[2].cpu().numpy())

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -448,7 +448,10 @@ def predict_trials(module, dataset, return_targets=True, batch_size=1, num_worke
     device = next(module.parameters()).device
     all_preds, all_ys, all_inds = [], [], []
     with torch.no_grad():
-        for X, y, ind in loader:
+        for batch in loader:
+            # Tolerate extended batches (e.g. with channel positions): the
+            # window indices are always the third element.
+            X, y, ind = batch[0], batch[1], batch[2]
             X = X.to(device)
             preds = module(X)
             all_preds.extend(preds.cpu().numpy().astype(np.float32))

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -449,8 +449,12 @@ def predict_trials(module, dataset, return_targets=True, batch_size=1, num_worke
     all_preds, all_ys, all_inds = [], [], []
     with torch.no_grad():
         for batch in loader:
-            # Tolerate extended batches (e.g. with channel positions): the
-            # window indices are always the third element.
+            if len(batch) > 3:
+                raise ValueError(
+                    "Cropped trial prediction does not support channel positions; "
+                    "disable return_ch_pos (set_return_ch_pos(False)) for cropped "
+                    "evaluation."
+                )
             X, y, ind = batch[0], batch[1], batch[2]
             X = X.to(device)
             preds = module(X)

--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -337,6 +337,17 @@ def create_mne_dummy_raw(
     return raw, save_fname
 
 
+def _looks_like_channel_mask(tensor):
+    """Heuristic: a channel mask is 2D (batch, n_ch) or boolean.
+
+    Used to tell the channel mask (2D bool) from channel positions (3D float)
+    among the trailing elements of an extended batch.
+    """
+    return (
+        getattr(tensor, "dtype", None) == torch.bool or getattr(tensor, "ndim", 0) == 2
+    )
+
+
 class ThrowAwayIndexLoader(object):
     def __init__(self, net, loader, is_regression):
         self.net = net
@@ -353,11 +364,35 @@ class ThrowAwayIndexLoader(object):
                 x, y, i = batch
                 # Store for scoring callbacks
                 self.net._last_window_inds_ = i
+            elif len(batch) > 3:
+                # Extended batch produced by ``return_ch_pos`` /
+                # ``pad_channels_collate``:
+                #   (X, y, crop_inds, [ch_pos], [ch_mask]).
+                # Route the signal + extras to the module via a dict input;
+                # skorch then calls ``module_(**x)``. The forward must accept
+                # ``forward(self, x, pos=None, ch_mask=None, ...)``.
+                signal, y, i = batch[0], batch[1], batch[2]
+                self.net._last_window_inds_ = i
+                x = {"x": signal}
+                for extra in batch[3:]:
+                    if _looks_like_channel_mask(extra):
+                        x["ch_mask"] = extra
+                    else:
+                        x["pos"] = extra
             else:
                 x, y = batch
 
             # TODO: should be on dataset side
-            if hasattr(x, "type"):
+            if isinstance(x, dict):
+                if hasattr(x["x"], "type"):
+                    x["x"] = x["x"].type(torch.float32)
+                if hasattr(y, "type"):
+                    y = (
+                        y.type(torch.float32)
+                        if self.is_regression
+                        else y.type(torch.int64)
+                    )
+            elif hasattr(x, "type"):
                 x = x.type(torch.float32)
                 if self.is_regression:
                     y = y.type(torch.float32)

--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -338,14 +338,13 @@ def create_mne_dummy_raw(
 
 
 def _looks_like_channel_mask(tensor):
-    """Heuristic: a channel mask is 2D (batch, n_ch) or boolean.
+    """Tell the channel mask from channel positions in an extended batch.
 
-    Used to tell the channel mask (2D bool) from channel positions (3D float)
-    among the trailing elements of an extended batch.
+    ``pad_channels_collate`` emits the mask as a boolean tensor and the
+    positions as float; keying on dtype avoids misclassifying a 2D position
+    array as a mask.
     """
-    return (
-        getattr(tensor, "dtype", None) == torch.bool or getattr(tensor, "ndim", 0) == 2
-    )
+    return getattr(tensor, "dtype", None) == torch.bool
 
 
 class ThrowAwayIndexLoader(object):

--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -341,10 +341,11 @@ def _looks_like_channel_mask(tensor):
     """Tell the channel mask from channel positions in an extended batch.
 
     ``pad_channels_collate`` emits the mask as a boolean tensor and the
-    positions as float; keying on dtype avoids misclassifying a 2D position
-    array as a mask.
+    positions as float; keying on the boolean dtype avoids misclassifying a 2D
+    position array as a mask. Accepts both torch and NumPy boolean dtypes.
     """
-    return getattr(tensor, "dtype", None) == torch.bool
+    dtype = getattr(tensor, "dtype", None)
+    return dtype == torch.bool or getattr(dtype, "kind", None) == "b"
 
 
 class ThrowAwayIndexLoader(object):

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,6 +28,14 @@ Current 1.6.1 (GitHub)
 Enhancements
 ============
 
+- Add opt-in electrode positions in the batch via
+  :meth:`braindecode.datasets.BaseConcatDataset.set_return_ch_pos` and a cached
+  ``ch_pos`` accessor on windowed datasets, plus
+  :func:`braindecode.datasets.pad_channels_collate` to make collections with
+  **heterogeneous montages** (different channel sets) batchable. Positions and a
+  channel mask are routed into the model's ``forward`` under
+  :class:`braindecode.EEGClassifier`. Default-off, so the ``(X, y, crop_inds)``
+  contract is unchanged. (:gh:`1066` by `Bruno Aristimunha`_)
 - Add a ``revision`` keyword argument to
   :meth:`braindecode.datasets.BaseConcatDataset.pull_from_hub` so callers can
   pin dataset downloads to a specific branch, tag, or commit on the Hugging

--- a/examples/model_building/plot_heterogeneous_montage_training.py
+++ b/examples/model_building/plot_heterogeneous_montage_training.py
@@ -1,0 +1,173 @@
+""".. _heterogeneous-montage-training:
+
+Training on recordings with different channels (heterogeneous montages)
+=======================================================================
+
+EEG datasets often do not share the same channels: recordings come from
+different caps, montages, or vendors. Stacking such recordings into a single
+training batch is normally impossible -- the signal tensors have different
+numbers of channels and cannot be concatenated.
+
+This example shows braindecode's tools for training a **position-aware** model
+across recordings with different channel sets:
+
+* :meth:`~braindecode.datasets.BaseConcatDataset.set_return_ch_pos` makes every
+  window carry its electrode positions ``(n_ch, 3)`` (x, y, z), so channel
+  identity is encoded by *where* each electrode sits rather than by its row
+  index.
+* :func:`~braindecode.datasets.pad_channels_collate` pads each batch to the
+  largest channel count present and returns a boolean ``ch_mask`` marking the
+  real (non-padded) channels.
+
+A model that consumes positions (and ignores padded channels via the mask) can
+then train on the mixed collection. Here we use a tiny illustrative model;
+swap in any position-aware architecture (e.g. ``REVE``).
+
+.. contents:: This example covers:
+   :local:
+   :depth: 2
+
+"""
+
+# Authors: The braindecode developers
+#
+# License: BSD (3-clause)
+
+import mne
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+from braindecode import EEGClassifier
+from braindecode.datasets import (
+    BaseConcatDataset,
+    RawDataset,
+    pad_channels_collate,
+)
+from braindecode.preprocessing import create_fixed_length_windows
+
+mne.set_log_level("ERROR")
+
+######################################################################
+# Build two recordings with different channel sets
+# ------------------------------------------------
+#
+# We synthesise two short recordings: one with 8 channels and one with 10, both
+# using ``standard_1020`` electrode positions. In practice these would be real
+# datasets loaded with different montages.
+
+
+def make_recording(ch_names, label, seed):
+    info = mne.create_info(ch_names, sfreq=100.0, ch_types="eeg")
+    data = np.random.RandomState(seed).randn(len(ch_names), 4000) * 1e-6
+    raw = mne.io.RawArray(data, info)
+    raw.set_montage("standard_1020")
+    return RawDataset(raw, description={"label": label})
+
+
+chs_a = ["Fp1", "Fp2", "F3", "F4", "C3", "C4", "P3", "P4"]  # 8 channels
+chs_b = ["Fz", "Cz", "Pz", "Oz", "T7", "T8", "O1", "O2", "F7", "F8"]  # 10 channels
+
+concat = BaseConcatDataset(
+    [
+        make_recording(chs_a, label=0, seed=1),
+        make_recording(chs_b, label=1, seed=2),
+        make_recording(chs_a, label=0, seed=3),
+        make_recording(chs_b, label=1, seed=4),
+    ]
+)
+
+######################################################################
+# Window the recordings and enable channel positions
+# --------------------------------------------------
+#
+# After cutting fixed-length windows we assign the per-recording ``label`` as
+# the target and turn on position returning for the whole collection.
+
+windows = create_fixed_length_windows(
+    concat,
+    window_size_samples=200,
+    window_stride_samples=200,
+    drop_last_window=True,
+    preload=True,
+)
+windows.set_target("label")
+windows.set_return_ch_pos(True)
+
+######################################################################
+# Inspect a heterogeneous batch
+# -----------------------------
+#
+# ``pad_channels_collate`` pads each batch to the largest channel count (10
+# here) and returns a boolean ``ch_mask``. Because we mix 8- and 10-channel
+# recordings, batches contain both -- the mask tells real channels from padding.
+
+loader = DataLoader(
+    windows, batch_size=4, shuffle=True, collate_fn=pad_channels_collate
+)
+X, y, crop_inds, ch_pos, ch_mask = next(iter(loader))
+print("X       :", tuple(X.shape))  # (batch, max_ch, n_times)
+print("ch_pos  :", tuple(ch_pos.shape))  # (batch, max_ch, 3)
+print("ch_mask :", tuple(ch_mask.shape))  # (batch, max_ch) bool
+print("real channels per sample:", ch_mask.sum(1).tolist())
+
+######################################################################
+# A minimal position-aware model
+# ------------------------------
+#
+# This tiny model is permutation-invariant over channels: it embeds each
+# channel from a small signal summary plus its (x, y, z) position, then
+# **masked-mean-pools** over channels so padded channels are ignored. Any model
+# that accepts ``forward(x, pos=None, ch_mask=None)`` works the same way -- this
+# is the signature braindecode routes positions and the mask into.
+
+
+class TinyPositionalNet(nn.Module):
+    def __init__(self, n_outputs=2, dim=32):
+        super().__init__()
+        self.embed = nn.Sequential(nn.Linear(6, dim), nn.ReLU(), nn.Linear(dim, dim))
+        self.head = nn.Linear(dim, n_outputs)
+
+    def forward(self, x, pos=None, ch_mask=None):
+        # Per-channel signal summary: mean, std, max over time -> (B, C, 3).
+        feat = torch.stack([x.mean(-1), x.std(-1), x.amax(-1)], dim=-1)
+        if pos is None:
+            pos = torch.zeros_like(feat)
+        h = self.embed(torch.cat([feat, pos], dim=-1))  # (B, C, dim)
+        if ch_mask is not None:
+            m = ch_mask.unsqueeze(-1).float()
+            h = (h * m).sum(1) / m.sum(1).clamp(min=1)  # masked mean over channels
+        else:
+            h = h.mean(1)
+        return self.head(h)
+
+
+######################################################################
+# Train with EEGClassifier
+# ------------------------
+#
+# We pass ``pad_channels_collate`` as the iterator's ``collate_fn``. braindecode
+# routes the signal, positions and mask into the model's ``forward`` for you.
+
+clf = EEGClassifier(
+    TinyPositionalNet(n_outputs=2),
+    max_epochs=3,
+    batch_size=4,
+    train_split=None,
+    classes=[0, 1],
+    iterator_train__collate_fn=pad_channels_collate,
+    iterator_train__shuffle=True,
+    iterator_train__drop_last=False,
+)
+clf.fit(windows, y=None)
+
+######################################################################
+# Next steps
+# ----------
+#
+# The data layer here makes a heterogeneous collection **batchable** and feeds
+# positions plus a channel mask to the model. How a model *normalizes* and
+# consumes variable channels (e.g. applying ``ch_mask`` inside attention, or
+# mapping electrode positions to a canonical space) is model-specific and the
+# natural next step when adapting a real architecture such as ``REVE``.

--- a/test/unit_tests/datasets/test_ch_pos.py
+++ b/test/unit_tests/datasets/test_ch_pos.py
@@ -1,0 +1,185 @@
+# Authors: The braindecode developers
+#
+# License: BSD (3-clause)
+
+"""Tests for channel positions in the batch (issue #1066).
+
+Covers the opt-in ``return_ch_pos`` accessor on windowed datasets, the
+collection-level ``set_return_ch_pos`` toggle, and ``pad_channels_collate`` for
+heterogeneous (variable-channel) montages.
+"""
+
+import json
+
+import mne
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+from torch.utils.data import DataLoader
+
+from braindecode.datasets import (
+    BaseConcatDataset,
+    EEGWindowsDataset,
+    RawDataset,
+    pad_channels_collate,
+)
+from braindecode.datasets.bids.hub_io import _restore_nan_from_json
+from braindecode.preprocessing import create_fixed_length_windows
+
+mne.set_log_level("ERROR")
+
+CHS_A = ["Fp1", "Fp2", "F3", "F4", "C3", "C4", "P3", "P4"]  # 8 channels
+CHS_B = ["Fz", "Cz", "Pz", "Oz", "T7", "T8", "O1", "O2", "F7", "F8"]  # 10
+
+
+def _raw_ds(ch_names, label=0, sfreq=100.0, n_times=1000, montage=True):
+    info = mne.create_info(ch_names, sfreq, ch_types="eeg")
+    data = np.random.RandomState(label).randn(len(ch_names), n_times) * 1e-6
+    raw = mne.io.RawArray(data, info)
+    if montage:
+        raw.set_montage("standard_1020")
+    return RawDataset(raw, description={"label": label})
+
+
+def _windows(datasets):
+    concat = BaseConcatDataset(datasets)
+    return create_fixed_length_windows(
+        concat,
+        window_size_samples=200,
+        window_stride_samples=200,
+        drop_last_window=True,
+        preload=True,
+    )
+
+
+def test_ch_pos_shape_and_values():
+    win = _windows([_raw_ds(CHS_A)])
+    ds = win.datasets[0]
+    pos = ds.ch_pos
+    assert pos.shape == (len(CHS_A), 3)
+    assert pos.dtype == np.float32
+    assert np.isfinite(pos).all()
+    # matches the raw info loc directly
+    expected = np.asarray([ch["loc"][:3] for ch in ds.raw.info["chs"]], dtype="float32")
+    np.testing.assert_allclose(pos, expected)
+
+
+def test_default_off_returns_three_tuple():
+    win = _windows([_raw_ds(CHS_A)])
+    assert len(win.datasets[0][0]) == 3  # (X, y, crop_inds)
+
+
+def test_opt_in_returns_positions():
+    win = _windows([_raw_ds(CHS_A)])
+    win.set_return_ch_pos(True)
+    sample = win.datasets[0][0]
+    assert len(sample) == 4
+    X, y, crop_inds, pos = sample
+    assert pos.shape == (X.shape[0], 3)
+
+
+def test_set_return_ch_pos_propagates_and_collection_accessor():
+    win = _windows([_raw_ds(CHS_A, 0), _raw_ds(CHS_B, 1)])
+    out = win.set_return_ch_pos(True)
+    assert out is win  # chainable
+    assert all(ds.return_ch_pos for ds in win.datasets)
+    # collection-level accessor returns the first recording's positions
+    np.testing.assert_allclose(win.ch_pos, win.datasets[0].ch_pos)
+    win.set_return_ch_pos(False)
+    assert not any(ds.return_ch_pos for ds in win.datasets)
+
+
+def test_ch_pos_cached():
+    win = _windows([_raw_ds(CHS_A)])
+    ds = win.datasets[0]
+    assert ds.ch_pos is ds.ch_pos  # same cached array object
+
+
+def test_ch_pos_misc_alignment():
+    # targets_from="channels": the misc channel is dropped from X, so the
+    # matching position row must be dropped too.
+    ch_names = CHS_A + ["target"]
+    info = mne.create_info(ch_names, 100.0, ch_types=["eeg"] * len(CHS_A) + ["misc"])
+    data = np.random.RandomState(0).randn(len(ch_names), 1000) * 1e-6
+    raw = mne.io.RawArray(data, info)
+    raw.set_montage("standard_1020", on_missing="ignore")
+    metadata = pd.DataFrame(
+        {"i_window_in_trial": [0], "i_start_in_trial": [0], "i_stop_in_trial": [200]}
+    )
+    ds = EEGWindowsDataset(raw, metadata, targets_from="channels")
+    ds.return_ch_pos = True
+    X, y, crop_inds, pos = ds[0]
+    assert X.shape[0] == len(CHS_A)  # misc excluded from signal
+    assert pos.shape == (len(CHS_A), 3)  # ...and from positions
+
+
+def test_no_montage_warns_and_non_finite():
+    win = _windows([_raw_ds(CHS_A, montage=False)])
+    ds = win.datasets[0]
+    with pytest.warns(UserWarning, match="no montage"):
+        pos = ds.ch_pos
+    has_real_pos = np.isfinite(pos).all(axis=1) & np.any(pos != 0, axis=1)
+    assert not has_real_pos.any()
+
+
+def test_uniform_default_collate_stacks_positions():
+    win = _windows([_raw_ds(CHS_A, 0), _raw_ds(CHS_A, 1)])  # both 8 channels
+    win.set_return_ch_pos(True)
+    loader = DataLoader(win, batch_size=4)
+    X, y, crop_inds, pos = next(iter(loader))
+    assert pos.shape == (4, len(CHS_A), 3)
+
+
+def test_pad_channels_collate_heterogeneous():
+    win = _windows([_raw_ds(CHS_A, 0), _raw_ds(CHS_B, 1)])
+    win.set_return_ch_pos(True)
+    loader = DataLoader(
+        win, batch_size=4, shuffle=True, collate_fn=pad_channels_collate
+    )
+    X, y, crop_inds, pos, ch_mask = next(iter(loader))
+    max_ch = len(CHS_B)
+    assert X.shape == (4, max_ch, 200)
+    assert pos.shape == (4, max_ch, 3)
+    assert ch_mask.shape == (4, max_ch)
+    assert ch_mask.dtype == torch.bool
+    # mask counts equal each sample's true channel count
+    assert set(ch_mask.sum(1).tolist()) <= {len(CHS_A), len(CHS_B)}
+    # padded rows are zero in both signal and positions
+    for i in range(X.shape[0]):
+        c = int(ch_mask[i].sum())
+        assert X[i, c:].abs().sum() == 0
+        assert pos[i, c:].abs().sum() == 0
+
+
+def test_pad_channels_collate_without_positions():
+    win = _windows([_raw_ds(CHS_A, 0), _raw_ds(CHS_B, 1)])  # no return_ch_pos
+    loader = DataLoader(win, batch_size=4, collate_fn=pad_channels_collate)
+    batch = next(iter(loader))
+    assert len(batch) == 4  # (X, y, crop_inds, ch_mask) -- no positions
+    X, y, crop_inds, ch_mask = batch
+    assert ch_mask.shape == (X.shape[0], X.shape[1])
+
+
+def test_pad_channels_collate_nonuniform_time_raises():
+    a = np.zeros((4, 100), dtype="float32")
+    b = np.zeros((6, 200), dtype="float32")
+    batch = [(a, 0, [0, 0, 100]), (b, 1, [0, 0, 200])]
+    with pytest.raises(ValueError, match="same number of time samples"):
+        pad_channels_collate(batch)
+
+
+def test_info_json_roundtrip_preserves_positions():
+    # Guards the Zarr/Hub lazy path: positions come from
+    # ``mne.Info.from_json_dict``; ``loc`` must survive the JSON round-trip.
+    info = mne.create_info(CHS_A, 100.0, ch_types="eeg")
+    raw = mne.io.RawArray(np.zeros((len(CHS_A), 10)), info)
+    raw.set_montage("standard_1020")
+    before = np.asarray([ch["loc"][:3] for ch in raw.info["chs"]], dtype="float32")
+
+    json_dict = json.loads(json.dumps(raw.info.to_json_dict()))
+    restored = mne.Info.from_json_dict(_restore_nan_from_json(json_dict))
+    after = np.asarray([ch["loc"][:3] for ch in restored["chs"]], dtype="float32")
+
+    np.testing.assert_allclose(before, after)
+    assert np.isfinite(after).all()

--- a/test/unit_tests/datasets/test_ch_pos.py
+++ b/test/unit_tests/datasets/test_ch_pos.py
@@ -96,6 +96,22 @@ def test_ch_pos_cached():
     assert ds.ch_pos is ds.ch_pos  # same cached array object
 
 
+def test_ch_pos_cache_invalidated_on_raw_setter():
+    win = _windows([_raw_ds(CHS_A)])
+    ds = win.datasets[0]
+    assert ds.ch_pos.shape == (len(CHS_A), 3)  # populate cache
+    # Reassign raw with a different channel set; cache must be recomputed.
+    other = _windows([_raw_ds(CHS_B)]).datasets[0].raw
+    ds.raw = other
+    assert ds.ch_pos.shape == (len(CHS_B), 3)
+
+
+def test_concat_ch_pos_raises_clear_error_on_rawdataset():
+    concat = BaseConcatDataset([_raw_ds(CHS_A)])  # RawDataset, not windowed
+    with pytest.raises(AttributeError, match="does not expose channel positions"):
+        _ = concat.ch_pos
+
+
 def test_ch_pos_misc_alignment():
     # targets_from="channels": the misc channel is dropped from X, so the
     # matching position row must be dropped too.

--- a/test/unit_tests/datasets/test_ch_pos.py
+++ b/test/unit_tests/datasets/test_ch_pos.py
@@ -27,7 +27,9 @@ from braindecode.datasets import (
 from braindecode.datasets.bids.hub_io import _restore_nan_from_json
 from braindecode.preprocessing import create_fixed_length_windows
 
-mne.set_log_level("ERROR")
+# NB: do not call ``mne.set_log_level`` at module level here -- under pytest it
+# perturbs warning capture for the rest of the session, making later
+# ``pytest.warns`` checks in other test modules spuriously fail (#1072).
 
 CHS_A = ["Fp1", "Fp2", "F3", "F4", "C3", "C4", "P3", "P4"]  # 8 channels
 CHS_B = ["Fz", "Cz", "Pz", "Oz", "T7", "T8", "O1", "O2", "F7", "F8"]  # 10

--- a/test/unit_tests/test_util.py
+++ b/test/unit_tests/test_util.py
@@ -373,3 +373,61 @@ def test_read_all_files_not_extension():
     with pytest.raises(AssertionError):
         # Call the read_all_file_names function with a non-existent directory
         read_all_file_names('non_existent_dir', 'txt')
+
+
+class _FakeNet:
+    """Minimal stand-in for a skorch net used by ThrowAwayIndexLoader."""
+
+
+def _route(batch, is_regression=False):
+    from braindecode.util import ThrowAwayIndexLoader
+
+    net = _FakeNet()
+    loader = ThrowAwayIndexLoader(net, iter([batch]), is_regression=is_regression)
+    (x, y), = list(loader)
+    return x, y, net
+
+
+def test_throwaway_index_loader_backward_compat():
+    """2- and 3-tuple batches keep yielding a plain tensor x (no dict)."""
+    B, C, T = 4, 10, 200
+    X = torch.randn(B, C, T)
+    y = torch.randint(0, 2, (B,))
+    crop = [torch.zeros(B), torch.zeros(B), torch.full((B,), T)]
+
+    x, yy, net = _route((X, y))
+    assert torch.is_tensor(x) and x.dtype == torch.float32
+    assert yy.dtype == torch.int64
+
+    x, yy, net = _route((X, y, crop))
+    assert torch.is_tensor(x)
+    assert net._last_window_inds_ is crop  # index stashed for scoring
+
+
+def test_throwaway_index_loader_routes_pos_and_mask():
+    """Extended batches route signal/pos/mask into a dict for skorch splat."""
+    B, C, T = 4, 10, 200
+    X = torch.randn(B, C, T)
+    y = torch.randint(0, 2, (B,))
+    crop = [torch.zeros(B), torch.zeros(B), torch.full((B,), T)]
+    pos = torch.randn(B, C, 3)
+    mask = torch.ones(B, C, dtype=torch.bool)
+
+    # positions only (uniform + return_ch_pos via default_collate)
+    x, _, _ = _route((X, y, crop, pos))
+    assert isinstance(x, dict) and set(x) == {"x", "pos"}
+    assert x["x"].dtype == torch.float32
+
+    # mask only (pad_channels_collate without positions)
+    x, _, _ = _route((X, y, crop, mask))
+    assert isinstance(x, dict) and set(x) == {"x", "ch_mask"}
+
+    # positions + mask (pad_channels_collate with positions)
+    x, yy, net = _route((X, y, crop, pos, mask))
+    assert set(x) == {"x", "pos", "ch_mask"}
+    assert x["pos"].shape == (B, C, 3) and x["ch_mask"].dtype == torch.bool
+    assert net._last_window_inds_ is crop
+
+    # regression casts y to float even on the dict path
+    _, yy, _ = _route((X, torch.randn(B), crop, pos, mask), is_regression=True)
+    assert yy.dtype == torch.float32

--- a/test/unit_tests/test_util.py
+++ b/test/unit_tests/test_util.py
@@ -404,6 +404,15 @@ def test_throwaway_index_loader_backward_compat():
     assert net._last_window_inds_ is crop  # index stashed for scoring
 
 
+def test_looks_like_channel_mask_dtypes():
+    from braindecode.util import _looks_like_channel_mask
+
+    assert _looks_like_channel_mask(torch.ones(4, 10, dtype=torch.bool))
+    assert _looks_like_channel_mask(np.ones((4, 10), dtype=bool))  # numpy bool
+    assert not _looks_like_channel_mask(torch.randn(4, 10, 3))  # float positions
+    assert not _looks_like_channel_mask(np.zeros((4, 10, 3), dtype="float32"))
+
+
 def test_throwaway_index_loader_routes_pos_and_mask():
     """Extended batches route signal/pos/mask into a dict for skorch splat."""
     B, C, T = 4, 10, 200


### PR DESCRIPTION
Closes #1066.

## Motivation

Today a window yields `(X, y, crop_inds)` and drops channel identity. Channel-aware / variable-montage models (foundation models, REVE-style positional encoders) need to know *where each channel sits* per sample. This adds an opt-in path to carry electrode **positions `(n_ch, 3)` xyz** along in the batch, and makes collections that mix recordings with **different channel sets** trainable.

## What's in it

**Data layer** (`datasets/base.py`)
- Cached `ch_pos` property on `EEGWindowsDataset` / `WindowsDataset`, built from the canonical `info["chs"][i]["loc"][:3]` that braindecode models already consume (e.g. `signal_jepa`, `REVE`), aligned to `X`'s channel rows (misc channels handled).
- `BaseConcatDataset.set_return_ch_pos(True)` toggles the whole collection. **Opt-in / default off** — the `(X, y, crop_inds)` contract is unchanged.

**Heterogeneous montages** (`datasets/collate.py`)
- `pad_channels_collate`: pads each batch to the largest channel count and emits a boolean `ch_mask`. Channel identity is carried by the positions (positional, not index-based), so a batch can mix e.g. a 19- and a 22-channel recording.

**Training integration** (`util.py`)
- `ThrowAwayIndexLoader` routes the signal, positions and mask into the model's `forward` via a skorch dict input, so it flows through `EEGClassifier`. The existing 2-/3-tuple paths are untouched.

**Example + docs**
- `examples/model_building/plot_heterogeneous_montage_training.py` — trains a position-aware model on a mixed-montage collection end to end.
- `whats_new.rst` entry.

## Scope / follow-up

This makes heterogeneous collections **batchable** and feeds positions + a channel mask to the model. How a specific architecture *normalizes* and consumes variable channels (applying `ch_mask` inside attention, mapping positions to a canonical space) is model-specific and intended as a follow-up. The example uses a tiny inline position-aware net to demonstrate the `forward(x, pos=None, ch_mask=None)` contract.

## Tests

- New `test/unit_tests/datasets/test_ch_pos.py` (12 tests): accessor shape/values, default-off backward-compat, misc-channel alignment, no-montage warning, uniform default-collate, heterogeneous pad-collate, non-uniform-time guard, info JSON round-trip (guards the Zarr/Hub lazy path).
- `test/unit_tests/test_util.py`: loader dict-routing + 2-/3-tuple backward-compat.
- Existing dataset/neuralnet suites pass unchanged (default-off).