### PR TITLE
feat(docs): pin braindecode installation version in generated notebooks

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+# Authors: Fashad Ahmed <fashad.ahmed20@gmail.com>
+#
 """Our local Sphinx configuration file."""
 
 #!/usr/bin/env python3
@@ -282,6 +284,17 @@ intersphinx_mapping = {
     "spd_learn": ("https://spdlearn.org/", None),
 }
 
+if release.endswith("dev0"):
+    _pip_install_cell = (
+        "# Install the development version of braindecode\n"
+        "%pip install git+https://github.com/braindecode/braindecode.git"
+    )
+else:
+    _pip_install_cell = (
+        f"# Install braindecode (pinned to the version used to build this notebook)\n"
+        f"%pip install braindecode=={release}"
+    )
+
 sphinx_gallery_conf = {
     "examples_dirs": ["../examples"],
     "gallery_dirs": ["auto_examples"],
@@ -289,6 +302,7 @@ sphinx_gallery_conf = {
     "backreferences_dir": "generated",
     "show_memory": True,
     "reference_url": dict(braindecode=None),
+    "first_notebook_cell": _pip_install_cell,
     "subsection_order": ExplicitOrder(
         [
             "../examples/model_building",

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -32,7 +32,7 @@ Enhancements
   version used to build them (``braindecode==X.Y.Z`` for stable releases,
   ``git+https://github.com/braindecode/braindecode.git`` for dev builds),
   so notebooks can be reproduced with a matching installation.
-  (:gh:`1079` by `Fashad Ahmed`_)
+  (:gh:`1080` by `Fashad Ahmed`_)
 - Add :func:`braindecode.functional.sinusoidal_positional_encoding`, a shared
   sine/cosine positional-encoding primitive (handling odd dimensions), and reuse
   it in :class:`braindecode.models.BIOT`, :class:`braindecode.models.MEDFormer`,

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,6 +28,11 @@ Current 1.6.1 (GitHub)
 Enhancements
 ============
 
+- Pin the ``%pip install braindecode`` cell in generated notebooks to the
+  version used to build them (``braindecode==X.Y.Z`` for stable releases,
+  ``git+https://github.com/braindecode/braindecode.git`` for dev builds),
+  so notebooks can be reproduced with a matching installation.
+  (:gh:`1079` by `Fashad Ahmed`_)
 - Add :func:`braindecode.functional.sinusoidal_positional_encoding`, a shared
   sine/cosine positional-encoding primitive (handling odd dimensions), and reuse
   it in :class:`braindecode.models.BIOT`, :class:`braindecode.models.MEDFormer`,


### PR DESCRIPTION
Issue: https://github.com/braindecode/braindecode/issues/906

Add a conditional installation cell in the Sphinx configuration to ensure that the `%pip install braindecode` command installs the correct version based on the release type (stable or development). This change enhances reproducibility of generated notebooks. Also, include author information in the configuration file.