### PR TITLE
Fix EEGSym reference architecture

### DIFF
--- a/braindecode/models/eegsym.py
+++ b/braindecode/models/eegsym.py
@@ -14,16 +14,6 @@ from braindecode.models.base import EEGModuleMixin
 from braindecode.models.util import _disable_batch_norm_training_if_batch_size_one
 
 
-_BATCH_NORM_EPS = 1e-3
-_BATCH_NORM_MOMENTUM = 0.01
-
-
-def _batch_norm_3d(num_features: int) -> nn.BatchNorm3d:
-    return nn.BatchNorm3d(
-        num_features, eps=_BATCH_NORM_EPS, momentum=_BATCH_NORM_MOMENTUM
-    )
-
-
 class EEGSym(EEGModuleMixin, nn.Module):
     r"""EEGSym from Pérez-Velasco et al (2022) [eegsym2022]_.
 
@@ -484,7 +474,7 @@ class _InceptionBlock(nn.Module):
                         kernel_size=(1, scale, 1),
                         padding="same",
                     ),
-                    _batch_norm_3d(filters_per_branch),
+                    nn.BatchNorm3d(filters_per_branch, eps=1e-3, momentum=0.01),
                     activation,
                     nn.Dropout(drop_prob),
                 )
@@ -507,7 +497,11 @@ class _InceptionBlock(nn.Module):
                             groups=filters_per_branch * len(scales_samples),
                             bias=False,
                         ),
-                        _batch_norm_3d(filters_per_branch * len(scales_samples)),
+                        nn.BatchNorm3d(
+                            filters_per_branch * len(scales_samples),
+                            eps=1e-3,
+                            momentum=0.01,
+                        ),
                         activation,
                         nn.Dropout(drop_prob),
                     )
@@ -584,7 +578,7 @@ class _ResidualBlock(nn.Module):
                 kernel_size=(1, kernel_size, 1),
                 padding="same",
             ),
-            _batch_norm_3d(filters),
+            nn.BatchNorm3d(filters, eps=1e-3, momentum=0.01),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -598,7 +592,7 @@ class _ResidualBlock(nn.Module):
                 kernel_size=(1, 1, 1),
                 bias=False,
             ),
-            _batch_norm_3d(filters),
+            nn.BatchNorm3d(filters, eps=1e-3, momentum=0.01),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -622,7 +616,7 @@ class _ResidualBlock(nn.Module):
                             groups=1,
                             bias=False,
                         ),
-                        _batch_norm_3d(filters),
+                        nn.BatchNorm3d(filters, eps=1e-3, momentum=0.01),
                         activation,
                         nn.Dropout(drop_prob),
                     )
@@ -681,7 +675,7 @@ class _TemporalBlock(nn.Module):
                 padding="same",
                 bias=False,
             ),
-            _batch_norm_3d(filters),
+            nn.BatchNorm3d(filters, eps=1e-3, momentum=0.01),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -742,7 +736,7 @@ class _ChannelMergingBlock(nn.Module):
                         padding=(0, 0, 0),  # Valid padding
                         bias=False,
                     ),
-                    _batch_norm_3d(filters),
+                    nn.BatchNorm3d(filters, eps=1e-3, momentum=0.01),
                     activation,
                     nn.Dropout(drop_prob),
                 )
@@ -759,7 +753,7 @@ class _ChannelMergingBlock(nn.Module):
                 padding=(0, 0, 0),
                 bias=False,
             ),
-            _batch_norm_3d(filters),
+            nn.BatchNorm3d(filters, eps=1e-3, momentum=0.01),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -824,7 +818,7 @@ class _TemporalMergingBlock(nn.Module):
                 padding=(0, 0, 0),  # Valid padding - reduces time to 1
                 bias=False,
             ),
-            _batch_norm_3d(in_channels),
+            nn.BatchNorm3d(in_channels, eps=1e-3, momentum=0.01),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -839,7 +833,7 @@ class _TemporalMergingBlock(nn.Module):
                 padding=(0, 0, 0),
                 bias=False,
             ),
-            _batch_norm_3d(filters),
+            nn.BatchNorm3d(filters, eps=1e-3, momentum=0.01),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -888,7 +882,7 @@ class _OutputBlock(nn.Module):
                         padding=(0, 0, 0),
                         bias=False,
                     ),
-                    _batch_norm_3d(in_channels),
+                    nn.BatchNorm3d(in_channels, eps=1e-3, momentum=0.01),
                     activation,
                     nn.Dropout(drop_prob),
                 )

--- a/braindecode/models/eegsym.py
+++ b/braindecode/models/eegsym.py
@@ -184,8 +184,8 @@ class EEGSym(EEGModuleMixin, nn.Module):
             raise ValueError(
                 "Either both or none of left_right_chs and middle_chs must be provided."
             )
-        if filters_per_branch % 8 != 0:
-            raise ValueError("filters_per_branch must be a multiple of 8.")
+        if filters_per_branch <= 0 or filters_per_branch % 8 != 0:
+            raise ValueError("filters_per_branch must be a positive multiple of 8.")
         super().__init__(
             n_outputs=n_outputs,
             n_chans=n_chans,

--- a/braindecode/models/eegsym.py
+++ b/braindecode/models/eegsym.py
@@ -14,6 +14,16 @@ from braindecode.models.base import EEGModuleMixin
 from braindecode.models.util import _disable_batch_norm_training_if_batch_size_one
 
 
+_BATCH_NORM_EPS = 1e-3
+_BATCH_NORM_MOMENTUM = 0.01
+
+
+def _batch_norm_3d(num_features: int) -> nn.BatchNorm3d:
+    return nn.BatchNorm3d(
+        num_features, eps=_BATCH_NORM_EPS, momentum=_BATCH_NORM_MOMENTUM
+    )
+
+
 class EEGSym(EEGModuleMixin, nn.Module):
     r"""EEGSym from Pérez-Velasco et al (2022) [eegsym2022]_.
 
