### PR TITLE
clarify predict_trials targets

### DIFF
--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -3,6 +3,7 @@
 #          Lukas Gemein <l.gemein@gmail.com>
 #          Bruno Aristimunha <b.aristimunha@gmail.com>
 #          Pierre Guetschel <pierre.guetschel@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -195,9 +196,7 @@ class EEGClassifier(_EEGNeuralNet, NeuralNetClassifier):
         return self.predict_proba(X).argmax(1)
 
     def predict_trials(self, X, return_targets=True):
-        """Create trialwise predictions and optionally also return trialwise.
-
-        labels from cropped dataset.
+        """Create trialwise predictions from a cropped dataset.
 
         Parameters
         ----------
@@ -212,10 +211,11 @@ class EEGClassifier(_EEGNeuralNet, NeuralNetClassifier):
             3-dimensional array (n_trials x n_classes x n_predictions), where
             the number of predictions depend on the chosen window size and the
             receptive field of the network.
-        trial_labels : np.ndarray
-            2-dimensional array (n_trials x n_targets) where the number of
-            targets depends on the decoding paradigm and can be either a single
-            value, multiple values, or a sequence.
+        trial_targets : np.ndarray
+            Ground-truth targets from the dataset in a 2-dimensional array
+            (n_trials x n_targets). The number of targets depends on the
+            decoding paradigm and can be either a single value, multiple
+            values, or a sequence.
         """
         if not self.cropped:
             warnings.warn(

--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -213,9 +213,9 @@ class EEGClassifier(_EEGNeuralNet, NeuralNetClassifier):
             receptive field of the network.
         trial_targets : np.ndarray
             Ground-truth targets from the dataset in a 2-dimensional array
-            (n_trials x n_targets). The number of targets depends on the
-            decoding paradigm and can be either a single value, multiple
-            values, or a sequence.
+            (n_trials x n_targets). Only returned when ``return_targets=True``.
+            The number of targets depends on the decoding paradigm and can be
+            either a single value, multiple values, or a sequence.
         """
         if not self.cropped:
             warnings.warn(

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -157,9 +157,9 @@ class EEGRegressor(_EEGNeuralNet, NeuralNetRegressor):
             receptive field of the network.
         trial_targets : np.ndarray
             Ground-truth targets from the dataset in a 2-dimensional array
-            (n_trials x n_targets). The number of targets depends on the
-            decoding paradigm and can be either a single value, multiple
-            values, or a sequence.
+            (n_trials x n_targets). Only returned when ``return_targets=True``.
+            The number of targets depends on the decoding paradigm and can be
+            either a single value, multiple values, or a sequence.
         """
         if not self.cropped:
             warnings.warn(

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -3,6 +3,7 @@
 #          Lukas Gemein <l.gemein@gmail.com>
 #          Bruno Aristimunha <b.aristimunha@gmail.com>
 #          Pierre Guetschel <pierre.guetschel@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -139,9 +140,7 @@ class EEGRegressor(_EEGNeuralNet, NeuralNetRegressor):
             return y_pred
 
     def predict_trials(self, X, return_targets=True):
-        """Create trialwise predictions and optionally also return trialwise.
-
-        labels from cropped dataset.
+        """Create trialwise predictions from a cropped dataset.
 
         Parameters
         ----------
@@ -156,10 +155,11 @@ class EEGRegressor(_EEGNeuralNet, NeuralNetRegressor):
             3-dimensional array (n_trials x n_classes x n_predictions), where
             the number of predictions depend on the chosen window size and the
             receptive field of the network.
-        trial_labels : np.ndarray
-            2-dimensional array (n_trials x n_targets) where the number of
-            targets depends on the decoding paradigm and can be either a single
-            value, multiple values, or a sequence.
+        trial_targets : np.ndarray
+            Ground-truth targets from the dataset in a 2-dimensional array
+            (n_trials x n_targets). The number of targets depends on the
+            decoding paradigm and can be either a single value, multiple
+            values, or a sequence.
         """
         if not self.cropped:
             warnings.warn(

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -425,9 +425,9 @@ def predict_trials(module, dataset, return_targets=True, batch_size=1, num_worke
             receptive field of the network.
         trial_targets: np.ndarray
             Ground-truth targets from the dataset in a 2-dimensional array
-            (n_trials x n_targets). The number of targets depends on the
-            decoding paradigm and can be either a single value, multiple
-            values, or a sequence.
+            (n_trials x n_targets). Only returned when ``return_targets=True``.
+            The number of targets depends on the decoding paradigm and can be
+            either a single value, multiple values, or a sequence.
     """
     # Ensure the model is in evaluation mode
     module.eval()

--- a/braindecode/training/scoring.py
+++ b/braindecode/training/scoring.py
@@ -3,6 +3,7 @@
 #          Alexandre Gramfort <alexandre.gramfort@inria.fr>
 #          Lukas Gemein <l.gemein@gmail.com>
 #          Mohammed Fattouh <mo.fattouh@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD-3
 
@@ -401,7 +402,7 @@ class PostEpochTrainScoring(EpochScoring):
 
 def predict_trials(module, dataset, return_targets=True, batch_size=1, num_workers=0):
     """Create trialwise predictions and optionally also return trialwise
-    labels from cropped dataset given module.
+    targets from a cropped dataset given a module.
 
     Parameters
     ----------
@@ -422,10 +423,11 @@ def predict_trials(module, dataset, return_targets=True, batch_size=1, num_worke
             3-dimensional array (n_trials x n_classes x n_predictions), where
             the number of predictions depend on the chosen window size and the
             receptive field of the network.
-        trial_labels: np.ndarray
-            2-dimensional array (n_trials x n_targets) where the number of
-            targets depends on the decoding paradigm and can be either a single
-            value, multiple values, or a sequence.
+        trial_targets: np.ndarray
+            Ground-truth targets from the dataset in a 2-dimensional array
+            (n_trials x n_targets). The number of targets depends on the
+            decoding paradigm and can be either a single value, multiple
+            values, or a sequence.
     """
     # Ensure the model is in evaluation mode
     module.eval()

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -49,6 +49,10 @@ Requirements
 Bug fixes
 ==========
 
+- Clarify that :func:`braindecode.training.scoring.predict_trials`,
+  :meth:`braindecode.EEGClassifier.predict_trials`, and
+  :meth:`braindecode.EEGRegressor.predict_trials` return ground-truth dataset
+  targets alongside predictions. By `Sarthak Tayal`_.
 - Make the :class:`braindecode.models.REVE` position bank robust on offline /
   limited-network nodes: it is now cached in the writable MNE data directory
   (resolved via the ``REVE_POSITIONS_PATH`` config key, defaulting under


### PR DESCRIPTION
Closes #566
 
Summary

`predict_trials` returns model predictions alongside ground truth targets taken directly from the dataset. The existing docstrings described the second value as `trial_labels`, which could be interpreted as labels derived from model predictions.

This update renames the documented return value to `trial_targets`. It also states that these values are ground truth dataset targets. Runtime behavior remains unchanged.