### PR TITLE
Add a `Modality` column to the model summary table

### DIFF
--- a/braindecode/models/summary.csv
+++ b/braindecode/models/summary.csv
@@ -1,61 +1,61 @@
-﻿Model,Application,Type,Sampling Frequency (Hz),Hyperparameters,#Parameters,get_#Parameters,Categorization
-ATCNet,General,Prediction,250,"n_chans, n_outputs, n_times",113732,"ATCNet(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Recurrent,Attention/Transformer"
-AttentionBaseNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",3692,"AttentionBaseNet(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer"
-BDTCN,Normal Abnormal,Prediction,100,"n_chans, n_outputs, n_times",456502,"BDTCN(n_chans=21, n_outputs=2, n_times=6000, n_blocks=5, n_filters=55, kernel_size=16)","Convolution,Recurrent"
-BIOT,"Sleep Staging, Epilepsy",Prediction,200,"n_chans, n_outputs",3183879,"BIOT(n_chans=2,  n_outputs=5,  n_times=6000)","Foundation Model"
-CBraMod,General,"Prediction, Embedding",200,"n_outputs",4924000,"CBraMod(n_outputs=2)","Foundation Model"
-CodeBrain,General,"Prediction, Embedding",200,"n_chans, n_outputs, n_times",15238802,"CodeBrain(n_chans=19, n_outputs=2, n_times=6000)","Foundation Model,Attention/Transformer"
-ContraWR,Sleep Staging,"Prediction, Embedding",125,"n_chans, n_outputs, sfreq",1160165,"ContraWR(n_chans=2, n_outputs=5, n_times=3750, emb_size=256, sfreq=125)",Convolution
-CTNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",26900,"CTNet(n_chans=22, n_outputs=4, n_times=1000, n_filters_time=8, kernel_size=16, num_heads=2, embed_dim=16)","Convolution,Attention/Transformer"
-Deep4Net,General,Prediction,250,"n_chans, n_outputs, n_times",282879,"Deep4Net(n_chans=22, n_outputs=4, n_times=1000)","Convolution"
-DeepSleepNet,Sleep Staging,Prediction,256,"n_chans, n_outputs",24744837,"DeepSleepNet(n_chans=1, n_outputs=5, n_times=7680, sfreq=256)","Convolution,Recurrent"
-EEGConformer,General,Prediction,250,"n_chans, n_outputs, n_times",789572,"EEGConformer(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer"
-EEGPT,General,Prediction,256,"n_chans, n_outputs, n_times",25477635,"EEGPT(n_chans=58, n_outputs=4, n_times=1024)","Foundation Model,Attention/Transformer"
-EEGInceptionERP,"ERP, SSVEP",Prediction,128,"n_chans, n_outputs",14926,"EEGInceptionERP(n_chans=8, n_outputs=2, n_times=128, sfreq=128)","Convolution"
-EEGInceptionMI,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",558028,"EEGInceptionMI(n_chans=22, n_outputs=4, n_times=1000, n_convs=5, n_filters=12)","Convolution"
-EEGITNet,Motor Imagery,Prediction,125,"n_chans, n_outputs, n_times",5212,"EEGITNet(n_chans=22,  n_outputs=4,  n_times=500)","Convolution,Recurrent"
-EEGNet,General,Prediction,128,"n_chans, n_outputs, n_times",2484,"EEGNet(n_chans=22,  n_outputs=4,  n_times=512)","Convolution"
-EEGNeX,Motor Imagery,Prediction,125,"n_chans, n_outputs, n_times",55940,"EEGNeX(n_chans=22,  n_outputs=4,  n_times=500)","Convolution"
-EEGSym,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",299218,"EEGSym(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,Channel"
-EEGMiner,Emotion Recognition,Prediction,128,"n_chans, n_outputs, n_times, sfreq",7572,"EEGMiner(n_chans=62, n_outputs=2, n_times=2560, sfreq=128)","Convolution,Interpretability"
-EEGSimpleConv,Motor Imagery,Prediction,80,"n_chans, n_outputs, sfreq",730404,"EEGSimpleConv(n_chans=22,  n_outputs=4,  n_times=320, sfreq=80)","Convolution"
-EEGTCNet,Motor Imagery,Prediction,250,"n_chans, n_outputs",4516,"EEGTCNet(n_chans=22,  n_outputs=4,  n_times=1000, kern_length=32)","Convolution,Recurrent"
-Labram,General,"Prediction, Embedding",200,"n_chans, n_outputs, n_times",5866180,"Labram(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,Foundation Model"
-MSVTNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",75494," MSVTNet(n_chans=22,  n_outputs=4,  n_times=1000)","Convolution,Recurrent,Attention/Transformer"
-SCCNet,Motor Imagery,Prediction,125,"n_chans, n_outputs, n_times, sfreq",12070,"SCCNet(n_chans=22,  n_outputs=4,  n_times=1000, sfreq=125)","Convolution"
-SignalJEPA,"Motor Imagery, ERP, SSVEP",Embedding,128,"n_times, chs_info",3456882,"SignalJEPA(n_times=512, chs_info=Lee2019_MI().get_data(subjects=[1])[1]['0']['1train'].info[""chs""][:62])","Convolution,Channel,Foundation Model"
-SignalJEPA_Contextual,"Motor Imagery, ERP, SSVEP",Prediction,128,"n_outputs, n_times, chs_info",3459184,"SignalJEPA_Contextual(n_outputs=2, input_window_seconds=4.19, sfreq=128, chs_info=Lee2019_MI().get_data(subjects=[1])[1]['0']['1train'].info[""chs""][:62])","Convolution,Channel,Foundation Model"
-SignalJEPA_PostLocal,"Motor Imagery, ERP, SSVEP",Prediction,128,"n_chans, n_outputs, n_times",16142,"SignalJEPA_PostLocal(n_chans=62, n_outputs=2, input_window_seconds=4.19, sfreq=128)","Convolution,Channel,Foundation Model"
-SignalJEPA_PreLocal,"Motor Imagery, ERP, SSVEP",Prediction,128,"n_outputs, n_times, chs_info",16142,"SignalJEPA_PreLocal(n_chans=62, n_outputs=2, input_window_seconds=4.19, sfreq=128)","Convolution,Channel,Foundation Model"
-SincShallowNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",21892,"SincShallowNet(n_chans=22,  n_outputs=4,  n_times=1000, sfreq=250)","Convolution,Interpretability"
-ShallowFBCSPNet,General,Prediction,250,"n_chans, n_outputs, n_times",46084,"ShallowFBCSPNet(n_chans=22,  n_outputs=4,  n_times=1000, sfreq=250)","Convolution"
-SleepStagerBlanco2020,Sleep Staging,Prediction,100,"n_chans, n_outputs, n_times",2845,"SleepStagerBlanco2020(n_chans=2, n_outputs=5, n_times=3000, sfreq=100)","Convolution"
-SleepStagerChambon2018,Sleep Staging,Prediction,128,"n_chans, n_outputs, n_times, sfreq",5835,"SleepStagerChambon2018(n_chans=2, n_outputs=5, n_times=3840, sfreq=128)","Convolution"
-AttnSleep,Sleep Staging,Prediction,100,"n_chans, n_outputs, n_times, sfreq",719925,"AttnSleep(n_chans=2, n_outputs=5, n_times=3000, sfreq=100)","Convolution, Attention/Transformer"
-SPARCNet,Epilepsy,Prediction,200,"n_chans, n_outputs, n_times",1141921,"SPARCNet(n_chans=16, n_outputs=6, n_times=2000, sfreq=200)","Convolution"
-SyncNet,"Emotion Recognition, Alcoholism",Prediction,256,"n_chans, n_outputs, n_times",554,"SyncNet(n_chans=62, n_outputs=3, n_times=5120, sfreq=256)","Interpretability"
-TSception,Emotion Recognition,Prediction,256,"n_chans, n_outputs, n_times, sfreq",2187206,"TSception(n_chans=62, n_outputs=3, n_times=5120, sfreq=256)","Convolution"
-TIDNet,General,Prediction,250,"n_chans, n_outputs, n_times",240404,"TIDNet(n_chans=22,  n_outputs=4,  n_times=1000)","Convolution"
-USleep,Sleep Staging,Prediction,128,"n_chans, n_outputs, n_times, sfreq",2482011,"USleep(n_chans=2, n_outputs=5, n_times=3000, sfreq=100)","Convolution"
-FBCNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",11812,"FCNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank"
-FBMSNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",16231,"FBMSNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank"
-MetaNeuromotorHand,Handwriting (sEMG),CTC Sequence,2000,"n_chans, n_outputs, n_times, sfreq",1021284,"MetaNeuromotorHand(n_chans=16, n_outputs=100, n_times=32000, sfreq=2000)","Convolution,Attention/Transformer"
-EMG2QwertyNet,Touch typing (sEMG),CTC Sequence,2000,"n_chans, n_outputs, n_times, sfreq",5293315,"EMG2QwertyNet(n_chans=32, n_outputs=99, n_times=8000, sfreq=2000)","Convolution"
-FBLightConvNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",6596,"FBLightConvNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank"
-IFNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",9860,"IFNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank"
-BrainModule,Speech Decoding,Prediction,250,"n_chans, n_outputs, n_times, sfreq",6186909,"BrainModule(n_chans=64, n_outputs=29, n_times=160, sfreq=1000)","Convolution"
-PBT,General,Prediction,250,"n_chans, n_outputs, n_times",818948,"PBT(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Foundation Model"
-SSTDPN,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",19502,"SSTDPN(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer"
-BENDR,General,"Prediction, Embedding",250,"n_chans, n_times, n_outputs",157141049,"BENDR(n_chans=22, n_outputs=4, n_times=1000)","Foundation Model,Convolution"
-LUNA,General,"Prediction, Embedding",128,"n_chans, n_times, sfreq, chs_info",7100731,"LUNA(n_chans=22, n_times=512, sfreq=128)","Convolution,Channel,Foundation Model"
-MEDFormer,General,Prediction,250,"n_chans, n_outputs, n_times",5313924,"MEDFormer(n_chans=22, n_outputs=4, n_times=1000)","Foundation Model,Convolution"
-REVE,General,Prediction,200,"n_outputs, n_times, n_chans",69481476,"REVE(n_times=1000, n_outputs=4, n_chans=19)","Foundation Model,Attention/Transformer"
-DGCNN,Emotion Recognition,Prediction,128,"n_chans, n_outputs, n_times, chs_info",1037385,"DGCNN(n_chans=62, n_outputs=4, n_times=128)","Graph Neural Network,Channel"
-InterpolatedBENDR,General,"Prediction, Embedding",250,"chs_info, n_outputs, n_times",157143101,"InterpolatedBENDR(chs_info=<user>, n_outputs=4, n_times=1000)","Foundation Model,Convolution,Channel"
-InterpolatedBIOT,"Sleep Staging, Epilepsy",Prediction,200,"chs_info, n_outputs, n_times, sfreq",3184101,"InterpolatedBIOT(chs_info=<user>, n_outputs=5, sfreq=200, n_times=6000)","Foundation Model,Channel"
-InterpolatedEEGPT,General,Prediction,256,"chs_info, n_outputs, n_times",25323137,"InterpolatedEEGPT(chs_info=<user>, n_outputs=4, n_times=1024)","Foundation Model,Attention/Transformer,Channel"
-InterpolatedLaBraM,General,"Prediction, Embedding",200,"chs_info, n_outputs, n_times",5866196,"InterpolatedLaBraM(chs_info=<user>, n_outputs=4, n_times=1000)","Convolution,Foundation Model,Channel"
-InterpolatedSignalJEPA,"Motor Imagery, ERP, SSVEP",Embedding,128,"chs_info",3456882,"InterpolatedSignalJEPA(chs_info=<user>)","Convolution,Channel,Foundation Model"
-TCFormer,Motor Imagery,Classification,250,"n_chans, n_outputs, n_times",77820,"TCFormer(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer"
-EEGDINO,General,Classification,200,"n_chans, n_outputs, n_times",4539698,"EEGDINO(n_chans=19, n_outputs=4, n_times=1000)","Foundation Model,Attention/Transformer"
-STEEGFormer,General,Classification,250,"n_chans, n_outputs, n_times",25305604,"STEEGFormer(n_chans=22, n_outputs=4, n_times=1000)","Attention/Transformer,Foundation Model"
+﻿Model,Application,Type,Sampling Frequency (Hz),Hyperparameters,#Parameters,get_#Parameters,Categorization,Modality
+ATCNet,General,Prediction,250,"n_chans, n_outputs, n_times",113732,"ATCNet(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Recurrent,Attention/Transformer",EEG
+AttentionBaseNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",3692,"AttentionBaseNet(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer",EEG
+BDTCN,Normal Abnormal,Prediction,100,"n_chans, n_outputs, n_times",456502,"BDTCN(n_chans=21, n_outputs=2, n_times=6000, n_blocks=5, n_filters=55, kernel_size=16)","Convolution,Recurrent",EEG
+BIOT,"Sleep Staging, Epilepsy",Prediction,200,"n_chans, n_outputs",3183879,"BIOT(n_chans=2,  n_outputs=5,  n_times=6000)","Foundation Model",EEG
+CBraMod,General,"Prediction, Embedding",200,"n_outputs",4924000,"CBraMod(n_outputs=2)","Foundation Model",EEG
+CodeBrain,General,"Prediction, Embedding",200,"n_chans, n_outputs, n_times",15238802,"CodeBrain(n_chans=19, n_outputs=2, n_times=6000)","Foundation Model,Attention/Transformer",EEG
+ContraWR,Sleep Staging,"Prediction, Embedding",125,"n_chans, n_outputs, sfreq",1160165,"ContraWR(n_chans=2, n_outputs=5, n_times=3750, emb_size=256, sfreq=125)",Convolution,EEG
+CTNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",26900,"CTNet(n_chans=22, n_outputs=4, n_times=1000, n_filters_time=8, kernel_size=16, num_heads=2, embed_dim=16)","Convolution,Attention/Transformer",EEG
+Deep4Net,General,Prediction,250,"n_chans, n_outputs, n_times",282879,"Deep4Net(n_chans=22, n_outputs=4, n_times=1000)","Convolution",EEG
+DeepSleepNet,Sleep Staging,Prediction,256,"n_chans, n_outputs",24744837,"DeepSleepNet(n_chans=1, n_outputs=5, n_times=7680, sfreq=256)","Convolution,Recurrent",EEG
+EEGConformer,General,Prediction,250,"n_chans, n_outputs, n_times",789572,"EEGConformer(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer",EEG
+EEGPT,General,Prediction,256,"n_chans, n_outputs, n_times",25477635,"EEGPT(n_chans=58, n_outputs=4, n_times=1024)","Foundation Model,Attention/Transformer",EEG
+EEGInceptionERP,"ERP, SSVEP",Prediction,128,"n_chans, n_outputs",14926,"EEGInceptionERP(n_chans=8, n_outputs=2, n_times=128, sfreq=128)","Convolution",EEG
+EEGInceptionMI,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",558028,"EEGInceptionMI(n_chans=22, n_outputs=4, n_times=1000, n_convs=5, n_filters=12)","Convolution",EEG
+EEGITNet,Motor Imagery,Prediction,125,"n_chans, n_outputs, n_times",5212,"EEGITNet(n_chans=22,  n_outputs=4,  n_times=500)","Convolution,Recurrent",EEG
+EEGNet,General,Prediction,128,"n_chans, n_outputs, n_times",2484,"EEGNet(n_chans=22,  n_outputs=4,  n_times=512)","Convolution",EEG
+EEGNeX,Motor Imagery,Prediction,125,"n_chans, n_outputs, n_times",55940,"EEGNeX(n_chans=22,  n_outputs=4,  n_times=500)","Convolution",EEG
+EEGSym,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",299218,"EEGSym(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,Channel",EEG
+EEGMiner,Emotion Recognition,Prediction,128,"n_chans, n_outputs, n_times, sfreq",7572,"EEGMiner(n_chans=62, n_outputs=2, n_times=2560, sfreq=128)","Convolution,Interpretability",EEG
+EEGSimpleConv,Motor Imagery,Prediction,80,"n_chans, n_outputs, sfreq",730404,"EEGSimpleConv(n_chans=22,  n_outputs=4,  n_times=320, sfreq=80)","Convolution",EEG
+EEGTCNet,Motor Imagery,Prediction,250,"n_chans, n_outputs",4516,"EEGTCNet(n_chans=22,  n_outputs=4,  n_times=1000, kern_length=32)","Convolution,Recurrent",EEG
+Labram,General,"Prediction, Embedding",200,"n_chans, n_outputs, n_times",5866180,"Labram(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,Foundation Model",EEG
+MSVTNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",75494," MSVTNet(n_chans=22,  n_outputs=4,  n_times=1000)","Convolution,Recurrent,Attention/Transformer",EEG
+SCCNet,Motor Imagery,Prediction,125,"n_chans, n_outputs, n_times, sfreq",12070,"SCCNet(n_chans=22,  n_outputs=4,  n_times=1000, sfreq=125)","Convolution",EEG
+SignalJEPA,"Motor Imagery, ERP, SSVEP",Embedding,128,"n_times, chs_info",3456882,"SignalJEPA(n_times=512, chs_info=Lee2019_MI().get_data(subjects=[1])[1]['0']['1train'].info[""chs""][:62])","Convolution,Channel,Foundation Model",EEG
+SignalJEPA_Contextual,"Motor Imagery, ERP, SSVEP",Prediction,128,"n_outputs, n_times, chs_info",3459184,"SignalJEPA_Contextual(n_outputs=2, input_window_seconds=4.19, sfreq=128, chs_info=Lee2019_MI().get_data(subjects=[1])[1]['0']['1train'].info[""chs""][:62])","Convolution,Channel,Foundation Model",EEG
+SignalJEPA_PostLocal,"Motor Imagery, ERP, SSVEP",Prediction,128,"n_chans, n_outputs, n_times",16142,"SignalJEPA_PostLocal(n_chans=62, n_outputs=2, input_window_seconds=4.19, sfreq=128)","Convolution,Channel,Foundation Model",EEG
+SignalJEPA_PreLocal,"Motor Imagery, ERP, SSVEP",Prediction,128,"n_outputs, n_times, chs_info",16142,"SignalJEPA_PreLocal(n_chans=62, n_outputs=2, input_window_seconds=4.19, sfreq=128)","Convolution,Channel,Foundation Model",EEG
+SincShallowNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",21892,"SincShallowNet(n_chans=22,  n_outputs=4,  n_times=1000, sfreq=250)","Convolution,Interpretability",EEG
+ShallowFBCSPNet,General,Prediction,250,"n_chans, n_outputs, n_times",46084,"ShallowFBCSPNet(n_chans=22,  n_outputs=4,  n_times=1000, sfreq=250)","Convolution",EEG
+SleepStagerBlanco2020,Sleep Staging,Prediction,100,"n_chans, n_outputs, n_times",2845,"SleepStagerBlanco2020(n_chans=2, n_outputs=5, n_times=3000, sfreq=100)","Convolution",EEG
+SleepStagerChambon2018,Sleep Staging,Prediction,128,"n_chans, n_outputs, n_times, sfreq",5835,"SleepStagerChambon2018(n_chans=2, n_outputs=5, n_times=3840, sfreq=128)","Convolution",EEG
+AttnSleep,Sleep Staging,Prediction,100,"n_chans, n_outputs, n_times, sfreq",719925,"AttnSleep(n_chans=2, n_outputs=5, n_times=3000, sfreq=100)","Convolution, Attention/Transformer",EEG
+SPARCNet,Epilepsy,Prediction,200,"n_chans, n_outputs, n_times",1141921,"SPARCNet(n_chans=16, n_outputs=6, n_times=2000, sfreq=200)","Convolution",EEG
+SyncNet,"Emotion Recognition, Alcoholism",Prediction,256,"n_chans, n_outputs, n_times",554,"SyncNet(n_chans=62, n_outputs=3, n_times=5120, sfreq=256)","Interpretability",EEG
+TSception,Emotion Recognition,Prediction,256,"n_chans, n_outputs, n_times, sfreq",2187206,"TSception(n_chans=62, n_outputs=3, n_times=5120, sfreq=256)","Convolution",EEG
+TIDNet,General,Prediction,250,"n_chans, n_outputs, n_times",240404,"TIDNet(n_chans=22,  n_outputs=4,  n_times=1000)","Convolution",EEG
+USleep,Sleep Staging,Prediction,128,"n_chans, n_outputs, n_times, sfreq",2482011,"USleep(n_chans=2, n_outputs=5, n_times=3000, sfreq=100)","Convolution",EEG
+FBCNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",11812,"FCNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank",EEG
+FBMSNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",16231,"FBMSNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank",EEG
+MetaNeuromotorHand,Handwriting (sEMG),CTC Sequence,2000,"n_chans, n_outputs, n_times, sfreq",1021284,"MetaNeuromotorHand(n_chans=16, n_outputs=100, n_times=32000, sfreq=2000)","Convolution,Attention/Transformer",sEMG
+EMG2QwertyNet,Touch typing (sEMG),CTC Sequence,2000,"n_chans, n_outputs, n_times, sfreq",5293315,"EMG2QwertyNet(n_chans=32, n_outputs=99, n_times=8000, sfreq=2000)","Convolution",sEMG
+FBLightConvNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",6596,"FBLightConvNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank",EEG
+IFNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",9860,"IFNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank",EEG
+BrainModule,Speech Decoding,Prediction,250,"n_chans, n_outputs, n_times, sfreq",6186909,"BrainModule(n_chans=64, n_outputs=29, n_times=160, sfreq=1000)","Convolution","EEG, MEG"
+PBT,General,Prediction,250,"n_chans, n_outputs, n_times",818948,"PBT(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Foundation Model",EEG
+SSTDPN,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",19502,"SSTDPN(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer",EEG
+BENDR,General,"Prediction, Embedding",250,"n_chans, n_times, n_outputs",157141049,"BENDR(n_chans=22, n_outputs=4, n_times=1000)","Foundation Model,Convolution",EEG
+LUNA,General,"Prediction, Embedding",128,"n_chans, n_times, sfreq, chs_info",7100731,"LUNA(n_chans=22, n_times=512, sfreq=128)","Convolution,Channel,Foundation Model",EEG
+MEDFormer,General,Prediction,250,"n_chans, n_outputs, n_times",5313924,"MEDFormer(n_chans=22, n_outputs=4, n_times=1000)","Foundation Model,Convolution",EEG
+REVE,General,Prediction,200,"n_outputs, n_times, n_chans",69481476,"REVE(n_times=1000, n_outputs=4, n_chans=19)","Foundation Model,Attention/Transformer",EEG
+DGCNN,Emotion Recognition,Prediction,128,"n_chans, n_outputs, n_times, chs_info",1037385,"DGCNN(n_chans=62, n_outputs=4, n_times=128)","Graph Neural Network,Channel",EEG
+InterpolatedBENDR,General,"Prediction, Embedding",250,"chs_info, n_outputs, n_times",157143101,"InterpolatedBENDR(chs_info=<user>, n_outputs=4, n_times=1000)","Foundation Model,Convolution,Channel",EEG
+InterpolatedBIOT,"Sleep Staging, Epilepsy",Prediction,200,"chs_info, n_outputs, n_times, sfreq",3184101,"InterpolatedBIOT(chs_info=<user>, n_outputs=5, sfreq=200, n_times=6000)","Foundation Model,Channel",EEG
+InterpolatedEEGPT,General,Prediction,256,"chs_info, n_outputs, n_times",25323137,"InterpolatedEEGPT(chs_info=<user>, n_outputs=4, n_times=1024)","Foundation Model,Attention/Transformer,Channel",EEG
+InterpolatedLaBraM,General,"Prediction, Embedding",200,"chs_info, n_outputs, n_times",5866196,"InterpolatedLaBraM(chs_info=<user>, n_outputs=4, n_times=1000)","Convolution,Foundation Model,Channel",EEG
+InterpolatedSignalJEPA,"Motor Imagery, ERP, SSVEP",Embedding,128,"chs_info",3456882,"InterpolatedSignalJEPA(chs_info=<user>)","Convolution,Channel,Foundation Model",EEG
+TCFormer,Motor Imagery,Classification,250,"n_chans, n_outputs, n_times",77820,"TCFormer(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer",EEG
+EEGDINO,General,Classification,200,"n_chans, n_outputs, n_times",4539698,"EEGDINO(n_chans=19, n_outputs=4, n_times=1000)","Foundation Model,Attention/Transformer",EEG
+STEEGFormer,General,Classification,250,"n_chans, n_outputs, n_times",25305604,"STEEGFormer(n_chans=22, n_outputs=4, n_times=1000)","Attention/Transformer,Foundation Model",EEG

--- a/docs/models/models_table.rst
+++ b/docs/models/models_table.rst
@@ -45,6 +45,9 @@ Columns definitions:
     - **Application**: The application(s) the model is typically used for (e.g., Motor
       Imagery, P300, Sleep Staging). 'General' indicates applicability across multiple
       applications or no specific application focus.
+    - **Modality**: The recording modality (bio-signal type) the model is designed and
+      validated for, e.g. EEG, MEG, or sEMG. Most Braindecode models target EEG; a few
+      support more than one modality (e.g. EEG, MEG).
     - **Type**: The model's output interface. ``Prediction`` indicates a supervised head
       that can be used for classification or regression, depending on the wrapper, loss,
       and target. ``Embedding`` indicates a model that exposes an embedding
@@ -153,7 +156,7 @@ Braindecode.
       }
 
       /* --- DataTable: panes hidden until button click ---------------------- */
-      var FILTER_COLS = [1,2,3,4]; // Paradigm, Type, Categorization, Hyperparameters
+      var FILTER_COLS = [1,2,3,4]; // Application, Modality, Type, Categorization
       var table = $('.sortable').DataTable({
         dom: 'Blfrtip',                           // B = Buttons (no 'P' here)
         paging: false,

--- a/docs/prepare_summary_tables.py
+++ b/docs/prepare_summary_tables.py
@@ -275,11 +275,13 @@ def main(source_dir: str, target_dir: str):
         df["Categorization"] = df["Categorization"].str.replace(",", ", ")
         df["Categorization"] = df["Categorization"].apply(wrap_tags)
         df["Type"] = df["Type"].apply(wrap_tags)
+        df["Modality"] = df["Modality"].apply(wrap_tags)
 
         df = df[
             [
                 "Model",
                 "Application",
+                "Modality",
                 "Type",
                 "Categorization",
                 "Sampling Frequency (Hz)",

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -59,6 +59,9 @@ Enhancements
 - Clarify the model summary table's ``Type`` column by using ``Prediction`` for
   supervised heads instead of describing them as classification-only.
   By `Sarthak Tayal`_.
+- Add a ``Modality`` column (EEG, MEG, sEMG, ...) to the model summary table so
+  models can be filtered by the bio-signal they target, and validate it against a
+  controlled vocabulary. By `Bhargav Kowshik`_.
 - Add :class:`braindecode.models.InterpolatedEEGPT`, a channel-interpolation
   variant of :class:`braindecode.models.EEGPT` built with
   :func:`~braindecode.models.interpolated.InterpolatedModel`.

--- a/test/unit_tests/models/test_model_modality.py
+++ b/test/unit_tests/models/test_model_modality.py
@@ -1,0 +1,54 @@
+# Authors: Bhargav Kowshik <bhargav.kowshik@gmail.com>
+#
+# License: BSD-3
+
+"""Test that every model has a valid Modality entry in summary.csv."""
+
+import csv
+from pathlib import Path
+
+import pytest
+
+from braindecode.models.util import models_dict
+
+# Controlled vocabulary for the "Modality" column of summary.csv. Keep this in
+# sync with the column definition in docs/models/models_table.rst. Add a new
+# token here (and document it) before using it in the CSV.
+ALLOWED_MODALITIES = {"EEG", "MEG", "iEEG", "ECoG", "sEMG"}
+
+
+def load_model_modalities():
+    """Load model modalities from summary.csv (model name -> list of modalities)."""
+    csv_path = Path(__file__).parents[3] / "braindecode" / "models" / "summary.csv"
+
+    model_modalities = {}
+    with open(csv_path, "r", encoding="utf-8-sig") as f:  # utf-8-sig handles BOM
+        reader = csv.DictReader(f)
+        for row in reader:
+            raw = row.get("Modality", "") or ""
+            modalities = [m.strip() for m in raw.split(",") if m.strip()]
+            model_modalities[row["Model"]] = modalities
+
+    return model_modalities
+
+
+MODEL_MODALITIES = load_model_modalities()
+
+
+@pytest.mark.parametrize("model_name", sorted(models_dict.keys()))
+def test_model_has_valid_modality(model_name):
+    """Every model has at least one modality, all from the allowed vocabulary."""
+    modalities = MODEL_MODALITIES.get(model_name, [])
+
+    assert len(modalities) > 0, (
+        f"{model_name} has no Modality defined in summary.csv. "
+        f"Add one of {sorted(ALLOWED_MODALITIES)}."
+    )
+
+    for modality in modalities:
+        assert modality in ALLOWED_MODALITIES, (
+            f"{model_name} has unknown modality '{modality}'. "
+            f"Allowed values are {sorted(ALLOWED_MODALITIES)}. "
+            f"If this is a new modality, add it to ALLOWED_MODALITIES and "
+            f"document it in docs/models/models_table.rst."
+        )


### PR DESCRIPTION
Closes #846.

As braindecode grows beyond EEG (MEG, sEMG, ...), the [models summary table](https://braindecode.org/stable/models/models_table.html) has no consistent way to say *which signal type* a model targets — so the information leaks into the `Application` column (e.g. `"Handwriting (sEMG)"`) or is missing entirely (BrainModule is MEG, but the table never says so). This adds an explicit, filterable `Modality` column.

### What changed
- **`braindecode/models/summary.csv`** — new `Modality` column: 57 `EEG`, 2 `sEMG` (the Meta neuromotor models), 1 `EEG, MEG` (BrainModule, per its docstring). Pure append — no other cells touched.
- **`docs/prepare_summary_tables.py`** — render `Modality` as tag pills, placed right after `Application`.
- **`docs/models/models_table.rst`** — column definition + corrected `FILTER_COLS` comment (the column now slots into the existing 4 filter panes).
- **`test/unit_tests/models/test_model_modality.py`** (new) — `ALLOWED_MODALITIES` controlled vocabulary + a per-model test asserting every model has a valid modality.
- **`docs/whats_new.rst`** — changelog entry.

### Design notes
- Comma-separated / multi-valued (like `Application`), so cross-modal models (BrainModule → `EEG, MEG`) render as separate pills and filter independently.
- Validation lives in the CSV test only — I did **not** mirror modality into model docstrings as badges (the heavier `Categorization`-style "sync test" pattern). Happy to do that as a follow-up if you'd like parity.

### Open questions for maintainers
1. **Sleep-staging models** are labeled `EEG`, though polysomnography also uses EOG/EMG — is `EEG` the convention you want here?
2. **`iEEG`/`ECoG`** are in the allowed vocabulary but unused (no such model yet) — keep them as forward-looking, or drop until needed?
3. Should I also **clean the `(sEMG)` text out of the `Application` column** now that `Modality` exists (kept this PR additive for now)?

### Verification
- `pytest test/unit_tests/models/test_model_modality.py` → 60 passed (one per model).
- `pytest test/unit_tests/models/test_model_categorization.py` → 120 passed (unchanged).
- Integration completeness test → 59 passed.
- Rendered the table locally: column order is `Model · Application · Modality · Type · Categorization · …`, and `EEG, MEG` shows as two separate filter pills.

<img width="1440" height="854" alt="image" src="https://github.com/user-attachments/assets/e96ea451-be55-41e0-968c-81950d2adff0" />
