### PR TITLE
refactor(modules): share sinusoidal PE primitive + add GatedLinearUnit (GEGLU)

### DIFF
--- a/braindecode/functional/__init__.py
+++ b/braindecode/functional/__init__.py
@@ -5,6 +5,7 @@ from .functions import (
     identity,
     plv_time,
     safe_log,
+    sinusoidal_positional_encoding,
     square,
 )
 from .initialization import glorot_weight_zero_bias, rescale_parameter
@@ -16,6 +17,7 @@ __all__ = [
     "identity",
     "plv_time",
     "safe_log",
+    "sinusoidal_positional_encoding",
     "square",
     "glorot_weight_zero_bias",
     "rescale_parameter",

--- a/braindecode/functional/functions.py
+++ b/braindecode/functional/functions.py
@@ -2,6 +2,8 @@
 #
 # License: BSD (3-clause)
 
+import math
+
 import torch
 import torch.nn.functional as F
 
@@ -249,3 +251,40 @@ def plv_time(x, forward_fourier=True, epsilon: float = 1e-6):
     )
 
     return plv_matrix
+
+
+def sinusoidal_positional_encoding(n_positions: int, dim: int) -> torch.Tensor:
+    r"""Fixed sine/cosine positional-encoding table of shape ``(n_positions, dim)``.
+
+    The standard encoding of Vaswani et al. (2017): for position :math:`p` and
+    channel :math:`i`, :math:`pe[p, 2i] = \sin(p / 10000^{2i/d})` and
+    :math:`pe[p, 2i+1] = \cos(p / 10000^{2i/d})`. PyTorch ships no sinusoidal
+    encoding (``nn.Embedding`` is a *learned* lookup), so braindecode models that
+    need one share this primitive instead of re-deriving it. An odd ``dim`` is
+    computed on the next even width and truncated, reproducing the per-model
+    wrappers (e.g. :class:`~braindecode.models.medformer` odd-``d_model``).
+
+    Parameters
+    ----------
+    n_positions : int
+        Number of positions (sequence length) to encode.
+    dim : int
+        Embedding dimension of each position.
+
+    Returns
+    -------
+    torch.Tensor
+        ``(n_positions, dim)`` float table; callers add their own batch axis,
+        dropout, or offset.
+    """
+    dim_even = dim + (dim % 2)
+    position = torch.arange(n_positions).unsqueeze(1).float()
+    div_term = torch.exp(
+        torch.arange(0, dim_even, 2).float() * (-math.log(10000.0) / dim_even)
+    )
+    pe = torch.zeros(n_positions, dim_even)
+    pe[:, 0::2] = torch.sin(position * div_term)
+    pe[:, 1::2] = torch.cos(position * div_term)
+    # ``.contiguous()`` so an odd-``dim`` truncation owns tight storage -- a
+    # non-contiguous view over the padded width breaks safetensors buffer saving.
+    return pe[:, :dim].contiguous()

--- a/braindecode/models/biot.py
+++ b/braindecode/models/biot.py
@@ -1,4 +1,3 @@
-import math
 from warnings import warn
 
 import numpy as np
@@ -6,6 +5,7 @@ import torch
 import torch.nn as nn
 from linear_attention_transformer import LinearAttentionTransformer
 
+from braindecode.functional import sinusoidal_positional_encoding
 from braindecode.models.base import EEGModuleMixin
 
 # -----------------------------------------------------------------------------
@@ -388,15 +388,8 @@ class _PositionalEncoding(nn.Module):
     def __init__(self, emb_size: int, drop_prob: float = 0.1, max_len: int = 1000):
         super(_PositionalEncoding, self).__init__()
 
-        # Compute the positional encodings once in log space.
-        pe = torch.zeros(max_len, emb_size)
-        position = torch.arange(0, max_len).unsqueeze(1).float()
-        div_term = torch.exp(
-            torch.arange(0, emb_size, 2).float() * -(math.log(10000.0) / emb_size)
-        )
-        pe[:, 0::2] = torch.sin(position * div_term)
-        pe[:, 1::2] = torch.cos(position * div_term)
-        pe = pe.unsqueeze(0)
+        # Compute the positional encodings once (shared sinusoidal primitive).
+        pe = sinusoidal_positional_encoding(max_len, emb_size).unsqueeze(0)
         self.register_buffer("pe", pe)
         self.dropout = nn.Dropout(p=drop_prob)
 

