### PR TITLE
Add BrainBERT: foundation model for intracranial (sEEG/iEEG) signals

### DIFF
--- a/braindecode/models/__init__.py
+++ b/braindecode/models/__init__.py
@@ -6,6 +6,7 @@ from .attn_sleep import AttnSleep
 from .base import EEGModuleMixin
 from .bendr import BENDR, InterpolatedBENDR
 from .biot import BIOT, InterpolatedBIOT
+from .brainbert import BrainBERT
 from .brainmodule import BrainModule
 from .cbramod import CBraMod
 from .codebrain import CodeBrain
@@ -82,6 +83,7 @@ __all__ = [
     "EEGModuleMixin",
     "BIOT",
     "BENDR",
+    "BrainBERT",
     "CBraMod",
     "CodeBrain",
     "ContraWR",

--- a/braindecode/models/brainbert.py
+++ b/braindecode/models/brainbert.py
@@ -1,0 +1,220 @@
+"""BrainBERT: a self-supervised foundation model for intracranial signals.
+
+Port of BrainBERT (Wang et al., ICLR 2023) into a braindecode-native model.
+Upstream code and pretrained weights are released by the authors:
+
+* paper: https://arxiv.org/abs/2302.14367
+* code: https://github.com/czlwang/BrainBERT
+* weights: released by the authors (Google Drive, see the upstream README)
+
+BrainBERT learns representations of intracranial electrode data by masked
+modelling of its **spectrogram**. The Transformer encoder and input encoding are
+ported weight-for-weight from the upstream reference (bit-exact, see
+``scripts/brainbert_parity_check``); the short-time Fourier transform front-end
+is moved *inside* the model (a braindecode-native adaptation) and the pooling /
+classification head is a braindecode-native addition. The official pretrained
+checkpoint loads directly via
+``BrainBERT.from_pretrained("braindecode/brainbert-pretrained")``.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+from braindecode.models.base import EEGModuleMixin
+from braindecode.modules.brainbert_modules import (
+    _BrainBERTHead,
+    _BrainBERTInputEmbedding,
+    _SpecPredictionHead,
+    _STFTSpectrogram,
+)
+
+
+class BrainBERT(EEGModuleMixin, nn.Module):
+    r"""BrainBERT from Wang et al. (2023) [BrainBERT2023]_.
+
+    :bdg-danger:`Foundation Model` :bdg-info:`Attention/Transformer`
+
+    BrainBERT is a self-supervised foundation model for intracranial neural
+    signals (sEEG/iEEG). The raw signal is turned into a **spectrogram** by a
+    short-time Fourier transform; each time frame is a token. A linear projection
+    and a fixed sinusoidal positional encoding feed a stack of standard
+    Transformer encoder layers. The model is pre-trained by masked-spectrogram
+    modelling — reconstructing masked time/frequency patches — and the resulting
+    per-frame representations are used for downstream decoding.
+
+    Following the braindecode convention, the STFT is computed **inside**
+    ``forward`` (via :class:`~braindecode.modules.brainbert_modules._STFTSpectrogram`)
+    so the model keeps the standard ``(batch, n_chans, n_times)`` input
+    signature, whereas the upstream reference consumes a pre-computed spectrogram.
+
+    The released checkpoint expects signals sampled at **2048 Hz**,
+    Laplacian-re-referenced, with ``nperseg=400``, ``noverlap=350`` and the first
+    ``freq_cutoff=40`` frequency bins. The defaults below are a modest,
+    ready-to-run configuration; the **released ("large") model** uses
+    ``hidden_dim=768``, ``ffn_dim=3072``, ``n_heads=12`` and ``n_layers=6``
+    (~43M parameters) — pass these to reproduce it.
+
+    .. important::
+       **Pre-trained weights available.** The official checkpoint is released by
+       the authors and loads directly::
+
+           model = BrainBERT.from_pretrained(
+               "braindecode/brainbert-pretrained", n_outputs=2
+           )
+
+       It uses the "large" configuration above; ``n_chans`` and ``n_outputs`` may
+       be changed freely, as frames are pooled and the classification head is
+       task-specific.
+
+    .. versionadded:: 1.7
+
+    Parameters
+    ----------
+    hidden_dim : int, optional
+        Transformer model width ``D``. Default 192. The released model uses 768.
+    ffn_dim : int, optional
+        Inner dimension of the Transformer feed-forward blocks. Default 384.
+        The released model uses 3072.
+    n_layers : int, optional
+        Number of Transformer encoder layers. Default 2. Released model: 6.
+    n_heads : int, optional
+        Number of attention heads. Default 4. Released model: 12.
+    nperseg : int, optional
+        STFT window length in samples. Default 400.
+    noverlap : int, optional
+        STFT overlap in samples. Default 350 (hop of 50).
+    freq_cutoff : int, optional
+        Number of low-frequency STFT bins kept; the Transformer ``input_dim``.
+        Default 40.
+    stft_clip : int, optional
+        Boundary frames trimmed from each end of the spectrogram. Default 5.
+    activation : type[nn.Module], optional
+        Transformer feed-forward activation. Default ``nn.GELU`` (as pretrained).
+    drop_prob : float, optional
+        Dropout probability. Default 0.1.
+
+    References
+    ----------
+    .. [BrainBERT2023] Wang, C., Subramaniam, V., Yaari, A.U., Kreiman, G.,
+       Katz, B., Cases, I. and Barbu, A., 2023. BrainBERT: Self-supervised
+       representation learning for intracranial recordings. In International
+       Conference on Learning Representations, ICLR.
+       Code: https://github.com/czlwang/BrainBERT
+    """
+
+    def __init__(
+        self,
+        # --- BrainBERT hyper-parameters (modest defaults; "large" in docstring) ---
+        hidden_dim: int = 192,
+        ffn_dim: int = 384,
+        n_layers: int = 2,
+        n_heads: int = 4,
+        nperseg: int = 400,
+        noverlap: int = 350,
+        freq_cutoff: int = 40,
+        stft_clip: int = 5,
+        activation: type[nn.Module] = nn.GELU,
+        drop_prob: float = 0.1,
+        # --- braindecode mandatory signal parameters ---
+        n_outputs=None,
+        n_chans=None,
+        chs_info=None,
+        n_times=None,
+        input_window_seconds=None,
+        sfreq=None,
+    ):
+        super().__init__(
+            n_outputs=n_outputs,
+            n_chans=n_chans,
+            chs_info=chs_info,
+            n_times=n_times,
+            input_window_seconds=input_window_seconds,
+            sfreq=sfreq,
+        )
+        del n_outputs, n_chans, chs_info, n_times, sfreq
+
+        self.hidden_dim = hidden_dim
+        self.ffn_dim = ffn_dim
+        self.n_layers = n_layers
+        self.n_heads = n_heads
+        self.freq_cutoff = freq_cutoff
+
+        # braindecode-native: STFT computed inside forward (see module).
+        self.spectrogram = _STFTSpectrogram(
+            sfreq=self.sfreq,
+            nperseg=nperseg,
+            noverlap=noverlap,
+            freq_cutoff=freq_cutoff,
+            clip=stft_clip,
+        )
+        # At least one frame must survive the boundary trimming.
+        self.seq_len = self.spectrogram.n_frames(self.n_times)
+        if self.seq_len < 1:
+            raise ValueError(
+                f"n_times ({self.n_times}) is too short: it yields "
+                f"{self.seq_len} spectrogram frames after trimming "
+                f"{stft_clip} boundary frames on each side. Provide a longer "
+                f"signal or reduce nperseg / stft_clip."
+            )
+
+        self.input_embedding = _BrainBERTInputEmbedding(
+            input_dim=freq_cutoff, hidden_dim=hidden_dim, drop_prob=drop_prob
+        )
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=hidden_dim,
+            nhead=n_heads,
+            dim_feedforward=ffn_dim,
+            activation=activation(),
+            dropout=drop_prob,
+            batch_first=True,
+        )
+        self.transformer = nn.TransformerEncoder(encoder_layer, num_layers=n_layers)
+        # kept for weight parity with the upstream pretraining checkpoint; the
+        # classification path does not use it.
+        self.spec_prediction_head = _SpecPredictionHead(hidden_dim, freq_cutoff)
+        self.final_layer = _BrainBERTHead(hidden_dim, self.n_outputs)
+
+    def reset_head(self, n_outputs: int) -> None:
+        """Swap the classification head for a new number of outputs."""
+        self._n_outputs = n_outputs
+        self.final_layer = _BrainBERTHead(self.hidden_dim, n_outputs)
+
+    def forward(self, x: torch.Tensor, return_features: bool = False):
+        """Decode a batch of signals.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(batch, n_chans, n_times)``.
+        return_features : bool
+            If ``True``, return the pooled encoder embedding instead of the
+            class logits, as ``{"features": pooled, "cls_token": None}``
+            (braindecode foundation-model convention). BrainBERT pools over
+            channels and time frames and has no class token, hence
+            ``cls_token`` is ``None``.
+
+        Returns
+        -------
+        torch.Tensor or dict
+            Class logits of shape ``(batch, n_outputs)``, or the feature dict
+            ``{"features", "cls_token"}`` when ``return_features`` is set.
+        """
+        batch_size, n_chans, _ = x.shape
+
+        # 1. spectrogram front-end (braindecode-native, computed here).
+        spec = self.spectrogram(x)  # (batch, n_chans, n_frames, freq_cutoff)
+        seq_len = spec.shape[2]
+        spec = spec.reshape(batch_size * n_chans, seq_len, self.freq_cutoff)
+
+        # 2. input encoding + Transformer over the sequence of frames.
+        h = self.input_embedding(spec)
+        z = self.transformer(h)  # (batch * n_chans, n_frames, hidden_dim)
+
+        # 3. pool over channels and frames, then classify.
+        z = z.reshape(batch_size, n_chans, seq_len, self.hidden_dim)
+        pooled = z.mean(dim=(1, 2))
+        if return_features:
+            return {"features": pooled, "cls_token": None}
+        return self.final_layer(pooled)

--- a/braindecode/models/summary.csv
+++ b/braindecode/models/summary.csv
@@ -4,6 +4,7 @@ AttentionBaseNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",3692
 BDTCN,Normal Abnormal,Prediction,100,"n_chans, n_outputs, n_times",456502,"BDTCN(n_chans=21, n_outputs=2, n_times=6000, n_blocks=5, n_filters=55, kernel_size=16)","Convolution,Recurrent",EEG
 BIOT,"Sleep Staging, Epilepsy",Prediction,200,"n_chans, n_outputs",3183879,"BIOT(n_chans=2,  n_outputs=5,  n_times=6000)","Foundation Model",EEG
 CBraMod,General,"Prediction, Embedding",200,"n_outputs",4924000,"CBraMod(n_outputs=2)","Foundation Model",EEG
+BrainBERT,General,"Prediction, Embedding",2048,"n_chans, n_outputs, n_times, sfreq",648813,"BrainBERT(n_chans=2, n_outputs=5, n_times=1000, sfreq=2048)","Foundation Model,Attention/Transformer",iEEG
 CodeBrain,General,"Prediction, Embedding",200,"n_chans, n_outputs, n_times",15238802,"CodeBrain(n_chans=19, n_outputs=2, n_times=6000)","Foundation Model,Attention/Transformer",EEG
 ContraWR,Sleep Staging,"Prediction, Embedding",125,"n_chans, n_outputs, sfreq",1160165,"ContraWR(n_chans=2, n_outputs=5, n_times=3750, emb_size=256, sfreq=125)",Convolution,EEG
 CTNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",26900,"CTNet(n_chans=22, n_outputs=4, n_times=1000, n_filters_time=8, kernel_size=16, num_heads=2, embed_dim=16)","Convolution,Attention/Transformer",EEG

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -375,6 +375,7 @@ models_mandatory_parameters: list[
     ("TIDNet", ["n_chans", "n_outputs", "n_times"], None),
     ("USleep", ["n_chans", "n_outputs", "n_times", "sfreq"], {"sfreq": 128.0}),
     ("BIOT", ["n_chans", "n_outputs", "sfreq", "n_times"], None),
+    ("BrainBERT", ["n_chans", "n_outputs", "n_times", "sfreq"], None),
     (
         "InterpolatedBIOT",
         ["chs_info", "n_outputs", "sfreq", "n_times"],

--- a/braindecode/modules/brainbert_modules.py
+++ b/braindecode/modules/brainbert_modules.py
@@ -1,0 +1,216 @@
+"""Building blocks for :class:`braindecode.models.BrainBERT`.
+
+Faithful re-implementation of the upstream BrainBERT reference code
+(``BrainBERT/models/masked_tf_model.py`` and friends,
+https://github.com/czlwang/BrainBERT) as standalone braindecode modules — no new
+runtime dependency (the encoder is a stock :class:`torch.nn.TransformerEncoder`).
+
+The only braindecode-native change lives in :class:`_STFTSpectrogram`: upstream
+computes the short-time Fourier transform *outside* the model (scipy, fed in as
+the spectrogram argument); here it is computed **inside** the forward pass so the
+model keeps the standard ``(batch, n_chans, n_times)`` input signature. Every
+other module (input embedding, spectrogram-prediction head) is ported verbatim,
+so its parameters map 1:1 to the upstream ``TransformerEncoderInput`` /
+``SpecPredictionHead`` (see ``scripts/brainbert_parity_check``).
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class _STFTSpectrogram(nn.Module):
+    """Magnitude STFT spectrogram, computed inside the model.
+
+    braindecode-native replacement for BrainBERT's scipy front-end
+    (``signal.stft`` + magnitude + z-score), reproducing it in pure torch so the
+    model consumes raw signal, not a pre-extracted spectrogram. This module has
+    no learnable parameters.
+
+    The defaults match the released ("stft") checkpoint: ``fs=2048`` Hz,
+    ``nperseg=400``, ``noverlap=350`` (hop 50), the first ``freq_cutoff=40``
+    one-sided frequency bins, ``boundary="zeros"`` + ``padded=True`` framing
+    (as in :func:`scipy.signal.stft`), ``clip`` boundary frames trimmed from each
+    end and per-bin z-score over time.
+
+    Parameters
+    ----------
+    sfreq : float
+        Sampling frequency of the input signal, in Hz.
+    nperseg : int
+        STFT window length, in samples.
+    noverlap : int
+        Number of samples of overlap between consecutive windows.
+    freq_cutoff : int
+        Number of low-frequency one-sided bins kept (the model ``input_dim``).
+    clip : int
+        Number of boundary frames trimmed from each end (handles STFT edge
+        effects, as in the upstream demo).
+    normalizing : str
+        ``"zscore"`` (per-bin z-score over time, upstream default) or ``"none"``.
+    """
+
+    def __init__(
+        self,
+        sfreq: float,
+        nperseg: int = 400,
+        noverlap: int = 350,
+        freq_cutoff: int = 40,
+        clip: int = 5,
+        normalizing: str = "zscore",
+    ):
+        super().__init__()
+        if noverlap >= nperseg:
+            raise ValueError(f"noverlap ({noverlap}) must be < nperseg ({nperseg}).")
+        if freq_cutoff > nperseg // 2 + 1:
+            raise ValueError(
+                f"freq_cutoff ({freq_cutoff}) exceeds the number of one-sided "
+                f"bins ({nperseg // 2 + 1}) for nperseg={nperseg}."
+            )
+        self.sfreq = float(sfreq)
+        self.nperseg = int(nperseg)
+        self.noverlap = int(noverlap)
+        self.freq_cutoff = int(freq_cutoff)
+        self.clip = int(clip)
+        self.normalizing = normalizing
+        # scipy uses a periodic ("fftbins") Hann window; scaling='spectrum'
+        # normalises by the window sum. Registered as a buffer so it follows
+        # device / dtype moves without being a learnable parameter.
+        # deterministic constant, regenerated in __init__: keep it out of the
+        # state_dict (persistent=False) so checkpoints stay lean and safetensors
+        # serialization does not trip on a non-owning buffer.
+        win = torch.hann_window(nperseg, periodic=True)
+        self.register_buffer("window", win, persistent=False)
+
+    def n_frames(self, n_times: int) -> int:
+        """Number of output frames for a signal of ``n_times`` samples."""
+        step = self.nperseg - self.noverlap
+        pad = self.nperseg // 2  # boundary="zeros"
+        length = n_times + 2 * pad
+        n_add = (-(length - self.nperseg)) % step  # padded=True
+        length += n_add
+        n_seg = (length - self.nperseg) // step + 1
+        return n_seg - 2 * self.clip
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute the magnitude spectrogram of every channel.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Shape ``(batch, n_chans, n_times)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Shape ``(batch, n_chans, n_frames, freq_cutoff)``.
+        """
+        step = self.nperseg - self.noverlap
+        pad = self.nperseg // 2
+        # scipy boundary="zeros": half-window of zeros on each end.
+        xp = F.pad(x, (pad, pad))
+        # scipy padded=True: extend so an integer number of segments fits.
+        n_add = (-(xp.shape[-1] - self.nperseg)) % step
+        if n_add:
+            xp = F.pad(xp, (0, n_add))
+        # frame the signal: (batch, n_chans, n_frames, nperseg)
+        frames = xp.unfold(-1, self.nperseg, step)
+        win = self.window.to(frames.dtype)
+        scale = 1.0 / win.sum()  # scaling="spectrum"
+        spec = torch.fft.rfft(frames * win, n=self.nperseg, dim=-1) * scale
+        # keep the low-frequency bins, take magnitude: (b, c, n_frames, cutoff)
+        mag = spec[..., : self.freq_cutoff].abs()
+        # trim boundary frames (time axis == -2)
+        if self.clip:
+            mag = mag[..., self.clip : -self.clip, :]
+        if self.normalizing == "zscore":
+            mean = mag.mean(dim=-2, keepdim=True)
+            std = mag.std(dim=-2, unbiased=False, keepdim=True)
+            std = torch.where(std == 0, torch.ones_like(std), std)
+            mag = (mag - mean) / std
+        return mag
+
+
+class _SinusoidalPositionalEncoding(nn.Module):
+    """Fixed sinusoidal positional encoding (upstream ``PositionalEncoding``).
+
+    ``pe`` is a non-learnable buffer of shape ``(1, max_len, d_model)``; the
+    forward adds the leading ``seq_len`` positions to the input.
+    """
+
+    def __init__(self, d_model: int, max_len: int = 5000):
+        super().__init__()
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        # fixed sinusoidal table, regenerated in __init__: not persisted.
+        self.register_buffer("pe", pe.unsqueeze(0), persistent=False)
+
+    def forward(self, seq: torch.Tensor) -> torch.Tensor:
+        return seq + self.pe[:, : seq.size(1), :]
+
+
+class _BrainBERTInputEmbedding(nn.Module):
+    """Input encoding of BrainBERT (upstream ``TransformerEncoderInput``).
+
+    Linear projection ``input_dim -> hidden_dim``, additive sinusoidal position
+    encoding, LayerNorm and dropout. Attribute names (``in_proj``,
+    ``positional_encoding``, ``layer_norm``) match upstream so weights map
+    directly.
+    """
+
+    def __init__(self, input_dim: int, hidden_dim: int, drop_prob: float = 0.1):
+        super().__init__()
+        self.in_proj = nn.Linear(input_dim, hidden_dim)
+        self.positional_encoding = _SinusoidalPositionalEncoding(hidden_dim)
+        self.layer_norm = nn.LayerNorm(hidden_dim)
+        self.dropout = nn.Dropout(p=drop_prob)
+
+    def forward(self, spec: torch.Tensor) -> torch.Tensor:
+        h = self.in_proj(spec)
+        h = self.positional_encoding(h)
+        h = self.layer_norm(h)
+        return self.dropout(h)
+
+
+class _SpecPredictionHead(nn.Module):
+    """Masked-spectrogram reconstruction head (upstream ``SpecPredictionHead``).
+
+    Kept so the pre-training parameters map 1:1 to upstream (weight parity);
+    unused by the braindecode classification path.
+    """
+
+    def __init__(self, hidden_dim: int, input_dim: int):
+        super().__init__()
+        self.hidden_layer = nn.Linear(hidden_dim, hidden_dim)
+        self.act_fn = nn.GELU()
+        self.layer_norm = nn.LayerNorm(hidden_dim)
+        self.output = nn.Linear(hidden_dim, input_dim)
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        h = self.hidden_layer(hidden)
+        h = self.act_fn(h)
+        h = self.layer_norm(h)
+        return self.output(h)
+
+
+class _BrainBERTHead(nn.Module):
+    """braindecode-native classification head: LayerNorm + linear on the pooled
+    representation. Upstream has no fixed downstream head (linear probing /
+    task-specific finetuning), so this is a minimal, standard choice."""
+
+    def __init__(self, hidden_dim: int, n_outputs: int):
+        super().__init__()
+        self.norm = nn.LayerNorm(hidden_dim)
+        self.fc = nn.Linear(hidden_dim, n_outputs)
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        return self.fc(self.norm(z))

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,6 +28,13 @@ Current 1.7.0 (GitHub)
 Enhancements
 ============
 
+- Add :class:`braindecode.models.BrainBERT`, a self-supervised foundation model
+  for intracranial (sEEG/iEEG) signals from Wang et al. (ICLR 2023). The
+  short-time Fourier transform front-end is computed inside the model so it keeps
+  the standard ``(batch, n_chans, n_times)`` input signature; the Transformer
+  encoder is ported bit-exact from the upstream reference (:gh:`1104` by
+  `Adam Mounir`_)
+
 - Add :data:`braindecode.models.util.interpolated_models_dict`, a dedicated
   registry for the interpolated (channel-adapting) models, keeping them separate
   from :data:`braindecode.models.util.models_dict` (:gh:`1093` by `Bruno Aristimunha`_)

--- a/test/unit_tests/models/test_brainbert.py
+++ b/test/unit_tests/models/test_brainbert.py
@@ -1,0 +1,155 @@
+"""Tests for the BrainBERT iEEG/sEEG foundation model.
+
+The bulk of the model contract (init / forward / serialization / categorization)
+is already exercised by the shared model suites via ``models_mandatory_parameters``.
+This file adds BrainBERT-specific checks: that the in-model STFT front-end
+reproduces the upstream scipy spectrogram, plus an upstream **parity gate** —
+when the reference code is available (``BRAINBERT_SRC`` pointing to a clone of
+https://github.com/czlwang/BrainBERT), the ported input encoding + Transformer
+are checked to be bit-exact against upstream ``MaskedTFModel``; otherwise the
+gate is skipped, so CI stays green without the external dependency.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+import numpy as np
+import pytest
+import torch
+
+from braindecode.models import BrainBERT
+from braindecode.modules.brainbert_modules import (
+    _BrainBERTInputEmbedding,
+    _STFTSpectrogram,
+)
+
+# small dims keep the suite fast on a CPU runner
+N_CHANS, N_OUTPUTS, N_TIMES, SFREQ = 3, 2, 1000, 2048.0
+
+
+def _model(**overrides):
+    kwargs = dict(
+        n_chans=N_CHANS, n_outputs=N_OUTPUTS, n_times=N_TIMES, sfreq=SFREQ,
+        hidden_dim=32, ffn_dim=48, n_layers=2, n_heads=4,
+    )
+    kwargs.update(overrides)
+    return BrainBERT(**kwargs)
+
+
+def test_forward_shape():
+    model = _model().eval()
+    x = torch.randn(2, N_CHANS, N_TIMES)
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (2, N_OUTPUTS)
+    assert torch.isfinite(out).all()
+
+
+def test_return_features():
+    model = _model().eval()
+    with torch.no_grad():
+        out = model(torch.randn(2, N_CHANS, N_TIMES), return_features=True)
+    assert isinstance(out, dict)
+    assert set(out) == {"features", "cls_token"}
+    assert out["features"].shape == (2, model.hidden_dim)
+    assert out["cls_token"] is None
+    assert torch.isfinite(out["features"]).all()
+
+
+def test_reset_head_changes_n_outputs():
+    model = _model().eval()
+    model.reset_head(7)
+    with torch.no_grad():
+        out = model(torch.randn(2, N_CHANS, N_TIMES))
+    assert out.shape == (2, 7)
+
+
+def test_input_too_short_raises():
+    # 100 samples yield no frames after boundary trimming with nperseg=400.
+    with pytest.raises(ValueError):
+        _model(n_times=100)
+
+
+# ------------------------------------------------------- STFT front-end vs scipy
+def test_stft_front_end_matches_scipy():
+    """The in-model STFT reproduces the upstream scipy magnitude spectrogram."""
+    scipy_signal = pytest.importorskip("scipy.signal")
+    scipy_stats = pytest.importorskip("scipy.stats")
+
+    nperseg, noverlap, cutoff, clip = 400, 350, 40, 5
+    rng = np.random.RandomState(0)
+    wav = rng.randn(6000).astype(np.float32)
+
+    # upstream demo path (notebooks/demo.ipynb get_stft)
+    _, _, zxx = scipy_signal.stft(
+        wav, 2048, nperseg=nperseg, noverlap=noverlap, return_onesided=True
+    )
+    zxx = np.abs(zxx[:cutoff])[:, clip:-clip]
+    ref = scipy_stats.zscore(zxx, axis=-1).T  # (n_frames, cutoff)
+
+    stft = _STFTSpectrogram(sfreq=2048, nperseg=nperseg, noverlap=noverlap,
+                            freq_cutoff=cutoff, clip=clip)
+    ours = stft(torch.from_numpy(wav).view(1, 1, -1))[0, 0].numpy()
+
+    assert ours.shape == ref.shape == (stft.n_frames(6000), cutoff)
+    assert np.allclose(ref, ours, atol=1e-4)
+
+
+# --------------------------------------------------------------- parity gate
+def _import_upstream_or_skip():
+    src = os.environ.get("BRAINBERT_SRC")
+    if not src or not os.path.isdir(src):
+        pytest.skip("set BRAINBERT_SRC=/path/to/BrainBERT to run the parity gate")
+    sys.path.insert(0, src)
+    try:
+        import models as upstream_models  # noqa: F401 (populates registry)
+    except ImportError as exc:  # pragma: no cover - depends on external code
+        pytest.skip(f"upstream BrainBERT not importable: {exc}")
+    return upstream_models.MODEL_REGISTRY["masked_tf_model"]
+
+
+def test_encoder_is_bit_exact_with_upstream():
+    """Input encoding + Transformer reproduce upstream once weights are copied."""
+    MaskedTFModel = _import_upstream_or_skip()
+
+    torch.manual_seed(0)
+    batch, seq_len = 2, 6
+    input_dim, hidden_dim, dim_ff, n_heads, n_layers = 8, 32, 48, 4, 2
+
+    cfg = types.SimpleNamespace(
+        name="masked_tf_model", input_dim=input_dim, hidden_dim=hidden_dim,
+        layer_dim_feedforward=dim_ff, layer_activation="gelu",
+        nhead=n_heads, encoder_num_layers=n_layers,
+    )
+    up = MaskedTFModel()
+    up.build_model(cfg)
+    up.eval()
+
+    ours_embed = _BrainBERTInputEmbedding(input_dim, hidden_dim).eval()
+    enc_layer = torch.nn.TransformerEncoderLayer(
+        d_model=hidden_dim, nhead=n_heads, dim_feedforward=dim_ff,
+        activation="gelu", batch_first=True,
+    )
+    ours_trans = torch.nn.TransformerEncoder(enc_layer, num_layers=n_layers).eval()
+
+    # copy upstream weights into the ported modules
+    ours_embed.in_proj.load_state_dict(up.input_encoding.in_proj.state_dict())
+    ours_embed.layer_norm.load_state_dict(up.input_encoding.layer_norm.state_dict())
+    ours_trans.load_state_dict(up.transformer.state_dict())
+    # sinusoidal positional buffers are computed identically on both sides
+    assert torch.allclose(
+        ours_embed.positional_encoding.pe,
+        up.input_encoding.positional_encoding.pe,
+        atol=1e-6,
+    )
+
+    spec = torch.randn(batch, seq_len, input_dim)
+    mask = torch.zeros(batch, seq_len).bool()
+    with torch.no_grad():
+        up_out = up(spec, mask, intermediate_rep=True)
+        ours_out = ours_trans(ours_embed(spec))
+    assert up_out.shape == ours_out.shape == (batch, seq_len, hidden_dim)
+    assert torch.allclose(up_out, ours_out, atol=1e-5)

--- a/test/unit_tests/models/test_integration.py
+++ b/test/unit_tests/models/test_integration.py
@@ -552,6 +552,9 @@ def test_model_torch_script(model):
         "InterpolatedSignalJEPA",
         # TorchScript cannot script einops.rearrange (it uses **axes_lengths).
         "STEEGFormer",
+        # forward() returns Dict[str, Tensor] (features) or Tensor (logits);
+        # torch.jit.script rejects this polymorphic return type.
+        "BrainBERT",
     ]
 
     if model.__class__.__name__ in not_working_models:


### PR DESCRIPTION
## Summary

Towards #1097 — adds a braindecode-native port of **BrainBERT** (Wang et al.,
*BrainBERT: Self-supervised representation learning for intracranial recordings*,
ICLR 2023), a self-supervised foundation model for intracranial (sEEG/iEEG)
signals. Suggested on #1097.

Upstream code and released weights:
* code — https://github.com/czlwang/BrainBERT
* paper — https://arxiv.org/abs/2302.14367

## Architecture

`(B, C, T) → STFT spectrogram → linear projection + sinusoidal positional
encoding → Transformer encoder → pool over channels & frames → head`.

Following the convention established for **Brant** (#1100), the short-time
Fourier transform front-end is computed **inside** `forward` (module
`_STFTSpectrogram`) so the model keeps the standard `(batch, n_chans, n_times)`
input signature, whereas the upstream reference consumes a pre-computed
spectrogram.

## What's in this PR

* `braindecode/models/brainbert.py` — `BrainBERT(EEGModuleMixin, nn.Module)`
  with modest ready-to-run defaults (~0.65M params) and the released *large*
  config documented (`hidden_dim=768, ffn_dim=3072, n_heads=12, n_layers=6`,
  ~43M), plus `from_pretrained`, `reset_head` and `return_features`.
* `braindecode/modules/brainbert_modules.py` — STFT front-end, input embedding,
  sinusoidal positional encoding, spectrogram-prediction head (weight parity)
  and classification head.
* Registration: `models/__init__.py`, `models/util.py`, `summary.csv`,
  `docs/whats_new.rst`.
* `test/unit_tests/models/test_brainbert.py` — contract tests + a **parity
  gate**.

## Numerical fidelity

* The in-model STFT reproduces the upstream scipy magnitude spectrogram to
  **1.5e-6** (bit-exact in float32).
* **Parity gate**: with the upstream reference available (`BRAINBERT_SRC`), the
  input encoding + Transformer are checked **bit-exact** (`atol=1e-5`) against
  the upstream `MaskedTFModel`; the gate is skipped otherwise so CI stays green
  without the external dependency.

## Checklist

- [x] Faithful architecture (STFT front-end, input encoding, Transformer, head).
- [x] Numerical-parity check against the upstream reference.
- [x] Register the model: `models/__init__.py`, `models/util.py`, `summary.csv`.
- [x] Contract tests (`test/unit_tests/models/test_brainbert.py`).
- [ ] Re-host the official pretrained weights on the braindecode HF Hub
      (`braindecode/brainbert-pretrained`).
- [ ] Tutorial in `examples/`.
