### PR TITLE
Model & filter fidelity fixes (#1067–#1071) + AugmentedDataLoader expansion & augmentation speedups

### DIFF
--- a/benchmarks/bench_augmentation_growth.py
+++ b/benchmarks/bench_augmentation_growth.py
@@ -1,0 +1,129 @@
+"""Benchmark the :class:`~braindecode.augmentation.AugmentedDataLoader` collate.
+
+Run from the repository root with::
+
+    python -m benchmarks.bench_augmentation_growth
+
+Two measurements:
+
+1. **Expansion scaling** (single process). Cost of in-place augmentation
+   (``n_augmentation=0``) versus fixed expansion, where each batch is grown to
+   ``(1 + n_augmentation)`` times its size. The batch is collated once per step
+   regardless of ``n_augmentation``; only the transform runs
+   ``(1 + n_augmentation)`` times, so time-per-step grows ~linearly.
+
+2. **Worker scaling.** ``collate_fn`` (and therefore the augmentation) runs in
+   the DataLoader worker process, so ``num_workers > 0`` parallelizes it. This
+   only works because the collate is a picklable callable. Pinned to one
+   intra-op thread per process so ``num_workers`` maps to cores used (otherwise
+   torch's intra-op threads already saturate the cores and hide the scaling).
+
+This is a standalone script, not a pytest test: it has no extra dependencies
+and is not collected by the test suite.
+"""
+
+from statistics import median
+from time import perf_counter
+
+import torch
+from torch.utils.data import Dataset
+
+from braindecode.augmentation import AugmentedDataLoader
+from braindecode.augmentation.transforms import SmoothTimeMask
+
+
+class _LazyEEGDataset(Dataset):
+    """Synthesize a random EEG window per index.
+
+    Cheap to pickle (only stores the shape), so spawning DataLoader workers does
+    not copy a large in-memory tensor — unlike a ``TensorDataset``.
+    """
+
+    def __init__(self, n_samples, n_chans, n_times, n_classes=4):
+        self.n_samples = n_samples
+        self.n_chans = n_chans
+        self.n_times = n_times
+        self.n_classes = n_classes
+
+    def __len__(self):
+        return self.n_samples
+
+    def __getitem__(self, idx):
+        return torch.randn(self.n_chans, self.n_times), idx % self.n_classes
+
+
+def _set_one_thread(_worker_id):
+    torch.set_num_threads(1)
+
+
+def _time_epoch(loader):
+    """Iterate one full epoch; return (seconds, samples produced)."""
+    start = perf_counter()
+    n = 0
+    for X, _ in loader:
+        n += X.shape[0]
+    return perf_counter() - start, n
+
+
+def _median_epoch(loader, repeats):
+    _time_epoch(loader)  # warmup (also spawns persistent workers)
+    times, produced = [], 0
+    for _ in range(repeats):
+        elapsed, produced = _time_epoch(loader)
+        times.append(elapsed)
+    return median(times), produced
+
+
+def expansion_scaling(dataset, batch_size, n_augmentations, repeats):
+    n_samples = len(dataset)
+    print("expansion scaling (num_workers=0):")
+    header = f"{'n_aug':>6} {'batch_out':>10} {'ms/epoch':>10} {'ms/step':>9} {'samples/s':>11}"
+    print(header)
+    print("-" * len(header))
+    n_steps = -(-n_samples // batch_size)  # ceil
+    for n_aug in n_augmentations:
+        loader = AugmentedDataLoader(
+            dataset,
+            transforms=SmoothTimeMask(probability=1.0),
+            batch_size=batch_size,
+            n_augmentation=n_aug,
+        )
+        t, produced = _median_epoch(loader, repeats)
+        print(
+            f"{n_aug:>6} {batch_size * (1 + n_aug):>10} "
+            f"{t * 1e3:>10.1f} {t / n_steps * 1e3:>9.2f} {produced / t:>11.0f}"
+        )
+
+
+def worker_scaling(dataset, batch_size, n_aug, workers, repeats):
+    torch.set_num_threads(1)  # one intra-op thread/process -> workers == cores
+    print(f"\nworker scaling (n_augmentation={n_aug}, 1 intra-op thread/process):")
+    header = f"{'workers':>7} {'ms/epoch':>10} {'samples/s':>11} {'speedup':>8}"
+    print(header)
+    print("-" * len(header))
+    base = None
+    for nw in workers:
+        loader = AugmentedDataLoader(
+            dataset,
+            transforms=SmoothTimeMask(probability=1.0),
+            batch_size=batch_size,
+            n_augmentation=n_aug,
+            num_workers=nw,
+            persistent_workers=nw > 0,
+            worker_init_fn=_set_one_thread if nw > 0 else None,
+        )
+        t, produced = _median_epoch(loader, repeats)
+        base = base or t
+        print(f"{nw:>7} {t * 1e3:>10.1f} {produced / t:>11.0f} {base / t:>7.2f}x")
+
+
+def benchmark(n_samples=2048, n_chans=22, n_times=1000, batch_size=64):
+    dataset = _LazyEEGDataset(n_samples, n_chans, n_times)
+    print(f"{n_samples} samples x {n_chans} ch x {n_times} t | batch={batch_size}\n")
+    expansion_scaling(dataset, batch_size, n_augmentations=(0, 1, 5, 10), repeats=5)
+    worker_scaling(dataset, batch_size, n_aug=5, workers=(0, 2, 4), repeats=3)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    benchmark()

--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -105,7 +105,15 @@ class Transform(torch.nn.Module):
         mask = self._get_mask(out_X.shape[0], out_X.device)
         num_valid = mask.sum().long()
 
-        if num_valid > 0:
+        if num_valid == out_X.shape[0]:
+            # Fast path: every sample is augmented (e.g. ``probability=1.0``,
+            # the common case). Operate on the whole batch and skip the boolean
+            # gather/scatter (``out_X[mask]`` then ``out_X[mask] = ...``), which
+            # would otherwise copy the batch twice.
+            out_X, out_y = self.operation(
+                out_X, out_y, **self.get_augmentation_params(out_X, out_y)
+            )
+        elif num_valid > 0:
             # Uses the mask to define the output
             out_X[mask, ...], tr_y = self.operation(
                 out_X[mask, ...],
@@ -168,23 +176,47 @@ class Compose(Transform):
         return X, y
 
 
-def _make_collateable(transform, device=None):
-    """Wraps a transform to make it collateable.
+class _AugmentationCollate:
+    """Collate that applies a transform to each batch, with optional expansion.
 
-    with device control.
+    A picklable callable (so it works with ``num_workers > 0``, unlike a
+    closure) that collates the batch once and then either augments it in place
+    or grows it.
+
+    Parameters
+    ----------
+    transform : Transform
+        Transform applied to the collated ``(X, y)``.
+    device : str | torch.device | None, optional
+        Device the batch is moved to before transforming. Defaults to None.
+    n_augmentation : int, optional
+        ``0`` (default) applies the transform in place (batch size unchanged).
+        ``> 0`` keeps the clean originals and appends ``n_augmentation``
+        independently transformed copies, returning ``(X, y)`` of
+        ``(1 + n_augmentation)`` times the original size.
     """
 
-    def _collate_fn(batch):
-        collated_batch = default_collate(batch)
-        X, y = collated_batch[:2]
+    def __init__(self, transform, device=None, n_augmentation=0):
+        self.transform = transform
+        self.device = device
+        self.n_augmentation = n_augmentation
 
-        if device is not None:
-            X = X.to(device)
-            y = y.to(device)
-
-        return (*transform(X, y), *collated_batch[2:])
-
-    return _collate_fn
+    def __call__(self, batch):
+        collated = default_collate(batch)
+        X, y = collated[:2]
+        if self.device is not None:
+            X = X.to(self.device)
+            y = y.to(self.device)
+        if self.n_augmentation == 0:
+            return (*self.transform(X, y), *collated[2:])
+        # Fixed expansion: keep the clean originals, then append
+        # ``n_augmentation`` independently transformed copies.
+        xs, ys = [X], [y]
+        for _ in range(self.n_augmentation):
+            aug_X, aug_y = self.transform(X, y)
+            xs.append(aug_X)
+            ys.append(aug_y)
+        return torch.cat(xs), torch.cat(ys)
 
 
 class AugmentedDataLoader(DataLoader):
@@ -198,28 +230,44 @@ class AugmentedDataLoader(DataLoader):
         Transform or sequence of Transform to be applied to each batch.
     device : str | torch.device | None, optional
         Device on which to transform the data. Defaults to None.
+    n_augmentation : int, optional
+        Number of augmented copies to append to each batch (fixed expansion).
+        When ``0`` (default) the transforms are applied in place and the batch
+        keeps its size (stochastic-per-epoch augmentation, backwards-compatible).
+        When ``> 0`` each batch becomes ``(1 + n_augmentation)`` times larger:
+        the clean originals are kept and ``n_augmentation`` independently
+        transformed copies are appended. This expresses augmentations defined as
+        a fixed set-expansion (e.g. the EEG-Inception MI 6x training set,
+        ``n_augmentation=5``). In this mode batches are returned as ``(X, y)``.
     **kwargs : dict, optional
         keyword arguments to pass to standard DataLoader class.
     """
 
-    def __init__(self, dataset, transforms=None, device=None, **kwargs):
+    def __init__(
+        self, dataset, transforms=None, device=None, n_augmentation=0, **kwargs
+    ):
         if "collate_fn" in kwargs:
             raise ValueError(
                 "collate_fn cannot be used in this context because it is used "
                 "to pass transform"
             )
+        if n_augmentation < 0:
+            raise ValueError("n_augmentation must be a non-negative integer.")
         if transforms is None or (
             isinstance(transforms, list) and len(transforms) == 0
         ):
-            self.collated_tr = _make_collateable(IdentityTransform(), device=device)
+            transform = IdentityTransform()
         elif isinstance(transforms, (Transform, nn.Module)):
-            self.collated_tr = _make_collateable(transforms, device=device)
+            transform = transforms
         elif isinstance(transforms, list):
-            self.collated_tr = _make_collateable(Compose(transforms), device=device)
+            transform = Compose(transforms)
         else:
             raise TypeError(
                 "transforms can be either a Transform object "
                 "or a list of Transform objects."
             )
 
+        self.collated_tr = _AugmentationCollate(
+            transform, device=device, n_augmentation=n_augmentation
+        )
         super().__init__(dataset, collate_fn=self.collated_tr, **kwargs)

--- a/braindecode/augmentation/functional.py
+++ b/braindecode/augmentation/functional.py
@@ -18,7 +18,7 @@ from mne.filter import notch_filter
 from scipy.interpolate import Rbf
 from sklearn.utils import check_random_state
 from torch.fft import fft, ifft
-from torch.nn.functional import one_hot, pad
+from torch.nn.functional import pad
 
 
 def identity(X: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -253,25 +253,34 @@ def channels_dropout(
     return X * mask.unsqueeze(-1), y
 
 
-def _make_permutation_matrix(
+def _make_channel_permutation(
     X: torch.Tensor, mask: torch.Tensor, random_state: int | np.random.Generator | None
 ) -> torch.Tensor:
+    """Per-sample channel permutation that shuffles only the masked channels.
+
+    Returns a ``(batch, n_channels)`` index permutation: output channel ``i`` is
+    taken from input channel ``perm[b, i]``. Masked channels are permuted among
+    their own positions; unmasked channels keep their place.
+
+    The per-sample ``rng.permutation`` is kept (rather than a vectorized random
+    draw) so the output is bit-for-bit identical to the previous one-hot/matmul
+    implementation — vectorizing the draw would change seeded results. The win
+    is downstream: the caller gathers with this index instead of building
+    ``(batch, n_channels, n_channels)`` one-hot matrices and a matmul.
+    """
     rng = check_random_state(random_state)
     batch_size, n_channels, _ = X.shape
-    hard_mask = mask.round()
-    batch_permutations = torch.empty(
-        batch_size, n_channels, n_channels, device=X.device
-    )
-    for b, mask in enumerate(hard_mask):
-        channels_to_shuffle = torch.arange(n_channels, device=X.device)
-        channels_to_shuffle = channels_to_shuffle[mask.bool()]
-        reordered_channels = torch.tensor(
-            rng.permutation(channels_to_shuffle.cpu()), device=X.device
+    hard_mask = mask.round().bool()
+    channels = torch.arange(n_channels, device=X.device)
+    perm = channels.repeat(batch_size, 1)
+    for b in range(batch_size):
+        channels_to_shuffle = channels[hard_mask[b]]
+        perm[b, channels_to_shuffle] = torch.tensor(
+            rng.permutation(channels_to_shuffle.cpu()),
+            device=X.device,
+            dtype=perm.dtype,
         )
-        channels_permutation = torch.arange(n_channels, device=X.device)
-        channels_permutation[channels_to_shuffle] = reordered_channels
-        batch_permutations[b, ...] = one_hot(channels_permutation)
-    return batch_permutations
+    return perm
 
 
 def channels_shuffle(
@@ -314,8 +323,11 @@ def channels_shuffle(
     if p_shuffle == 0:
         return X, y
     mask = _pick_channels_randomly(X, 1 - p_shuffle, random_state)
-    batch_permutations = _make_permutation_matrix(X, mask, random_state)
-    return torch.matmul(batch_permutations, X), y
+    perm = _make_channel_permutation(X, mask, random_state)
+    # Gather channels (output[b, i] = X[b, perm[b, i]]) instead of building
+    # one-hot permutation matrices and a (batch, C, C) @ (batch, C, T) matmul.
+    perm = perm.unsqueeze(-1).expand(-1, -1, X.shape[-1])
+    return torch.gather(X, 1, perm), y
 
 
 def gaussian_noise(
@@ -1188,19 +1200,21 @@ def mask_encoding(
        32 (2024): 875-886.
     """
 
-    batch_indices = torch.arange(X.shape[0]).repeat_interleave(n_segments)
-    start_indices = time_start.flatten()
-    mask_indices = start_indices[:, None] + torch.arange(segment_length)
+    # All channels are zeroed at the same time positions, so build a single
+    # (batch, n_times) time-mask and broadcast it over channels, vectorized
+    # (no Python loop over batch * n_segments).
+    device = X.device
+    batch_indices = torch.arange(X.shape[0], device=device).repeat_interleave(
+        n_segments * segment_length
+    )
+    seg_indices = (
+        time_start.flatten().to(device)[:, None]
+        + torch.arange(segment_length, device=device)
+    ).flatten()
+    time_mask = torch.zeros(X.shape[0], X.shape[-1], dtype=torch.bool, device=device)
+    time_mask[batch_indices, seg_indices] = True
 
-    # Create a boolean mask with the same shape as X
-    mask = torch.zeros_like(X, dtype=torch.bool)
-    for batch_index, grouped_mask_indices in zip(batch_indices, mask_indices):
-        mask[batch_index, :, grouped_mask_indices] = True
-
-    # Apply the mask to set the values to 0
-    X[mask] = 0
-
-    return X, y  # Return the masked tensor and labels
+    return X.masked_fill(time_mask.unsqueeze(1), 0), y
 
 
 def channels_rereference(

--- a/braindecode/models/eegitnet.py
+++ b/braindecode/models/eegitnet.py
@@ -4,9 +4,16 @@
 # License: BSD-3
 from einops.layers.torch import Rearrange
 from torch import nn
+from torch.nn.utils.parametrize import register_parametrization
 
 from braindecode.models.base import EEGModuleMixin
-from braindecode.modules import DepthwiseConv2d, Ensure4d, InceptionBlock
+from braindecode.modules import (
+    DepthwiseConv2d,
+    Ensure4d,
+    InceptionBlock,
+    LinearWithConstraint,
+    MaxNormParametrize,
+)
 
 
 class EEGITNet(EEGModuleMixin, nn.Sequential):
@@ -95,7 +102,9 @@ class EEGITNet(EEGModuleMixin, nn.Sequential):
             sfreq=sfreq,
         )
         self.mapping = {
-            "classification.1.weight": "final_layer.weight",
+            # final_layer is max-norm constrained, so its weight lives under the
+            # parametrization buffer rather than ``final_layer.weight``.
+            "classification.1.weight": "final_layer.parametrizations.weight.original",
             "classification.1.bias": "final_layer.bias",
         }
 
@@ -185,8 +194,10 @@ class EEGITNet(EEGModuleMixin, nn.Sequential):
         self.add_module(
             "dim_reduction",
             nn.Sequential(
-                nn.Conv2d(tcn_in_channel, tcn_in_channel * 2, kernel_size=(1, 1)),
-                nn.BatchNorm2d(tcn_in_channel * 2),
+                # The authors' DR layer keeps the width (14 filters, paper III-C),
+                # it does not double it.
+                nn.Conv2d(tcn_in_channel, tcn_in_channel, kernel_size=(1, 1)),
+                nn.BatchNorm2d(tcn_in_channel),
                 activation(),
                 nn.AvgPool2d((1, tcn_kernel_size)),
                 nn.Dropout(drop_prob),
@@ -198,7 +209,11 @@ class EEGITNet(EEGModuleMixin, nn.Sequential):
 
         num_features = self.get_output_shape()[-1]
 
-        self.add_module("final_layer", nn.Linear(num_features, self.n_outputs))
+        # The authors constrain the final dense with ``max_norm(0.25)``.
+        self.add_module(
+            "final_layer",
+            LinearWithConstraint(num_features, self.n_outputs, max_norm=0.25),
+        )
 
     @staticmethod
     def _get_inception_branch(
@@ -208,6 +223,18 @@ class EEGITNet(EEGModuleMixin, nn.Sequential):
         depth_multiplier=1,
         activation: type[nn.Module] = nn.ELU,
     ):
+        # The authors constrain the spatial depthwise conv with
+        # ``depthwise_constraint = MaxNorm(max_value=1)``.
+        spatial_depthwise = DepthwiseConv2d(
+            out_channels,
+            kernel_size=(in_channels, 1),
+            depth_multiplier=depth_multiplier,
+            bias=False,
+            padding="valid",
+        )
+        register_parametrization(
+            spatial_depthwise, "weight", MaxNormParametrize(max_norm=1.0)
+        )
         return nn.Sequential(
             nn.Conv2d(
                 1,
@@ -217,13 +244,7 @@ class EEGITNet(EEGModuleMixin, nn.Sequential):
                 bias=False,
             ),
             nn.BatchNorm2d(out_channels),
-            DepthwiseConv2d(
-                out_channels,
-                kernel_size=(in_channels, 1),
-                depth_multiplier=depth_multiplier,
-                bias=False,
-                padding="valid",
-            ),
+            spatial_depthwise,
             nn.BatchNorm2d(out_channels),
             activation(),
         )

--- a/braindecode/models/eegsym.py
+++ b/braindecode/models/eegsym.py
@@ -504,6 +504,11 @@ class _InceptionBlock(nn.Module):
                             out_channels=filters_per_branch * len(scales_samples),
                             kernel_size=(1, 1, ncha),
                             padding=(0, 0, 0),
+                            # depthwise/grouped spatial conv with no bias, as in
+                            # the authors' ``unit_dconv`` (per-filter spatial
+                            # filtering, not dense mixing across filters).
+                            groups=filters_per_branch * len(scales_samples),
+                            bias=False,
                         ),
                         nn.BatchNorm3d(filters_per_branch * len(scales_samples)),
                         activation,
@@ -621,6 +626,10 @@ class _ResidualBlock(nn.Module):
                             out_channels=filters,
                             kernel_size=(1, 1, ncha),  # Spatial convolution
                             padding=(0, 0, 0),
+                            # depthwise/grouped spatial conv with no bias, as in
+                            # the authors' ``unit_dconv``.
+                            groups=filters,
+                            bias=False,
                         ),
                         nn.BatchNorm3d(filters),
                         activation,

--- a/braindecode/models/msvtnet.py
+++ b/braindecode/models/msvtnet.py
@@ -186,9 +186,13 @@ class MSVTNet(EEGModuleMixin, nn.Module):
 
         x = self.final_layer(x)
         if self.return_features:
-            # x shape after final layer: [batch_size, num_classes]
-            # branch_preds shape: [batch_size, num_classes]
-            return torch.stack(branch_preds)
+            # Return BOTH the main-head logits and the stacked branch logits, as
+            # in the authors' implementation (``return x, bx``). This is required
+            # for the paper's joint deep-supervision loss
+            # ``lambda * CE(main) + (1 - lambda) * sum_i CE(branch_i)`` and lets
+            # callers score on the main head.
+            # x: [batch_size, n_classes]; branches: [n_branches, batch_size, n_classes]
+            return x, torch.stack(branch_preds)
         return x
 
 

--- a/braindecode/modules/filter.py
+++ b/braindecode/modules/filter.py
@@ -338,15 +338,18 @@ class FilterBankLayer(nn.Module):
         Tensor
             Filtered tensor of shape (batch_size, 1, n_chans, n_times).
         """
-        # Apply filtering using torchaudio's filtfilt
+        # Run the recursion in float64 and cast back: IIR band-passes with poles
+        # near the unit circle (e.g. cheby2 banks used by FBMSNet/FBCNet) diverge
+        # to NaN in float32. The coefficient buffers are already float64.
+        orig_dtype = x.dtype
         filtered = filtfilt(
-            x,
-            a_coeffs=a_coeffs.type_as(x).to(x.device),
-            b_coeffs=b_coeffs.type_as(x).to(x.device),
+            x.double(),
+            a_coeffs=a_coeffs.double().to(x.device),
+            b_coeffs=b_coeffs.double().to(x.device),
             clamp=False,
         )
         # Rearrange dimensions to (batch_size, 1, n_chans, n_times)
-        return filtered.unsqueeze(1)
+        return filtered.to(orig_dtype).unsqueeze(1)
 
 
 class GeneralizedGaussianFilter(nn.Module):

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -57,6 +57,14 @@ Enhancements
   grouped-query attention Transformer with rotary positional embeddings, and a
   grouped temporal convolutional network head. (:gh:`1065` by `Bruno
   Aristimunha`_)
+- Add an ``n_augmentation`` argument to
+  :class:`braindecode.augmentation.AugmentedDataLoader` for fixed set-expansion:
+  each batch keeps its clean originals and appends ``n_augmentation``
+  independently transformed copies (e.g. the EEG-Inception 6x training set with
+  ``n_augmentation=5``); the default ``0`` preserves the current in-place
+  behavior. The collate is now a picklable callable, so the loader supports
+  ``num_workers > 0``, and several augmentation transforms were vectorized for
+  speed. (:gh:`1070` by `Bruno Aristimunha`_)
 
 API and behavior changes
 ========================
@@ -130,6 +138,31 @@ Bug fixes
   now raised telling the user to lower ``batch_size`` or set
   ``iterator_train__drop_last=False``.
   (:gh:`1053` by `Bhargav Kowshik`_)
+
+- Fix :class:`braindecode.modules.FilterBankLayer` producing ``NaN`` in
+  ``float32``: the IIR path downcast the float64 filter coefficients to the
+  input dtype before :func:`~torchaudio.functional.filtfilt`, so band-pass banks
+  with poles near the unit circle (e.g. the Chebyshev-II banks used by
+  :class:`~braindecode.models.FBMSNet` and :class:`~braindecode.models.FBCNet`)
+  diverged. The recursion now runs in ``float64`` and is cast back.
+  (:gh:`1067` by `Bruno Aristimunha`_)
+
+- Fix :class:`braindecode.models.EEGITNet` diverging from the reference
+  implementation: the inception spatial depthwise convolutions and the final
+  dense layer now carry the authors' max-norm constraints (``1.0`` and
+  ``0.25``), and the dimensionality-reduction convolution uses ``14`` filters
+  instead of ``28``. (:gh:`1068` by `Bruno Aristimunha`_)
+
+- Fix :class:`braindecode.models.MSVTNet` dropping the main classification head
+  when ``return_features=True`` (it returned only the branch predictions, making
+  the paper's joint deep-supervision loss unreproducible). It now returns
+  ``(main_logits, stacked_branch_logits)``, matching the source.
+  (:gh:`1069` by `Bruno Aristimunha`_)
+
+- Fix the spatial convolutions in :class:`braindecode.models.EEGSym` being dense
+  (``groups=1``) with a bias: the authors' ``unit_dconv`` uses grouped/depthwise
+  convolutions without bias, so they now use ``groups=out_channels`` and
+  ``bias=False``. (:gh:`1071` by `Bruno Aristimunha`_)
 
 Code health
 ============

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -179,6 +179,62 @@ def test_dataset_with_transform(concat_windows_dataset):
     assert torch.all(transformed_X == factor)
 
 
+def test_augmented_data_loader_n_augmentation():
+    """``n_augmentation`` keeps the clean originals and appends augmented copies."""
+    from torch.utils.data import TensorDataset
+
+    n_samples, n_chans, n_times, batch_size = 8, 4, 20, 8
+    X = torch.randn(n_samples, n_chans, n_times)
+    y = torch.arange(n_samples)
+    k = 7.0
+
+    loader = AugmentedDataLoader(
+        TensorDataset(X, y),
+        transforms=DummyTransform(k=k, probability=1.0),
+        batch_size=batch_size,
+        n_augmentation=5,
+        shuffle=False,
+    )
+    batch_X, batch_y = next(iter(loader))
+
+    # 1 clean + 5 augmented copies -> 6x expansion
+    assert batch_X.shape == (6 * batch_size, n_chans, n_times)
+    assert batch_y.shape == (6 * batch_size,)
+    # The first block are the untouched originals (the point of the feature).
+    assert torch.equal(batch_X[:batch_size], X)
+    # Every appended copy was augmented (DummyTransform replaces X by all-k).
+    assert torch.all(batch_X[batch_size:] == k)
+    # Labels are tiled across the clean + augmented copies.
+    assert torch.equal(batch_y, y.repeat(6))
+
+
+def test_augmented_data_loader_default_no_expansion():
+    """Default (``n_augmentation=0``) keeps the batch size unchanged."""
+    from torch.utils.data import TensorDataset
+
+    batch_size = 8
+    X = torch.randn(batch_size, 4, 20)
+    y = torch.arange(batch_size)
+
+    loader = AugmentedDataLoader(
+        TensorDataset(X, y),
+        transforms=DummyTransform(k=1.0, probability=1.0),
+        batch_size=batch_size,
+        shuffle=False,
+    )
+    batch_X, _ = next(iter(loader))
+    assert batch_X.shape[0] == batch_size
+
+
+def test_augmented_data_loader_negative_n_augmentation():
+    """A negative ``n_augmentation`` is rejected."""
+    from torch.utils.data import TensorDataset
+
+    dataset = TensorDataset(torch.randn(4, 4, 20), torch.arange(4))
+    with pytest.raises(ValueError, match="n_augmentation"):
+        AugmentedDataLoader(dataset, n_augmentation=-1, batch_size=4)
+
+
 def test_single_input_aug(concat_windows_dataset):
     # Create single input without the batch dimension, just (channels, time)
     X, y, _ = concat_windows_dataset[0]

--- a/test/unit_tests/models/test_integration.py
+++ b/test/unit_tests/models/test_integration.py
@@ -527,6 +527,9 @@ def test_model_torch_script(model):
         # forward() returns Dict[str, Tensor] (features) or Tensor (logits);
         # torch.jit.script rejects this polymorphic return type.
         "EEGDINO",
+        # forward() returns Tensor (logits) or Tuple[Tensor, Tensor] (main +
+        # branch logits) when return_features=True; polymorphic return type.
+        "MSVTNet",
         # TorchScript / torch.jit.script cannot scriptify the MPF featurizer
         # (torch.linalg.eigh + torch.stft).
         "MetaNeuromotorHand",


### PR DESCRIPTION
Two themes: (1) correctness/fidelity fixes for four models and the IIR filter bank, and (2) the `AugmentedDataLoader` fixed-expansion feature plus a set of augmentation speedups. Each commit is scoped to one issue (the augmentation feature and the perf work share the augmentation subsystem and are in one commit). Happy to split into per-issue PRs if preferred.

## Model & filter fidelity fixes

- **`FilterBankLayer` IIR NaNs in float32 (#1067).** `_apply_iir` downcast the float64 coefficients to the input dtype before `filtfilt`, so band-passes with poles near the unit circle (cheby2 banks used by `FBMSNet`/`FBCNet`) diverged to NaN in float32. Run the recursion in float64 and cast back.
- **`EEGITNet` missing constraints + doubled DR width (#1068).** Apply the authors' `max_norm(1.0)` to the 3 inception spatial depthwise convs and `max_norm(0.25)` to the final dense (via the existing `LinearWithConstraint` / `MaxNormParametrize` primitives), and set the dimensionality-reduction conv width to 14 (it was doubled to 28). The weight-loading `mapping` now points at `final_layer.parametrizations.weight.original` (same convention as `codebrain`/`atcnet`).
- **`MSVTNet` drops main head with `return_features=True` (#1069).** `forward` returned only branch predictions, making the paper's joint deep-supervision loss unreproducible. It now returns `(main_logits, stacked_branch_logits)`, matching the source. MSVTNet is added to the torchscript skip-list (polymorphic return, exactly as `EEGDINO`); export/compile/default-forward are unaffected (they trace the actual path).
- **`EEGSym` dense spatial convs (#1071).** The inception/residual spatial convs were dense (`groups=1, bias=True`); the authors' `unit_dconv` uses grouped/depthwise convs with no bias. Now `groups=out_channels, bias=False`.

## AugmentedDataLoader `n_augmentation` + augmentation speedups (#1070)

**Feature.** `AugmentedDataLoader(..., n_augmentation=N)` expresses a fixed set-expansion: each batch keeps its clean originals and appends `N` independently transformed copies (`(1+N)x`), e.g. the EEG-Inception MI 6x training set (`n_augmentation=5`). Default `0` keeps the current in-place behavior — fully backwards compatible.

**Speedups** (all verified equivalent; benchmark in `benchmarks/bench_augmentation_growth.py`):

| change | effect |
|---|---|
| collate closure → picklable `_AugmentationCollate` class | enables `num_workers>0` (the closure couldn't pickle); near-linear worker scaling (2 wk → 2.01x, 4 wk → 3.63x) |
| `Transform.forward` all-True fast path | skips the boolean gather/scatter when every sample is augmented (`probability>=1.0`); **1.24x**, benefits all transforms, numerically identical |
| `mask_encoding` vectorized | drops the per-batch Python loop → single scatter broadcast over channels; **2.9x**, identical |
| `channels_shuffle` gather | replaces `(B,C,C)` one-hot matrices + matmul with a `gather`; **1.8x**, **bit-for-bit identical** and seed-reproducible (the per-sample `rng.permutation` is kept on purpose so seeded outputs don't change) |

## Test plan

- `pytest test/unit_tests/augmentation/` — 129 passed (includes new `n_augmentation` tests).
- `pytest test/unit_tests/models/test_models.py -k eegitnet` and the generic `test_integration.py` harness (torchscript / export / compile / batch-1) for EEGITNet, EEGSym, MSVTNet.
- `pytest test/unit_tests/models/test_modules.py` (FilterBankLayer) and FBCNet/FBMSNet forward.
- All equivalences (mask_encoding, channels_shuffle, the `forward` fast path) checked against the previous implementation; `channels_shuffle` is bit-identical.

Closes #1067, closes #1068, closes #1069, closes #1070, closes #1071.