--- a/braindecode/models/medformer.py
+++ b/braindecode/models/medformer.py
@@ -6,7 +6,6 @@
 
 """Medformer: A Multi-Granularity Patching Transformer for Medical Time-Series Classification."""
 
-import math
 from math import sqrt
 from typing import List, Optional, Tuple
 
@@ -14,6 +13,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from braindecode.functional import sinusoidal_positional_encoding
 from braindecode.models.base import EEGModuleMixin
 
 
@@ -329,28 +329,10 @@ class MEDFormer(EEGModuleMixin, nn.Module):
 class _PositionalEmbedding(nn.Module):
     def __init__(self, d_model: int, max_len: int = 5000):
         super().__init__()
-        # If d_model is odd, temporarily work with d_model + 1.
-        if d_model % 2 == 1:
-            d_model_adj = d_model + 1
-        else:
-            d_model_adj = d_model
         self.d_model = d_model  # store the original dimension
-
-        # Create a pe tensor of size (max_len, d_model_adj)
-        pe = torch.zeros(max_len, d_model_adj).float()
-        pe.requires_grad = False
-
-        # Compute the sinusoidal factors.
-        position = torch.arange(0, max_len).float().unsqueeze(1)
-        # Use d_model_adj in the denominator so that the frequencies are computed over an even number.
-        div_term = torch.exp(
-            torch.arange(0, d_model_adj, 2).float() * (-math.log(10000.0) / d_model_adj)
-        )
-        pe[:, 0::2] = torch.sin(position * div_term)
-        pe[:, 1::2] = torch.cos(position * div_term)
-
-        # Unsqueeze to shape (1, max_len, d_model_adj)
-        pe = pe.unsqueeze(0)
+        # Odd d_model is handled inside the shared primitive (computed on the
+        # next even width and truncated), so no manual padding is needed here.
+        pe = sinusoidal_positional_encoding(max_len, d_model).unsqueeze(0)
         self.register_buffer("pe", pe)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:

--- a/braindecode/models/steegformer.py
+++ b/braindecode/models/steegformer.py
@@ -9,7 +9,6 @@ Port of Yang et al. (2026), https://github.com/LiuyinYang1101/STEEGFormer
 from __future__ import annotations
 
 import json
-import math
 import warnings
 from functools import lru_cache
 
@@ -18,6 +17,7 @@ from einops import rearrange
 from einops.layers.torch import Rearrange
 from torch import nn
 