@@ -123,7 +133,7 @@ class EEGSym(EEGModuleMixin, nn.Module):
     ----------
     filters_per_branch : int, optional
         Number of filters in each inception branch. Should be a multiple of 8.
-        Default is 12 [eegsym2022]_.
+        Default is 8 [eegsym2022code]_.
     scales_time : tuple of int, optional
         Temporal scales (in milliseconds) for the temporal convolutions in the first
         inception module. Default is (500, 250, 125) [eegsym2022]_.
@@ -133,7 +143,7 @@ class EEGSym(EEGModuleMixin, nn.Module):
         Activation function class to use. Default is :class:`nn.ELU` [eegsym2022]_.
     spatial_resnet_repetitions : int, optional
         Number of repetitions of the spatial analysis operations at each step.
-        Default is 5 [eegsym2022]_.
+        Default is 1 [eegsym2022code]_.
     left_right_chs : list of tuple of str, optional
         List of tuples pairing left and right hemisphere channel names,
         e.g., ``[('C3', 'C4'), ('FC5', 'FC6')]``. If not provided, channels
@@ -172,11 +182,11 @@ class EEGSym(EEGModuleMixin, nn.Module):
         input_window_seconds=None,
         sfreq=None,
         # Model parameters
-        filters_per_branch: int = 12,
+        filters_per_branch: int = 8,
         scales_time: Tuple[int, int, int] = (500, 250, 125),
         drop_prob: float = 0.25,
         activation: type[nn.Module] = nn.ELU,
-        spatial_resnet_repetitions: int = 5,
+        spatial_resnet_repetitions: int = 1,
         left_right_chs: list[tuple[str, str]] | None = None,
         middle_chs: list[str] | None = None,
     ):
@@ -184,6 +194,8 @@ class EEGSym(EEGModuleMixin, nn.Module):
             raise ValueError(
                 "Either both or none of left_right_chs and middle_chs must be provided."
             )