+from braindecode.functional import sinusoidal_positional_encoding
 from braindecode.models.base import EEGModuleMixin
 from braindecode.modules import (
     DropPath,
@@ -550,13 +550,7 @@ class _TemporalPositionalEncoding(nn.Module):
     def __init__(self, embed_dim: int, max_len: int = 2048):
         super().__init__()
         self.max_len = max_len
-        position = torch.arange(max_len).unsqueeze(1)
-        div_term = torch.exp(
-            torch.arange(0, embed_dim, 2) * (-math.log(10000.0) / embed_dim)
-        )
-        pe = torch.zeros(max_len, embed_dim)
-        pe[:, 0::2] = torch.sin(position * div_term)
-        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = sinusoidal_positional_encoding(max_len, embed_dim)
         # Non-persistent: deterministic, regenerated identically at init.
         self.register_buffer("pe", pe, persistent=False)
 

--- a/braindecode/modules/__init__.py
+++ b/braindecode/modules/__init__.py
@@ -1,4 +1,4 @@
-from .activation import LogActivation, SafeLog, Square
+from .activation import GatedLinearUnit, LogActivation, SafeLog, Square
 from .attention import (
     CAT,
     CBAM,
@@ -50,6 +50,7 @@ from .util import aggregate_probas
 from .wrapper import Expression, IntermediateOutputWrapper
 
 __all__ = [
+    "GatedLinearUnit",
     "LogActivation",
     "SafeLog",
     "Square",

--- a/braindecode/modules/activation.py
+++ b/braindecode/modules/activation.py
@@ -104,3 +104,37 @@ class LogActivation(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return torch.log(x + self.epsilon)  # Adding epsilon to prevent log(0)
+
+
+class GatedLinearUnit(nn.Module):
+    r"""Generalized gated linear unit (GLU family).
+
+    Splits the last dimension in half into a ``value`` and a ``gate`` and
+    returns :math:`\text{value} \otimes \text{activation}(\text{gate})`. With the
+    default ``activation=nn.GELU`` this is **GEGLU** (Shazeer, 2020); ``nn.SiLU``
+    gives SwiGLU and ``nn.Sigmoid`` the original GLU. Unlike
+    :class:`torch.nn.GLU`, the gate nonlinearity is configurable (``torch.nn.GLU``
+    is hard-wired to the sigmoid).
+
+    Parameters
+    ----------
+    activation : type[nn.Module], default=nn.GELU
+        Constructor of the gate activation. The default yields GEGLU.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from braindecode.modules import GatedLinearUnit
+    >>> module = GatedLinearUnit()
+    >>> outputs = module(torch.randn(2, 10, 16))
+    >>> outputs.shape
+    torch.Size([2, 10, 8])
+    """
+
+    def __init__(self, activation: type[nn.Module] = nn.GELU):
+        super().__init__()
+        self.activation = activation()
+
+    def forward(self, x: Tensor) -> Tensor:
+        value, gate = x.chunk(2, dim=-1)
+        return value * self.activation(gate)

--- a/braindecode/modules/blocks.py
+++ b/braindecode/modules/blocks.py
@@ -3,6 +3,8 @@ from warnings import warn
 import torch
 from torch import nn
 
+from braindecode.modules.activation import GatedLinearUnit
+
 
 class PatchTokenizer(nn.Module):
     r"""Tokenize an EEG signal into non-overlapping temporal patches.
@@ -293,7 +295,13 @@ class FeedForwardBlock(nn.Sequential):
     drop_p : float
         Dropout probability.
     activation : type[nn.Module], default=nn.GELU
-        Activation function constructor.
+        Activation function constructor. When ``gated=True`` this is the gate
+        nonlinearity of the :class:`~braindecode.modules.GatedLinearUnit`.
+    gated : bool, default=False
+        If ``True``, use a GLU-family feed-forward: the first projection is
+        doubled and split into value/gate (GEGLU with the default ``nn.GELU``).
+        The default ``False`` keeps the classic ``Linear -> activation -> Linear``
+        block, so existing models are unchanged.
 
     Examples
     --------
@@ -307,11 +315,28 @@ class FeedForwardBlock(nn.Sequential):
     """
 
     def __init__(
-        self, emb_size, expansion, drop_p, activation: type[nn.Module] = nn.GELU
+        self,
+        emb_size,
+        expansion,
+        drop_p,
+        activation: type[nn.Module] = nn.GELU,
+        gated: bool = False,
     ):
-        super().__init__(
-            nn.Linear(emb_size, expansion * emb_size),
-            activation(),
-            nn.Dropout(drop_p),
-            nn.Linear(expansion * emb_size, emb_size),
-        )
+        hidden = expansion * emb_size
+        if gated:
+            # GLU-family FFN (GEGLU with the default GELU): the first projection
+            # is doubled so GatedLinearUnit can split it into value/gate.
+            layers = (
+                nn.Linear(emb_size, hidden * 2),
+                GatedLinearUnit(activation),
+                nn.Dropout(drop_p),
+                nn.Linear(hidden, emb_size),
+            )
+        else:
+            layers = (
+                nn.Linear(emb_size, hidden),
+                activation(),
+                nn.Dropout(drop_p),
+                nn.Linear(hidden, emb_size),
+            )
+        super().__init__(*layers)

--- a/braindecode/modules/blocks.py
+++ b/braindecode/modules/blocks.py
@@ -3,8 +3,6 @@ from warnings import warn
 import torch
 from torch import nn
 
-from braindecode.modules.activation import GatedLinearUnit
-
 
 class PatchTokenizer(nn.Module):
     r"""Tokenize an EEG signal into non-overlapping temporal patches.
@@ -295,13 +293,7 @@ class FeedForwardBlock(nn.Sequential):
     drop_p : float
         Dropout probability.
     activation : type[nn.Module], default=nn.GELU
-        Activation function constructor. When ``gated=True`` this is the gate
-        nonlinearity of the :class:`~braindecode.modules.GatedLinearUnit`.
-    gated : bool, default=False
-        If ``True``, use a GLU-family feed-forward: the first projection is
-        doubled and split into value/gate (GEGLU with the default ``nn.GELU``).
-        The default ``False`` keeps the classic ``Linear -> activation -> Linear``
-        block, so existing models are unchanged.
+        Activation function constructor.
 
     Examples
     --------
@@ -315,28 +307,11 @@ class FeedForwardBlock(nn.Sequential):
     """
 
     def __init__(
-        self,
-        emb_size,
-        expansion,
-        drop_p,
-        activation: type[nn.Module] = nn.GELU,
-        gated: bool = False,
+        self, emb_size, expansion, drop_p, activation: type[nn.Module] = nn.GELU
     ):
-        hidden = expansion * emb_size
-        if gated:
-            # GLU-family FFN (GEGLU with the default GELU): the first projection
-            # is doubled so GatedLinearUnit can split it into value/gate.
-            layers = (
-                nn.Linear(emb_size, hidden * 2),
-                GatedLinearUnit(activation),
-                nn.Dropout(drop_p),
-                nn.Linear(hidden, emb_size),
-            )
-        else:
-            layers = (
-                nn.Linear(emb_size, hidden),
-                activation(),
-                nn.Dropout(drop_p),
-                nn.Linear(hidden, emb_size),
-            )
-        super().__init__(*layers)
+        super().__init__(
+            nn.Linear(emb_size, expansion * emb_size),
+            activation(),
+            nn.Dropout(drop_p),
+            nn.Linear(expansion * emb_size, emb_size),
+        )

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -215,6 +215,7 @@ stability.
     :template: class_in_subdir
     :recursive:
 
+    GatedLinearUnit
     LogActivation
     SafeLog
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -416,6 +416,7 @@ The functional module contains various functions that can be used like functiona
      plv_time
      rescale_parameter
      safe_log
+     sinusoidal_positional_encoding
      square
 
 **********

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,6 +28,12 @@ Current 1.6.1 (GitHub)
 Enhancements
 ============
 
+- Add :func:`braindecode.functional.sinusoidal_positional_encoding`, a shared
+  sine/cosine positional-encoding primitive (handling odd dimensions), and reuse
+  it in :class:`braindecode.models.BIOT`, :class:`braindecode.models.MEDFormer`,
+  and :class:`braindecode.models.STEEGFormer` instead of re-deriving the table in
+  each. Encodings are bit-identical, so model behavior is unchanged.
+  (:gh:`1078` by `Bruno Aristimunha`_)
 - Add an optional spatial Fourier :class:`braindecode.modules.ChannelMerger`
   (with :class:`braindecode.modules.FourierEmb`) to
   :class:`braindecode.models.BrainModule` via ``use_merger=True``, implementing

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,10 +33,10 @@ Enhancements
   it in :class:`braindecode.models.BIOT`, :class:`braindecode.models.MEDFormer`,
   and :class:`braindecode.models.STEEGFormer` instead of re-deriving the table in
   each. Encodings are bit-identical, so model behavior is unchanged. Also add
-  :class:`braindecode.modules.GatedLinearUnit` and a ``gated`` option on
-  :class:`braindecode.modules.FeedForwardBlock` for GLU-family feed-forwards
-  (GEGLU with the default ``nn.GELU``); default-off, so existing models are
-  unchanged. (:gh:`1078` by `Bruno Aristimunha`_)
+  :class:`braindecode.modules.GatedLinearUnit`, a configurable GLU-family gate
+  (GEGLU with the default ``nn.GELU``, SwiGLU with ``nn.SiLU``; ``torch.nn.GLU``
+  is hard-wired to the sigmoid) for building gated transformer feed-forwards.
+  (:gh:`1078` by `Bruno Aristimunha`_)
 - Add an optional spatial Fourier :class:`braindecode.modules.ChannelMerger`
   (with :class:`braindecode.modules.FourierEmb`) to
   :class:`braindecode.models.BrainModule` via ``use_merger=True``, implementing

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,8 +32,11 @@ Enhancements
   sine/cosine positional-encoding primitive (handling odd dimensions), and reuse
   it in :class:`braindecode.models.BIOT`, :class:`braindecode.models.MEDFormer`,
   and :class:`braindecode.models.STEEGFormer` instead of re-deriving the table in
-  each. Encodings are bit-identical, so model behavior is unchanged.
-  (:gh:`1078` by `Bruno Aristimunha`_)
+  each. Encodings are bit-identical, so model behavior is unchanged. Also add
+  :class:`braindecode.modules.GatedLinearUnit` and a ``gated`` option on
+  :class:`braindecode.modules.FeedForwardBlock` for GLU-family feed-forwards
+  (GEGLU with the default ``nn.GELU``); default-off, so existing models are
+  unchanged. (:gh:`1078` by `Bruno Aristimunha`_)
 - Add an optional spatial Fourier :class:`braindecode.modules.ChannelMerger`
   (with :class:`braindecode.modules.FourierEmb`) to
   :class:`braindecode.models.BrainModule` via ``use_merger=True``, implementing

--- a/test/unit_tests/models/test_functional.py
+++ b/test/unit_tests/models/test_functional.py
@@ -2,7 +2,11 @@ import numpy as np
 import pytest
 import torch
 
-from braindecode.functional import hilbert_freq, plv_time
+from braindecode.functional import (
+    hilbert_freq,
+    plv_time,
+    sinusoidal_positional_encoding,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -65,3 +69,21 @@ def test_plv_time_perfect_synchronization():
     expected = torch.ones(batch, channels, channels)
     assert torch.allclose(plv_matrix, expected, atol=1e-5), \
         "PLV should be 1 for perfectly synchronized signals"
+
+
+def test_sinusoidal_positional_encoding_even_dim():
+    """Shape, contiguity, and the defining sin/cos values at position 0."""
+    pe = sinusoidal_positional_encoding(50, 16)
+    assert pe.shape == (50, 16)
+    assert pe.is_contiguous()
+    # position 0: sin(0)=0 on even channels, cos(0)=1 on odd channels.
+    assert torch.allclose(pe[0], torch.tensor([0.0, 1.0] * 8))
+
+
+def test_sinusoidal_positional_encoding_odd_dim_truncates_contiguously():
+    """Odd dim is computed on the next even width, truncated, and contiguous
+    (a non-contiguous view would break safetensors buffer saving)."""
+    pe_odd = sinusoidal_positional_encoding(50, 15)
+    assert pe_odd.shape == (50, 15)
+    assert pe_odd.is_contiguous()
+    assert torch.equal(pe_odd, sinusoidal_positional_encoding(50, 16)[:, :15])

--- a/test/unit_tests/models/test_modules.py
+++ b/test/unit_tests/models/test_modules.py
@@ -1359,22 +1359,3 @@ def test_gated_linear_unit_geglu_semantics():
     out = glu(x)
     assert out.shape == (2, 4, 5)
     assert torch.equal(out, value * torch.nn.functional.gelu(gate))
-
-
-def test_feedforwardblock_default_unchanged():
-    """gated=False keeps the classic Linear -> act -> Dropout -> Linear block."""
-    from braindecode.modules import FeedForwardBlock
-
-    ff = FeedForwardBlock(emb_size=16, expansion=4, drop_p=0.1)
-    assert [type(m).__name__ for m in ff] == ["Linear", "GELU", "Dropout", "Linear"]
-    assert ff[0].out_features == 64  # not doubled
-
-
-def test_feedforwardblock_gated_shapes():
-    """gated=True doubles the first projection and preserves emb_size end-to-end."""
-    from braindecode.modules import FeedForwardBlock, GatedLinearUnit
-
-    ff = FeedForwardBlock(emb_size=16, expansion=4, drop_p=0.0, gated=True)
-    assert ff[0].out_features == 128  # doubled for the value/gate split
-    assert isinstance(ff[1], GatedLinearUnit)
-    assert ff(torch.randn(2, 7, 16)).shape == (2, 7, 16)

--- a/test/unit_tests/models/test_modules.py
+++ b/test/unit_tests/models/test_modules.py
@@ -1347,3 +1347,34 @@ def test_patch_tokenizer():
     expected = tok_linear.proj(patches)
     assert torch.allclose(tok_linear(x), expected)
     assert set(tok_linear.state_dict()) == {"proj.weight", "proj.bias"}
+
+
+def test_gated_linear_unit_geglu_semantics():
+    """GatedLinearUnit halves the last dim and gates with the given activation."""
+    from braindecode.modules import GatedLinearUnit
+
+    glu = GatedLinearUnit()  # default GELU -> GEGLU
+    x = torch.randn(2, 4, 10)
+    value, gate = x.chunk(2, dim=-1)
+    out = glu(x)
+    assert out.shape == (2, 4, 5)
+    assert torch.equal(out, value * torch.nn.functional.gelu(gate))
+
+
+def test_feedforwardblock_default_unchanged():
+    """gated=False keeps the classic Linear -> act -> Dropout -> Linear block."""
+    from braindecode.modules import FeedForwardBlock
+
+    ff = FeedForwardBlock(emb_size=16, expansion=4, drop_p=0.1)
+    assert [type(m).__name__ for m in ff] == ["Linear", "GELU", "Dropout", "Linear"]
+    assert ff[0].out_features == 64  # not doubled
+
+
+def test_feedforwardblock_gated_shapes():
+    """gated=True doubles the first projection and preserves emb_size end-to-end."""
+    from braindecode.modules import FeedForwardBlock, GatedLinearUnit
+
+    ff = FeedForwardBlock(emb_size=16, expansion=4, drop_p=0.0, gated=True)
+    assert ff[0].out_features == 128  # doubled for the value/gate split
+    assert isinstance(ff[1], GatedLinearUnit)
+    assert ff(torch.randn(2, 7, 16)).shape == (2, 7, 16)


### PR DESCRIPTION
## What

Two deduplications of shared building blocks:

1. **Sinusoidal positional encoding** — add `braindecode.functional.sinusoidal_positional_encoding(n_positions, dim)` and reuse it in **BIOT**, **MEDFormer**, **STEEGFormer**, which each re-derived the identical `div_term`/`sin`/`cos` table.
2. **Gated linear unit** — add `braindecode.modules.GatedLinearUnit`, a configurable GLU-family gate (GEGLU with the default `nn.GELU`, SwiGLU with `nn.SiLU`; `torch.nn.GLU` is hard-wired to sigmoid and can't express these).

## Why (deep study)

- The "six PE copies" are **not** the same: only 3 are sinusoidal (consolidated); msvtnet/ctnet/steegformer-channel are **learnable** `nn.Parameter`/`nn.Embedding` — a different mechanism, untouched. PyTorch ships **no** sinusoidal encoding.
- `GatedLinearUnit` is the genuinely reusable, non-trivial piece (the chunk + gate). It deliberately does **not** touch `FeedForwardBlock`: a GLU halves the hidden dim, so it can't be passed as the block's `activation` (the final Linear's `in_features` wouldn't match), and adding a structural `gated` branch to a shared block for one consumer isn't worth it. Callers build the 3-line `nn.Sequential(Linear(d, d*m*2), GatedLinearUnit(), Linear(d*m, d))` themselves (DANCE drops its vendored `_GEGLU` this way).

## Correctness / backward-compat

- PE primitive reproduces each model's previous buffer **bit-for-bit** (even dims + MEDFormer's odd `d_model`); returns a **contiguous** table (a non-contiguous odd-dim view broke safetensors saving — caught by the HF round-trip).
- No existing model's behavior changes; `FeedForwardBlock` is untouched.

## Tests

Focused tests for the primitive (even/odd + contiguity) and `GatedLinearUnit` (GEGLU semantics). Full BIOT/MEDFormer/STEEGFormer + module suites pass; HF/config round-trips and lint green.