+        if filters_per_branch % 8 != 0:
+            raise ValueError("filters_per_branch must be a multiple of 8.")
         super().__init__(
             n_outputs=n_outputs,
             n_chans=n_chans,
@@ -201,7 +213,10 @@ class EEGSym(EEGModuleMixin, nn.Module):
         self.spatial_resnet_repetitions = spatial_resnet_repetitions
 
         # Calculate scales in samples
-        self.scales_samples = [int(s * self.sfreq / 2000) * 2 + 1 for s in scales_time]
+        self.scales_samples = sorted(int(s * self.sfreq / 1000) for s in scales_time)
+        total_inception_filters = self.filters_per_branch * len(self.scales_samples)
+        residual_filters = total_inception_filters // 2
+        reduced_filters = total_inception_filters // 4
 
         # Note: chs_info is actually list[dict] despite base class type hint
         # saying list[str]
@@ -255,10 +270,9 @@ class EEGSym(EEGModuleMixin, nn.Module):
             drop_prob=self.drop_prob,
             average_pool=2,
             spatial_resnet_repetitions=self.spatial_resnet_repetitions,
-            init=True,
         )
         self.inception_block2 = _InceptionBlock(
-            in_channels=self.filters_per_branch * len(self.scales_samples),
+            in_channels=total_inception_filters,
             scales_samples=[max(1, s // 4) for s in self.scales_samples],
             filters_per_branch=self.filters_per_branch,
             ncha=self.n_channels_per_hemi,
@@ -266,15 +280,13 @@ class EEGSym(EEGModuleMixin, nn.Module):
             drop_prob=self.drop_prob,
             average_pool=2,
             spatial_resnet_repetitions=self.spatial_resnet_repetitions,
-            init=False,
         )
 
         # Residual blocks (spatial dim is still n_channels_per_hemi through the network)
         self.residual_blocks = nn.Sequential(
             _ResidualBlock(
-                in_channels=self.filters_per_branch * len(self.scales_samples),
-                filters=self.filters_per_branch
-                * len(self.scales_samples),  # No reduction
+                in_channels=total_inception_filters,
+                filters=residual_filters,
                 kernel_size=16,
                 ncha=self.n_channels_per_hemi,
                 activation=self.activation,
@@ -283,10 +295,8 @@ class EEGSym(EEGModuleMixin, nn.Module):
                 spatial_resnet_repetitions=self.spatial_resnet_repetitions,
             ),
             _ResidualBlock(
-                in_channels=self.filters_per_branch * len(self.scales_samples),
-                filters=int(
-                    self.filters_per_branch * len(self.scales_samples) / 2
-                ),  # Reduce by /2
+                in_channels=residual_filters,
+                filters=residual_filters,
                 kernel_size=8,
                 ncha=self.n_channels_per_hemi,
                 activation=self.activation,
@@ -295,10 +305,8 @@ class EEGSym(EEGModuleMixin, nn.Module):
                 spatial_resnet_repetitions=self.spatial_resnet_repetitions,
             ),
             _ResidualBlock(
-                in_channels=int(self.filters_per_branch * len(self.scales_samples) / 2),
-                filters=int(
-                    self.filters_per_branch * len(self.scales_samples) / 4
-                ),  # Reduce by /2
+                in_channels=residual_filters,
+                filters=reduced_filters,
                 kernel_size=4,
                 ncha=self.n_channels_per_hemi,
                 activation=self.activation,
@@ -311,8 +319,8 @@ class EEGSym(EEGModuleMixin, nn.Module):
         # Temporal reduction
         self.temporal_reduction = nn.Sequential(
             _TemporalBlock(
-                in_channels=int(self.filters_per_branch * len(self.scales_samples) / 4),
-                filters=int(self.filters_per_branch * len(self.scales_samples) / 4),
+                in_channels=reduced_filters,
+                filters=reduced_filters,
                 kernel_size=4,
                 activation=self.activation,
                 drop_prob=self.drop_prob,
@@ -322,11 +330,9 @@ class EEGSym(EEGModuleMixin, nn.Module):
 
         # Channel merging
         self.channel_merging = _ChannelMergingBlock(
-            in_channels=int(self.filters_per_branch * len(self.scales_samples) / 4),
-            filters=int(self.filters_per_branch * len(self.scales_samples) / 4),
-            groups=int(
-                self.filters_per_branch * len(self.scales_samples) / 12
-            ),  # 36/12=3 groups
+            in_channels=reduced_filters,
+            filters=reduced_filters,
+            groups=total_inception_filters // 8,
             ncha=self.n_channels_per_hemi,
             division=2,
             activation=self.activation,
@@ -340,9 +346,9 @@ class EEGSym(EEGModuleMixin, nn.Module):
         temporal_dim_at_merging = self.n_times // 64
 
         self.temporal_merging = _TemporalMergingBlock(
-            in_channels=int(self.filters_per_branch * len(self.scales_samples) / 4),
-            filters=int(self.filters_per_branch * len(self.scales_samples) / 2),
-            groups=int(self.filters_per_branch * len(self.scales_samples) / 4),
+            in_channels=reduced_filters,
+            filters=residual_filters,
+            groups=reduced_filters,
             n_times=temporal_dim_at_merging,
             activation=self.activation,
             drop_prob=self.drop_prob,
@@ -351,7 +357,7 @@ class EEGSym(EEGModuleMixin, nn.Module):
         # Output layers
         self.output_blocks = nn.Sequential(
             _OutputBlock(
-                in_channels=int(self.filters_per_branch * len(self.scales_samples) / 2),
+                in_channels=residual_filters,
                 activation=self.activation,
                 drop_prob=self.drop_prob,
             ),
@@ -360,7 +366,7 @@ class EEGSym(EEGModuleMixin, nn.Module):
 
         # Final fully connected layer
         self.final_layer = nn.Linear(
-            in_features=int(self.filters_per_branch * len(self.scales_samples) / 2),
+            in_features=residual_filters,
             out_features=self.n_outputs,
         )
 
@@ -452,10 +458,6 @@ class _InceptionBlock(nn.Module):
         Kernel size for average pooling.
     spatial_resnet_repetitions : int
         Number of repetitions of the spatial analysis operations.
-    residual : bool
-        If True, includes residual connections.
-    init : bool
-        If True, applies channel merging operation if residual is False.
     """
 
     def __init__(
@@ -468,13 +470,8 @@ class _InceptionBlock(nn.Module):
         drop_prob: float,
         average_pool: int,
         spatial_resnet_repetitions: int,
-        init: bool = False,
     ):
         super().__init__()
-        self.activation = activation
-        self.drop_prob = drop_prob
-        self.average_pool = average_pool
-        self.init = init
 
         # Temporal convolutions
         self.temporal_convs = nn.ModuleList()
@@ -485,9 +482,9 @@ class _InceptionBlock(nn.Module):
                         in_channels=in_channels,
                         out_channels=filters_per_branch,
                         kernel_size=(1, scale, 1),
-                        padding=(0, scale // 2, 0),
+                        padding="same",
                     ),
-                    nn.BatchNorm3d(filters_per_branch),
+                    _batch_norm_3d(filters_per_branch),
                     activation,
                     nn.Dropout(drop_prob),
                 )
@@ -510,7 +507,7 @@ class _InceptionBlock(nn.Module):
                             groups=filters_per_branch * len(scales_samples),
                             bias=False,
                         ),
-                        nn.BatchNorm3d(filters_per_branch * len(scales_samples)),
+                        _batch_norm_3d(filters_per_branch * len(scales_samples)),
                         activation,
                         nn.Dropout(drop_prob),
                     )
@@ -528,10 +525,6 @@ class _InceptionBlock(nn.Module):
             # Apply temporal convolutions
             temp_outputs = [conv(x) for conv in self.temporal_convs]
             x_out = torch.cat(temp_outputs, dim=1)
-
-            # Trim temporal dimension if needed (due to even kernel sizes with padding)
-            if x_out.shape[3] > x.shape[3]:
-                x_out = x_out[:, :, :, : x.shape[3], :]
 
             # Residual connection
             x_out = x_out + x
@@ -568,8 +561,6 @@ class _ResidualBlock(nn.Module):
         Kernel size for average pooling.
     spatial_resnet_repetitions : int
         Number of repetitions of the spatial analysis operations.
-    residual : bool
-        If True, includes residual connections.
     """
 
     def __init__(
@@ -581,11 +572,9 @@ class _ResidualBlock(nn.Module):
         activation: nn.Module,
         drop_prob: float,
         average_pool: int,
-        spatial_resnet_repetitions: int = 5,
+        spatial_resnet_repetitions: int = 1,
     ):
         super().__init__()
-        self.activation = activation
-        self.drop_prob = drop_prob
 
         # Temporal convolution
         self.temporal_conv = nn.Sequential(
@@ -593,27 +582,29 @@ class _ResidualBlock(nn.Module):
                 in_channels=in_channels,
                 out_channels=filters,
                 kernel_size=(1, kernel_size, 1),
-                padding=(0, kernel_size // 2, 0),
+                padding="same",
             ),
-            nn.BatchNorm3d(filters),
+            _batch_norm_3d(filters),
             activation,
             nn.Dropout(drop_prob),
         )
 
-        # Projection layer for dimension matching if needed
-        if in_channels != filters:
-            self.projection = nn.Conv3d(
+        # The reference applies this 1x1x1 residual branch for every
+        # single-scale residual unit, even when the channel count is unchanged.
+        self.projection = nn.Sequential(
+            nn.Conv3d(
                 in_channels=in_channels,
                 out_channels=filters,
                 kernel_size=(1, 1, 1),
-            )
-        else:
-            self.projection = None
+                bias=False,
+            ),
+            _batch_norm_3d(filters),
+            activation,
+            nn.Dropout(drop_prob),
+        )
 
         # Average pooling
-        self.avg_pool = nn.AvgPool3d(
-            kernel_size=(1, average_pool, 1)
-        )  # FIXED: pool Time
+        self.avg_pool = nn.AvgPool3d(kernel_size=(1, average_pool, 1))
 
         # Spatial convolutions (multiple repetitions like in InceptionBlock)
         if ncha != 1:
@@ -626,12 +617,12 @@ class _ResidualBlock(nn.Module):
                             out_channels=filters,
                             kernel_size=(1, 1, ncha),  # Spatial convolution
                             padding=(0, 0, 0),
-                            # depthwise/grouped spatial conv with no bias, as in
-                            # the authors' ``unit_dconv``.
-                            groups=filters,
+                            # The single-scale residual branch uses the authors'
+                            # dense ``unit_conv_s``, not ``unit_dconv``.
+                            groups=1,
                             bias=False,
                         ),
-                        nn.BatchNorm3d(filters),
+                        _batch_norm_3d(filters),
                         activation,
                         nn.Dropout(drop_prob),
                     )
@@ -641,14 +632,7 @@ class _ResidualBlock(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x_res = self.temporal_conv(x)
-
-        # Trim temporal dimension if needed (due to even kernel sizes with padding)
-        if x_res.shape[3] > x.shape[3]:
-            x_res = x_res[:, :, :, : x.shape[3], :]
-
-        # Handle channel dimension mismatch if needed
-        if self.projection is not None:
-            x = self.projection(x)
+        x = self.projection(x)
 
         x_out = x_res + x  # Residual connection
         x_out = self.avg_pool(x_out)
@@ -677,8 +661,6 @@ class _TemporalBlock(nn.Module):
         Activation function to use.
     drop_prob : float
         Dropout probability.
-    residual : bool
-        If True, includes residual connections.
     """
 
     def __init__(
@@ -690,28 +672,22 @@ class _TemporalBlock(nn.Module):
         drop_prob: float,
     ):
         super().__init__()
-        self.activation = activation
-        self.drop_prob = drop_prob
 
         self.conv = nn.Sequential(
             nn.Conv3d(
                 in_channels=in_channels,
                 out_channels=filters,
                 kernel_size=(1, kernel_size, 1),
-                padding=(0, kernel_size // 2, 0),
+                padding="same",
+                bias=False,
             ),
-            nn.BatchNorm3d(filters),
+            _batch_norm_3d(filters),
             activation,
             nn.Dropout(drop_prob),
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x_res = self.conv(x)
-
-        # Trim temporal dimension if needed (due to even kernel sizes with padding)
-        if x_res.shape[3] > x.shape[3]:
-            x_res = x_res[:, :, :, : x.shape[3], :]
-
         x_res = x_res + x
         return x_res
 
@@ -752,8 +728,6 @@ class _ChannelMergingBlock(nn.Module):
         drop_prob: float,
     ):
         super().__init__()
-        self.activation = activation
-        self.drop_prob = drop_prob
 
         # TWO residual convolution iterations
         # Each reduces spatial dimension: ncha → 1
@@ -766,8 +740,9 @@ class _ChannelMergingBlock(nn.Module):
                         out_channels=filters,
                         kernel_size=(division, 1, ncha),  # (Z, Time, Space)
                         padding=(0, 0, 0),  # Valid padding
+                        bias=False,
                     ),
-                    nn.BatchNorm3d(filters),
+                    _batch_norm_3d(filters),
                     activation,
                     nn.Dropout(drop_prob),
                 )
@@ -782,8 +757,9 @@ class _ChannelMergingBlock(nn.Module):
                 kernel_size=(division, 1, ncha),  # (Z, Time, Space)
                 groups=groups,
                 padding=(0, 0, 0),
+                bias=False,
             ),
-            nn.BatchNorm3d(filters),
+            _batch_norm_3d(filters),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -834,8 +810,6 @@ class _TemporalMergingBlock(nn.Module):
         drop_prob: float,
     ):
         super().__init__()
-        self.activation = activation
-        self.drop_prob = drop_prob
 
         # Calculate temporal kernel size
         # At this point in network, temporal dim has been reduced by pooling
@@ -848,8 +822,9 @@ class _TemporalMergingBlock(nn.Module):
                 out_channels=in_channels,  # Same channels for residual
                 kernel_size=(1, self.temporal_kernel, 1),  # (Z, Time, Space)
                 padding=(0, 0, 0),  # Valid padding - reduces time to 1
+                bias=False,
             ),
-            nn.BatchNorm3d(in_channels),
+            _batch_norm_3d(in_channels),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -862,8 +837,9 @@ class _TemporalMergingBlock(nn.Module):
                 kernel_size=(1, self.temporal_kernel, 1),  # (Z, Time, Space)
                 groups=groups,
                 padding=(0, 0, 0),
+                bias=False,
             ),
-            nn.BatchNorm3d(filters),
+            _batch_norm_3d(filters),
             activation,
             nn.Dropout(drop_prob),
         )
@@ -890,8 +866,6 @@ class _OutputBlock(nn.Module):
         Activation function to use.
     drop_prob : float
         Dropout probability.
-    residual : bool
-        If True, includes residual connections.
     """
 
     def __init__(
@@ -902,8 +876,6 @@ class _OutputBlock(nn.Module):
         n_residual: int = 4,
     ):
         super().__init__()
-        self.activation = activation
-        self.drop_prob = drop_prob
 
         self.conv_blocks = nn.ModuleList()
         for _ in range(n_residual):
@@ -914,8 +886,9 @@ class _OutputBlock(nn.Module):
                         out_channels=in_channels,
                         kernel_size=(1, 1, 1),
                         padding=(0, 0, 0),
+                        bias=False,
                     ),
-                    nn.BatchNorm3d(in_channels),
+                    _batch_norm_3d(in_channels),
                     activation,
                     nn.Dropout(drop_prob),
                 )

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -216,10 +216,17 @@ Bug fixes
   ``(main_logits, stacked_branch_logits)``, matching the source.
   (:gh:`1069` by `Bruno Aristimunha`_)
 
-- Fix the spatial convolutions in :class:`braindecode.models.EEGSym` being dense
-  (``groups=1``) with a bias: the authors' ``unit_dconv`` uses grouped/depthwise
-  convolutions without bias, so they now use ``groups=out_channels`` and
-  ``bias=False``. (:gh:`1071` by `Bruno Aristimunha`_)
+- Fix the multi-scale spatial convolutions in :class:`braindecode.models.EEGSym`
+  being dense (``groups=1``) with a bias: the authors' ``unit_dconv`` uses
+  grouped/depthwise convolutions without bias, so they now use
+  ``groups=out_channels`` and ``bias=False``. (:gh:`1071` by `Bruno Aristimunha`_)
+
+- Align :class:`braindecode.models.EEGSym` with the reference implementation:
+  use the authors' even temporal kernels with ``padding="same"``, ascending
+  scale order, residual filter progression, residual projection blocks, dense
+  single-scale spatial convolutions, channel-merging groups, Keras batch
+  normalization settings, and default ``spatial_resnet_repetitions=1``.
+  (:gh:`1088` by `Bruno Aristimunha`_)
 
 Code health
 ============

--- a/test/unit_tests/models/test_eegsym.py
+++ b/test/unit_tests/models/test_eegsym.py
@@ -1,0 +1,100 @@
+import torch
+from torch import nn
+
+import pytest
+
+from braindecode.models import EEGSym
+
+
+_EEGSYM_8CH_CHS = [
+    {"ch_name": ch} for ch in ["F3", "C3", "P3", "Cz", "Pz", "F4", "C4", "P4"]
+]
+_EEGSYM_8CH_LEFT_RIGHT_CHS = [("F3", "F4"), ("C3", "C4"), ("P3", "P4")]
+_EEGSYM_8CH_MIDDLE_CHS = ["Cz", "Pz"]
+
+
+def _make_reference_8ch_eegsym() -> EEGSym:
+    return EEGSym(
+        n_outputs=2,
+        n_times=384,
+        sfreq=128,
+        chs_info=_EEGSYM_8CH_CHS,
+        filters_per_branch=24,
+        drop_prob=0.4,
+        spatial_resnet_repetitions=1,
+        left_right_chs=_EEGSYM_8CH_LEFT_RIGHT_CHS,
+        middle_chs=_EEGSYM_8CH_MIDDLE_CHS,
+    )
+
+
+def _reference_state_numel(model: EEGSym) -> int:
+    braindecode_runtime_buffers = {"left_idx", "right_idx", "middle_idx"}
+    return sum(
+        tensor.numel()
+        for name, tensor in model.state_dict().items()
+        if not name.endswith("num_batches_tracked")
+        and name not in braindecode_runtime_buffers
+    )
+
+
+def test_eegsym_matches_reference_8ch_architecture():
+    model = _make_reference_8ch_eegsym()
+
+    assert model.scales_samples == [16, 32, 64]
+    assert [
+        conv[0].kernel_size[1] for conv in model.inception_block1.temporal_convs
+    ] == [16, 32, 64]
+    assert [
+        conv[0].kernel_size[1] for conv in model.inception_block2.temporal_convs
+    ] == [4, 8, 16]
+
+    assert [block.temporal_conv[0].out_channels for block in model.residual_blocks] == [
+        36,
+        36,
+        18,
+    ]
+    assert [block.projection[0].out_channels for block in model.residual_blocks] == [
+        36,
+        36,
+        18,
+    ]
+    assert [block.spatial_convs[0][0].groups for block in model.residual_blocks] == [
+        1,
+        1,
+        1,
+    ]
+
+    channel_merge_conv = model.channel_merging.grouped_conv[0]
+    assert channel_merge_conv.groups == 9
+    assert channel_merge_conv.in_channels // channel_merge_conv.groups == 2
+
+    batch_norms = [
+        module for module in model.modules() if isinstance(module, nn.BatchNorm3d)
+    ]
+    assert {batch_norm.eps for batch_norm in batch_norms} == {1e-3}
+    assert {batch_norm.momentum for batch_norm in batch_norms} == {0.01}
+    assert _reference_state_numel(model) == 144440
+
+
+def test_eegsym_reference_8ch_forward_is_finite():
+    model = _make_reference_8ch_eegsym()
+    model.eval()
+
+    with torch.no_grad():
+        out = model(torch.randn(2, 8, 384))
+
+    assert out.shape == (2, 2)
+    assert torch.isfinite(out).all()
+
+
+def test_eegsym_filters_per_branch_must_be_multiple_of_8():
+    with pytest.raises(ValueError, match="filters_per_branch must be a multiple of 8"):
+        EEGSym(
+            n_outputs=2,
+            n_times=384,
+            sfreq=128,
+            chs_info=_EEGSYM_8CH_CHS,
+            filters_per_branch=12,
+            left_right_chs=_EEGSYM_8CH_LEFT_RIGHT_CHS,
+            middle_chs=_EEGSYM_8CH_MIDDLE_CHS,
+        )

--- a/test/unit_tests/models/test_eegsym.py
+++ b/test/unit_tests/models/test_eegsym.py
@@ -1,10 +1,8 @@
+import pytest
 import torch
 from torch import nn
 
-import pytest
-
 from braindecode.models import EEGSym
-
 
 _EEGSYM_8CH_CHS = [
     {"ch_name": ch} for ch in ["F3", "C3", "P3", "Cz", "Pz", "F4", "C4", "P4"]

--- a/test/unit_tests/models/test_eegsym.py
+++ b/test/unit_tests/models/test_eegsym.py
@@ -85,14 +85,17 @@ def test_eegsym_reference_8ch_forward_is_finite():
     assert torch.isfinite(out).all()
 
 
-def test_eegsym_filters_per_branch_must_be_multiple_of_8():
-    with pytest.raises(ValueError, match="filters_per_branch must be a multiple of 8"):
+@pytest.mark.parametrize("filters_per_branch", [0, -8, 12])
+def test_eegsym_filters_per_branch_must_be_positive_multiple_of_8(filters_per_branch):
+    with pytest.raises(
+        ValueError, match="filters_per_branch must be a positive multiple of 8"
+    ):
         EEGSym(
             n_outputs=2,
             n_times=384,
             sfreq=128,
             chs_info=_EEGSYM_8CH_CHS,
-            filters_per_branch=12,
+            filters_per_branch=filters_per_branch,
             left_right_chs=_EEGSYM_8CH_LEFT_RIGHT_CHS,
             middle_chs=_EEGSYM_8CH_MIDDLE_CHS,
         )


### PR DESCRIPTION
## Summary

Align `braindecode.models.EEGSym` with the reference Keras architecture from Perez-Velasco et al. and the converted original 8-channel checkpoint shape contract.

This PR covers the architecture side of #1088. It does not add a checkpoint artifact or a key-remapping loader for the Hugging Face checkpoint.

## What changed

- Use reference temporal kernel sizes from milliseconds directly, in ascending order.
- Use PyTorch `padding="same"` for the even temporal kernels, matching Keras asymmetric same-padding behavior for these stride-1 convolutions.
- Restore the reference residual filter progression and always-present residual projection branch.
- Use dense single-scale residual spatial convolutions while keeping multi-scale `unit_dconv` depthwise/grouped.
- Correct channel-merging groups, remove unintended biases in reference no-bias convolutions, and use Keras-compatible BatchNorm settings.
- Change the default `filters_per_branch` and `spatial_resnet_repetitions` to the upstream defaults.
- Add regression tests for the original 8-channel configuration, including the `144440` state-value count excluding Braindecode runtime channel-index buffers.

## Validation

- `python -m ruff check braindecode/models/eegsym.py test/unit_tests/models/test_eegsym.py`
- `python -m ruff format --check braindecode/models/eegsym.py test/unit_tests/models/test_eegsym.py`
- `pytest -q test/unit_tests/models/test_eegsym.py`
- `pytest -q test/unit_tests/models/test_models.py -k 'EEGSym or eegsym or batch1_train_mode'`
- `git diff --cached --check`

## Notes

PyTorch emits its standard warning for even-kernel `padding="same"`; a local check confirmed it is numerically identical to explicit Keras-style padding for EEGSym's `(1, k, 1)` stride-1 temporal convolutions.
