### PR TITLE
Add PopulationTransformer (PopT) iEEG/sEEG foundation model

### DIFF
--- a/braindecode/models/__init__.py
+++ b/braindecode/models/__init__.py
@@ -40,6 +40,7 @@ from .meta_neuromotor import MetaNeuromotorHand
 from .msvtnet import MSVTNet
 from .mvpformer import MVPFormer
 from .patchedtransformer import PBT
+from .popt import PopulationTransformer
 from .reve import REVE
 from .sccnet import SCCNet
 from .shallow_fbcsp import ShallowFBCSPNet
@@ -123,6 +124,7 @@ __all__ = [
     "MSVTNet",
     "MVPFormer",
     "PBT",
+    "PopulationTransformer",
     "REVE",
     "SCCNet",
     "ShallowFBCSPNet",

--- a/braindecode/models/popt.py
+++ b/braindecode/models/popt.py
@@ -1,0 +1,253 @@
+"""PopulationTransformer: a self-supervised aggregator over intracranial electrodes.
+
+Port of PopulationTransformer (PopT, Chau et al. 2024) into a braindecode-native
+model. Upstream code and pretrained weights are released by the authors:
+
+* paper: https://arxiv.org/abs/2406.03044
+* code: https://github.com/czlwang/PopulationTransformer
+* weights: https://huggingface.co/PopulationTransformer/popt_brainbert_stft
+
+Unlike a per-channel encoder, PopT operates on a **population** of electrodes:
+its input is a set of per-electrode feature vectors (the frozen embeddings of a
+channel-level foundation model such as BrainBERT) plus each electrode's integer
+anatomical coordinates. A ``CLS`` token summarises the population after a stack
+of Transformer encoder layers. The input embedding, spatial position encoding and
+Transformer are ported weight-for-weight from the upstream reference (bit-exact,
+see ``scripts/popt_parity_check``); the classification head is a
+braindecode-native addition. The official checkpoint loads directly via
+``PopulationTransformer.from_pretrained("braindecode/popt-pretrained")``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from braindecode.models.base import EEGModuleMixin
+from braindecode.modules.popt_modules import (
+    _PopTHead,
+    _PopTInputEmbedding,
+    _PopTSpecPredictionHead,
+)
+
+
+class PopulationTransformer(EEGModuleMixin, nn.Module):
+    r"""PopulationTransformer (PopT) from Chau et al. (2024) [PopT2024]_.
+
+    :bdg-danger:`Foundation Model` :bdg-info:`Attention/Transformer`
+
+    PopT is a self-supervised **population** model for intracranial recordings
+    (sEEG/iEEG). It does not encode a raw time signal; instead each electrode is
+    represented by a feature vector — typically the frozen embedding of a
+    per-channel foundation model such as :class:`~braindecode.models.BrainBERT` —
+    and PopT aggregates across electrodes. Every electrode feature is linearly
+    projected and given a fixed sinusoidal **spatial** position encoding built
+    from its integer anatomical coordinates (one embedding per X/Y/Z axis plus a
+    sequence id). A ``CLS`` token is prepended, a stack of standard Transformer
+    encoder layers mixes the population, and the ``CLS`` output is the pooled
+    representation used for downstream decoding. Pre-training is by masked /
+    replaced-token modelling over the electrode population.
+
+    Following the braindecode convention, the per-electrode feature vector plays
+    the role of the ``n_times`` axis, so the model keeps the standard
+    ``(batch, n_chans, n_times)`` input signature: ``n_chans`` is the number of
+    electrodes and ``n_times`` is the upstream feature dimension (768 for
+    BrainBERT ``stft`` features). Electrode coordinates are read from
+    ``chs_info`` (their ``loc``) and discretised to integer indices inside the
+    model; when no positions are available the electrodes fall back to distinct
+    sequential indices.
+
+    The released ``popt_brainbert_stft`` checkpoint uses ``hidden_dim=512``,
+    ``ffn_dim=2048``, ``n_heads=8``, ``n_layers=6`` on ``n_times=768`` BrainBERT
+    features (~20.6M parameters). The defaults below are a modest, ready-to-run
+    configuration; pass the released values to reproduce it.
+
+    .. important::
+       **Pre-trained weights available.** The official checkpoint is released by
+       the authors and loads directly::
+
+           model = PopulationTransformer.from_pretrained(
+               "braindecode/popt-pretrained", n_outputs=2
+           )
+
+       It uses the released configuration above; ``n_chans`` and ``n_outputs``
+       may be changed freely, as the population is pooled through the ``CLS``
+       token and the classification head is task-specific.
+
+    .. versionadded:: 1.7
+
+    Parameters
+    ----------
+    hidden_dim : int, optional
+        Transformer model width ``D``. Must be divisible by 4. Default 128. The
+        released model uses 512.
+    ffn_dim : int, optional
+        Inner dimension of the Transformer feed-forward blocks. Default 256. The
+        released model uses 2048.
+    n_layers : int, optional
+        Number of Transformer encoder layers. Default 2. Released model: 6.
+    n_heads : int, optional
+        Number of attention heads. Default 4. Released model: 8.
+    max_len : int, optional
+        Size of the coordinate table (largest addressable integer coordinate).
+        Default 5000, as upstream.
+    activation : type[nn.Module], optional
+        Feed-forward activation, given as a class. Default :class:`~torch.nn.GELU`.
+    drop_prob : float, optional
+        Dropout probability. Default 0.1.
+
+    References
+    ----------
+    .. [PopT2024] Chau, G., Wang, C., Talukder, S., Subramaniam, V., Soedarmadji,
+       S., Yue, Y., Katz, B., & Barbu, A. (2024). Population Transformer:
+       Learning Population-level Representations of Neural Activity. arXiv
+       preprint arXiv:2406.03044.
+    """
+
+    def __init__(
+        self,
+        hidden_dim: int = 128,
+        ffn_dim: int = 256,
+        n_layers: int = 2,
+        n_heads: int = 4,
+        max_len: int = 5000,
+        activation: type[nn.Module] = nn.GELU,
+        drop_prob: float = 0.1,
+        # --- braindecode mandatory signal parameters ---
+        n_outputs=None,
+        n_chans=None,
+        chs_info=None,
+        n_times=None,
+        input_window_seconds=None,
+        sfreq=None,
+    ):
+        super().__init__(
+            n_outputs=n_outputs,
+            n_chans=n_chans,
+            chs_info=chs_info,
+            n_times=n_times,
+            input_window_seconds=input_window_seconds,
+            sfreq=sfreq,
+        )
+        del n_outputs, n_chans, chs_info, n_times, sfreq
+
+        # The per-electrode feature vector plays the role of the "time" axis.
+        self.input_dim = self.n_times
+        self.hidden_dim = hidden_dim
+        self.ffn_dim = ffn_dim
+        self.n_layers = n_layers
+        self.n_heads = n_heads
+        self.max_len = max_len
+
+        self.input_embedding = _PopTInputEmbedding(
+            input_dim=self.input_dim,
+            hidden_dim=hidden_dim,
+            max_len=max_len,
+            drop_prob=drop_prob,
+        )
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=hidden_dim,
+            nhead=n_heads,
+            dim_feedforward=ffn_dim,
+            activation=activation(),
+            dropout=drop_prob,
+            batch_first=True,
+        )
+        self.transformer_encoder = nn.TransformerEncoder(
+            encoder_layer, num_layers=n_layers
+        )
+        # kept for weight parity with the upstream pretraining checkpoint; the
+        # classification path does not use it.
+        self.spec_prediction_head = _PopTSpecPredictionHead(hidden_dim, self.input_dim)
+        self.final_layer = _PopTHead(hidden_dim, self.n_outputs)
+
+        # Integer electrode coordinates / sequence ids, derived once from
+        # chs_info; broadcast over the batch at forward time. Buffers follow
+        # device moves and are regenerated per instance (persistent=False).
+        coords, seq_id = self._coords_from_chs_info()
+        self.register_buffer("electrode_coords", coords, persistent=False)
+        self.register_buffer("electrode_seq_id", seq_id, persistent=False)
+
+    def _coords_from_chs_info(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build integer ``(n_chans, 3)`` coordinates and ``(n_chans,)`` seq ids.
+
+        Coordinates are read from ``chs_info`` (each channel's ``loc[:3]``,
+        assumed in metres as per the MNE convention), converted to millimetres,
+        rounded and shifted per axis so the smallest index is 0. If ``chs_info``
+        is missing or carries no usable positions, electrodes fall back to
+        distinct sequential indices on every axis. All indices are clamped to
+        ``[0, max_len - 1]``. The sequence id is 0 for every electrode
+        (single-population downstream use).
+        """
+        n_chans = self.n_chans
+        loc = None
+        # chs_info is optional; the public property raises when unset, so read
+        # the underlying attribute directly.
+        chs_info = getattr(self, "_chs_info", None)
+        if chs_info is not None:
+            try:
+                loc = torch.tensor(
+                    np.asarray([ch["loc"][:3] for ch in chs_info]), dtype=torch.float
+                )
+            except (KeyError, TypeError, ValueError):
+                loc = None
+        if loc is None or not torch.isfinite(loc).all() or loc.abs().sum() == 0:
+            # Fallback: distinct sequential positions on each axis.
+            idx = torch.arange(n_chans, dtype=torch.long)
+            coords = idx.unsqueeze(1).repeat(1, 3)
+        else:
+            coords = (loc * 1000.0).round().long()
+            coords = coords - coords.min(dim=0, keepdim=True).values
+        coords = coords.clamp(0, self.max_len - 1)
+        seq_id = torch.zeros(n_chans, dtype=torch.long)
+        return coords, seq_id
+
+    def reset_head(self, n_outputs: int) -> None:
+        """Swap the classification head for a new number of outputs."""
+        self._n_outputs = n_outputs
+        self.final_layer = _PopTHead(self.hidden_dim, n_outputs)
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        coords: torch.Tensor | None = None,
+        seq_id: torch.Tensor | None = None,
+        return_features: bool = False,
+    ):
+        """Aggregate a population of electrode features.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Per-electrode features of shape ``(batch, n_chans, n_times)``, where
+            ``n_times`` is the upstream feature dimension.
+        coords : torch.Tensor, optional
+            Integer coordinates of shape ``(batch, n_chans, 3)``. Defaults to the
+            coordinates derived from ``chs_info`` at construction, broadcast over
+            the batch.
+        seq_id : torch.Tensor, optional
+            Integer sequence ids of shape ``(batch, n_chans)``. Defaults to zero
+            (single population).
+        return_features : bool
+            If ``True``, return ``{"features": cls, "cls_token": cls}`` (the
+            pooled ``CLS`` representation) instead of the class logits.
+
+        Returns
+        -------
+        torch.Tensor or dict
+            Class logits of shape ``(batch, n_outputs)``, or the feature dict
+            when ``return_features`` is set.
+        """
+        batch_size, n_chans, _ = x.shape
+        if coords is None:
+            coords = self.electrode_coords.unsqueeze(0).expand(batch_size, -1, -1)
+        if seq_id is None:
+            seq_id = self.electrode_seq_id.unsqueeze(0).expand(batch_size, -1)
+
+        h = self.input_embedding(x, coords, seq_id)
+        z = self.transformer_encoder(h)  # (batch, 1 + n_chans, hidden_dim)
+        cls_token = z[:, 0, :]
+        if return_features:
+            return {"features": cls_token, "cls_token": cls_token}
+        return self.final_layer(cls_token)

--- a/braindecode/models/popt.py
+++ b/braindecode/models/popt.py
@@ -13,7 +13,8 @@ channel-level foundation model such as BrainBERT) plus each electrode's integer
 anatomical coordinates. A ``CLS`` token summarises the population after a stack
 of Transformer encoder layers. The input embedding, spatial position encoding and
 Transformer are ported weight-for-weight from the upstream reference (bit-exact,
-see ``scripts/popt_parity_check``); the classification head is a
+verified by the ``test_encoder_is_bit_exact_with_upstream`` parity gate in
+``test/unit_tests/models/test_popt.py``); the classification head is a
 braindecode-native addition. The official checkpoint loads directly via
 ``PopulationTransformer.from_pretrained("braindecode/popt-pretrained")``.
 """

--- a/braindecode/models/summary.csv
+++ b/braindecode/models/summary.csv
@@ -45,6 +45,7 @@ FBLightConvNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq"
 IFNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq",9860,"IFNet(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Convolution,FilterBank",EEG
 BrainModule,Speech Decoding,Prediction,250,"n_chans, n_outputs, n_times, sfreq",6186909,"BrainModule(n_chans=64, n_outputs=29, n_times=160, sfreq=1000)","Convolution","EEG, MEG"
 PBT,General,Prediction,250,"n_chans, n_outputs, n_times",818948,"PBT(n_chans=22, n_outputs=4, n_times=1000, sfreq=250)","Foundation Model",EEG
+PopulationTransformer,General,"Prediction, Embedding",2048,"n_chans, n_outputs, n_times",480002,"PopulationTransformer(n_chans=8, n_outputs=2, n_times=768)","Foundation Model,Attention/Transformer",iEEG
 SSTDPN,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times",19502,"SSTDPN(n_chans=22, n_outputs=4, n_times=1000)","Convolution,Attention/Transformer",EEG
 BENDR,General,"Prediction, Embedding",250,"n_chans, n_times, n_outputs",157141049,"BENDR(n_chans=22, n_outputs=4, n_times=1000)","Foundation Model,Convolution",EEG
 LUNA,General,"Prediction, Embedding",128,"n_chans, n_times, sfreq, chs_info",7100731,"LUNA(n_chans=22, n_times=512, sfreq=128)","Convolution,Channel,Foundation Model",EEG

--- a/braindecode/models/util.py
+++ b/braindecode/models/util.py
@@ -375,6 +375,7 @@ models_mandatory_parameters: list[
     ("TIDNet", ["n_chans", "n_outputs", "n_times"], None),
     ("USleep", ["n_chans", "n_outputs", "n_times", "sfreq"], {"sfreq": 128.0}),
     ("BIOT", ["n_chans", "n_outputs", "sfreq", "n_times"], None),
+    ("PopulationTransformer", ["n_chans", "n_outputs", "n_times"], None),
     (
         "InterpolatedBIOT",
         ["chs_info", "n_outputs", "sfreq", "n_times"],

--- a/braindecode/modules/popt_modules.py
+++ b/braindecode/modules/popt_modules.py
@@ -17,7 +17,8 @@ pooled population representation.
 
 Every module here maps its parameters 1:1 to the upstream
 ``TransformerEncoderInput`` / ``SpecPredictionHead`` so the released checkpoint
-loads weight-for-weight (see ``scripts/popt_parity_check``). The only
+loads weight-for-weight (verified by the ``test_encoder_is_bit_exact_with_upstream``
+parity gate in ``test/unit_tests/models/test_popt.py``). The only
 braindecode-native changes are (i) the ``CLS`` feature row and the electrode
 coordinates are materialised **inside** the model so it keeps a standard
 ``forward(x)`` signature, and (ii) the classification head.

--- a/braindecode/modules/popt_modules.py
+++ b/braindecode/modules/popt_modules.py
@@ -1,0 +1,225 @@
+"""Building blocks for :class:`braindecode.models.PopulationTransformer`.
+
+Faithful re-implementation of the upstream PopulationTransformer (PopT) reference
+code (``PopulationTransformer/models/pt_model_custom.py`` and
+``transformer_encoder_input.py``, https://github.com/czlwang/PopulationTransformer)
+as standalone braindecode modules — no new runtime dependency (the encoder is a
+stock :class:`torch.nn.TransformerEncoder`).
+
+PopT is a *population* aggregator: it does **not** consume a raw time signal but a
+set of per-electrode feature vectors (typically the frozen 768-d embeddings of a
+per-channel foundation model such as BrainBERT) together with each electrode's
+integer anatomical coordinates. A learnable-free sinusoidal spatial encoding
+(one embedding per X/Y/Z axis plus a sequence-id embedding, each ``hidden//4``
+wide) is added to a linear projection of the features; a ``CLS`` token is
+prepended and, after a stack of Transformer encoder layers, its output is the
+pooled population representation.
+
+Every module here maps its parameters 1:1 to the upstream
+``TransformerEncoderInput`` / ``SpecPredictionHead`` so the released checkpoint
+loads weight-for-weight (see ``scripts/popt_parity_check``). The only
+braindecode-native changes are (i) the ``CLS`` feature row and the electrode
+coordinates are materialised **inside** the model so it keeps a standard
+``forward(x)`` signature, and (ii) the classification head.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+import torch.nn as nn
+
+
+class _PopTSpatialPositionalEncoding(nn.Module):
+    """Spatial sinusoidal positional encoding (upstream
+    ``MultiSubjBrainPositionalEncoding``).
+
+    A single sinusoidal table ``pe`` of shape ``(1, max_len, hidden_dim // 4)``
+    is indexed by **integer** coordinates: each of the three anatomical axes
+    (X/Y/Z) and the sequence id select a ``hidden_dim // 4`` slice, and the four
+    slices are concatenated into a ``hidden_dim`` position vector. The ``CLS``
+    token receives ``pe[0, 0]`` tiled four times. ``pe`` is non-learnable and
+    regenerated in ``__init__`` (``persistent=False``), so it stays out of the
+    checkpoint.
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Model width ``D``; must be divisible by 4.
+    max_len : int
+        Size of the coordinate table (largest addressable integer coordinate).
+    """
+
+    def __init__(self, hidden_dim: int, max_len: int = 5000):
+        super().__init__()
+        if hidden_dim % 4 != 0:
+            raise ValueError(
+                f"hidden_dim ({hidden_dim}) must be divisible by 4 for the "
+                "spatial positional encoding (one quarter per X/Y/Z axis and "
+                "the sequence id)."
+            )
+        pe_dim = hidden_dim // 4
+        pe = torch.zeros(max_len, pe_dim)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, pe_dim, 2).float() * (-math.log(10000.0) / pe_dim)
+        )
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        self.register_buffer("pe", pe.unsqueeze(0), persistent=False)
+
+    def forward(
+        self, seq: torch.Tensor, coords: torch.Tensor, seq_id: torch.Tensor
+    ) -> torch.Tensor:
+        """Add spatial position embeddings to a ``CLS``-prefixed sequence.
+
+        Parameters
+        ----------
+        seq : torch.Tensor
+            Projected tokens of shape ``(batch, 1 + n_electrodes, hidden_dim)``
+            (position 0 is the ``CLS`` token).
+        coords : torch.Tensor
+            Integer coordinates of shape ``(batch, n_electrodes, 3)``.
+        seq_id : torch.Tensor
+            Integer sequence ids of shape ``(batch, n_electrodes)``.
+
+        Returns
+        -------
+        torch.Tensor
+            ``seq`` with the position embeddings added, same shape.
+        """
+        table = self.pe[0]  # (max_len, pe_dim)
+        # (batch, n_elec, 3, pe_dim) -> (batch, n_elec, 3 * pe_dim)
+        p_embed = table[coords]
+        n_batch, n_elec, n_axes, pe_dim = p_embed.shape
+        p_embed = p_embed.reshape(n_batch, n_elec, n_axes * pe_dim)
+        # (batch, n_elec, pe_dim)
+        s_embed = table[seq_id]
+        elec_embed = torch.cat([p_embed, s_embed], dim=-1)  # (b, n_elec, hidden)
+        # CLS position embedding: pe[0] tiled over the four quarters.
+        cls_embed = table[0].repeat(n_batch, 4).unsqueeze(1)  # (b, 1, hidden)
+        pos = torch.cat([cls_embed, elec_embed], dim=1)  # (b, 1 + n_elec, hidden)
+        return seq + pos
+
+
+class _PopTInputEmbedding(nn.Module):
+    """Input encoding of PopT (upstream ``TransformerEncoderInput``).
+
+    Prepends a ``CLS`` feature row (a vector of ones, as upstream), projects the
+    per-electrode features ``input_dim -> hidden_dim``, adds the spatial position
+    encoding, then applies LayerNorm and dropout. Attribute names (``in_proj``,
+    ``positional_encoding``, ``layer_norm``) match upstream so weights map
+    directly.
+
+    Parameters
+    ----------
+    input_dim : int
+        Dimension of the per-electrode input features (e.g. 768 for BrainBERT).
+    hidden_dim : int
+        Transformer model width ``D``.
+    max_len : int
+        Size of the coordinate table, forwarded to the positional encoding.
+    drop_prob : float
+        Dropout probability applied to the embedded tokens.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dim: int,
+        max_len: int = 5000,
+        drop_prob: float = 0.1,
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.in_proj = nn.Linear(input_dim, hidden_dim)
+        self.positional_encoding = _PopTSpatialPositionalEncoding(
+            hidden_dim, max_len=max_len
+        )
+        self.layer_norm = nn.LayerNorm(hidden_dim)
+        self.dropout = nn.Dropout(p=drop_prob)
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        coords: torch.Tensor,
+        seq_id: torch.Tensor,
+    ) -> torch.Tensor:
+        """Embed per-electrode features into ``CLS``-prefixed tokens.
+
+        Parameters
+        ----------
+        features : torch.Tensor
+            Per-electrode features of shape ``(batch, n_electrodes, input_dim)``.
+        coords : torch.Tensor
+            Integer coordinates of shape ``(batch, n_electrodes, 3)``.
+        seq_id : torch.Tensor
+            Integer sequence ids of shape ``(batch, n_electrodes)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Embedded tokens of shape ``(batch, 1 + n_electrodes, hidden_dim)``.
+        """
+        batch_size = features.shape[0]
+        # Upstream prepends a CLS row of ones before the linear projection.
+        cls = features.new_ones((batch_size, 1, self.input_dim))
+        x = torch.cat([cls, features], dim=1)
+        x = self.in_proj(x)
+        x = self.positional_encoding(x, coords, seq_id)
+        x = self.layer_norm(x)
+        return self.dropout(x)
+
+
+class _PopTSpecPredictionHead(nn.Module):
+    """Feature-reconstruction head (upstream ``SpecPredictionHead``).
+
+    Kept so the pre-training parameters map 1:1 to upstream (weight parity);
+    unused by the braindecode classification path.
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Transformer model width ``D``.
+    output_dim : int
+        Reconstruction target dimension (the input feature dimension upstream).
+    """
+
+    def __init__(self, hidden_dim: int, output_dim: int):
+        super().__init__()
+        self.hidden_layer = nn.Linear(hidden_dim, hidden_dim)
+        self.act_fn = nn.GELU()
+        self.layer_norm = nn.LayerNorm(hidden_dim)
+        self.output = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        h = self.hidden_layer(hidden)
+        h = self.act_fn(h)
+        h = self.layer_norm(h)
+        return self.output(h)
+
+
+class _PopTHead(nn.Module):
+    """braindecode-native classification head on the ``CLS`` representation.
+
+    Upstream reads the ``CLS`` token and applies a single linear layer
+    (``cls_head``, ``hidden_dim -> 1``); here a LayerNorm precedes a linear layer
+    to ``n_outputs``, a minimal and standard braindecode choice that generalises
+    to any number of classes.
+
+    Parameters
+    ----------
+    hidden_dim : int
+        Transformer model width ``D``.
+    n_outputs : int
+        Number of decoding classes.
+    """
+
+    def __init__(self, hidden_dim: int, n_outputs: int):
+        super().__init__()
+        self.norm = nn.LayerNorm(hidden_dim)
+        self.fc = nn.Linear(hidden_dim, n_outputs)
+
+    def forward(self, cls_token: torch.Tensor) -> torch.Tensor:
+        return self.fc(self.norm(cls_token))

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,6 +28,13 @@ Current 1.7.0 (GitHub)
 Enhancements
 ============
 
+- Add :class:`braindecode.models.PopulationTransformer`, a self-supervised
+  population model for intracranial (sEEG/iEEG) signals from Chau et al. (2024).
+  It aggregates across electrodes from per-electrode features (e.g. frozen
+  BrainBERT embeddings) plus their anatomical coordinates; the input embedding,
+  spatial position encoding and Transformer encoder are ported bit-exact from the
+  upstream reference (:gh:`1109` by `Adam Mounir`_)
+
 - Add :data:`braindecode.models.util.interpolated_models_dict`, a dedicated
   registry for the interpolated (channel-adapting) models, keeping them separate
   from :data:`braindecode.models.util.models_dict` (:gh:`1093` by `Bruno Aristimunha`_)

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,7 +33,7 @@ Enhancements
   It aggregates across electrodes from per-electrode features (e.g. frozen
   BrainBERT embeddings) plus their anatomical coordinates; the input embedding,
   spatial position encoding and Transformer encoder are ported bit-exact from the
-  upstream reference (:gh:`1109` by `Adam Mounir`_)
+  upstream reference (:gh:`1105` by `Adam Mounir`_)
 
 - Add :data:`braindecode.models.util.interpolated_models_dict`, a dedicated
   registry for the interpolated (channel-adapting) models, keeping them separate

--- a/test/unit_tests/models/test_integration.py
+++ b/test/unit_tests/models/test_integration.py
@@ -552,6 +552,9 @@ def test_model_torch_script(model):
         "InterpolatedSignalJEPA",
         # TorchScript cannot script einops.rearrange (it uses **axes_lengths).
         "STEEGFormer",
+        # forward() returns Dict[str, Tensor] (features) or Tensor (logits);
+        # torch.jit.script rejects this polymorphic return type.
+        "PopulationTransformer",
     ]
 
     if model.__class__.__name__ in not_working_models:

--- a/test/unit_tests/models/test_popt.py
+++ b/test/unit_tests/models/test_popt.py
@@ -1,0 +1,167 @@
+"""Tests for the PopulationTransformer (PopT) iEEG/sEEG foundation model.
+
+The bulk of the model contract (init / forward / serialization / categorization)
+is already exercised by the shared model suites via ``models_mandatory_parameters``.
+This file adds PopT-specific checks: the ``CLS`` pooling and feature interface,
+that electrode coordinates are read from ``chs_info``, plus an upstream **parity
+gate** — when the reference code is available (``POPT_SRC`` pointing to a clone
+of https://github.com/czlwang/PopulationTransformer), the ported input embedding
++ Transformer are checked to be bit-exact against upstream ``PtModelCustom``;
+otherwise the gate is skipped, so CI stays green without the external dependency.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+import torch
+
+from braindecode.models import PopulationTransformer
+from braindecode.modules.popt_modules import _PopTInputEmbedding
+
+# small dims keep the suite fast on a CPU runner. n_times plays the role of the
+# per-electrode feature dimension (768 for real BrainBERT features).
+N_CHANS, N_OUTPUTS, N_TIMES = 5, 2, 16
+
+
+def _model(**overrides):
+    kwargs = dict(
+        n_chans=N_CHANS, n_outputs=N_OUTPUTS, n_times=N_TIMES,
+        hidden_dim=32, ffn_dim=48, n_layers=2, n_heads=4,
+    )
+    kwargs.update(overrides)
+    return PopulationTransformer(**kwargs)
+
+
+def test_forward_shape():
+    model = _model().eval()
+    x = torch.randn(2, N_CHANS, N_TIMES)
+    with torch.no_grad():
+        out = model(x)
+    assert out.shape == (2, N_OUTPUTS)
+    assert torch.isfinite(out).all()
+
+
+def test_return_features():
+    model = _model().eval()
+    with torch.no_grad():
+        out = model(torch.randn(2, N_CHANS, N_TIMES), return_features=True)
+    assert isinstance(out, dict)
+    assert set(out) == {"features", "cls_token"}
+    assert out["features"].shape == (2, model.hidden_dim)
+    # PopT has a real CLS token (unlike BrainBERT); it doubles as the feature.
+    assert out["cls_token"] is not None
+    assert torch.equal(out["features"], out["cls_token"])
+    assert torch.isfinite(out["features"]).all()
+
+
+def test_reset_head_changes_n_outputs():
+    model = _model().eval()
+    model.reset_head(7)
+    with torch.no_grad():
+        out = model(torch.randn(2, N_CHANS, N_TIMES))
+    assert out.shape == (2, 7)
+
+
+def test_hidden_dim_must_be_divisible_by_four():
+    with pytest.raises(ValueError):
+        _model(hidden_dim=30)
+
+
+def test_coords_from_chs_info():
+    """Electrode coordinates are read from chs_info and discretised."""
+    # three electrodes 1 mm apart along x (metres in the MNE convention).
+    chs_info = [
+        {"ch_name": f"E{i}", "kind": "eeg", "loc": [i * 1e-3, 0.0, 0.0] + [0.0] * 9}
+        for i in range(3)
+    ]
+    model = PopulationTransformer(
+        n_chans=3, n_outputs=2, n_times=N_TIMES, chs_info=chs_info,
+        hidden_dim=32, ffn_dim=48, n_layers=1, n_heads=4,
+    )
+    coords = model.electrode_coords
+    assert coords.shape == (3, 3)
+    # x axis is shifted to start at 0 and spaced by 1 (1 mm rounded).
+    assert torch.equal(coords[:, 0], torch.tensor([0, 1, 2]))
+    # y / z are constant -> all zero after the per-axis shift.
+    assert torch.equal(coords[:, 1], torch.zeros(3, dtype=torch.long))
+
+
+def test_coords_fallback_without_positions():
+    """Without usable positions, electrodes get distinct sequential indices."""
+    model = _model()
+    coords = model.electrode_coords
+    assert coords.shape == (N_CHANS, 3)
+    assert torch.equal(coords[:, 0], torch.arange(N_CHANS))
+
+
+# --------------------------------------------------------------- parity gate
+def _import_upstream_or_skip():
+    src = os.environ.get("POPT_SRC")
+    if not src or not os.path.isdir(src):
+        pytest.skip("set POPT_SRC=/path/to/PopulationTransformer for the parity gate")
+    sys.path.insert(0, src)
+    try:
+        import models as upstream_models  # noqa: F401 (populates registry)
+        from models.pt_model_custom import PtModelCustom
+    except ImportError as exc:  # pragma: no cover - depends on external code
+        pytest.skip(f"upstream PopulationTransformer not importable: {exc}")
+    return PtModelCustom
+
+
+def test_encoder_is_bit_exact_with_upstream():
+    """Input embedding + Transformer reproduce upstream once weights are copied."""
+    PtModelCustom = _import_upstream_or_skip()
+    from omegaconf import OmegaConf
+
+    torch.manual_seed(0)
+    batch, n_elec = 2, 6
+    input_dim, hidden_dim, n_heads, n_layers = 8, 32, 4, 2
+
+    cfg = OmegaConf.create(
+        dict(
+            name="pt_model_custom",
+            position_encoding="multi_subj_position_encoding",
+            n_head=n_heads, n_layers=n_layers, hidden_dim=hidden_dim,
+            input_dim=input_dim, layer_activation="gelu",
+            attention_weights=False, use_token_cls_head=False,
+        )
+    )
+    up = PtModelCustom()
+    up.build_model(cfg)
+    up.eval()
+
+    ours_embed = _PopTInputEmbedding(input_dim, hidden_dim).eval()
+    # upstream uses dim_feedforward=2048 (the nn default it never overrides).
+    enc_layer = torch.nn.TransformerEncoderLayer(
+        d_model=hidden_dim, nhead=n_heads, dim_feedforward=2048,
+        activation="gelu", batch_first=True,
+    )
+    ours_trans = torch.nn.TransformerEncoder(enc_layer, num_layers=n_layers).eval()
+
+    # copy upstream weights into the ported modules
+    ours_embed.in_proj.load_state_dict(up.input_encoding.in_proj.state_dict())
+    ours_embed.layer_norm.load_state_dict(up.input_encoding.layer_norm.state_dict())
+    ours_trans.load_state_dict(up.transformer_encoder.state_dict())
+    # sinusoidal spatial buffers are computed identically on both sides
+    assert torch.allclose(
+        ours_embed.positional_encoding.pe,
+        up.input_encoding.positional_encoding.pe,
+        atol=1e-6,
+    )
+
+    features = torch.randn(batch, n_elec, input_dim)
+    coords = torch.randint(0, 120, (batch, n_elec, 3))
+    seq_id = torch.zeros(batch, n_elec, dtype=torch.long)
+    # upstream expects the CLS row (a vector of ones) already prepended
+    cls = torch.ones(batch, 1, input_dim)
+    up_inputs = torch.cat([cls, features], dim=1)
+    src_key_mask = torch.zeros(batch, n_elec + 1).bool()
+
+    with torch.no_grad():
+        up_out = up(up_inputs, src_key_mask, (coords, seq_id), intermediate_rep=True)
+        ours_out = ours_trans(ours_embed(features, coords, seq_id))
+    assert up_out.shape == ours_out.shape == (batch, n_elec + 1, hidden_dim)
+    assert torch.allclose(up_out, ours_out, atol=1e-5)

--- a/test/unit_tests/models/test_popt.py
+++ b/test/unit_tests/models/test_popt.py
@@ -98,22 +98,34 @@ def test_coords_fallback_without_positions():
 
 
 # --------------------------------------------------------------- parity gate
-def _import_upstream_or_skip():
+@pytest.fixture
+def upstream_pt_model():
+    """Yield the upstream ``PtModelCustom`` class (skip if ``POPT_SRC`` unset).
+
+    ``POPT_SRC`` is inserted at the front of ``sys.path`` for the duration of the
+    test and restored on teardown, so the upstream clone never leaks onto the
+    import path of subsequent tests.
+    """
     src = os.environ.get("POPT_SRC")
     if not src or not os.path.isdir(src):
         pytest.skip("set POPT_SRC=/path/to/PopulationTransformer for the parity gate")
+    original_path = list(sys.path)
     sys.path.insert(0, src)
     try:
         import models as upstream_models  # noqa: F401 (populates registry)
         from models.pt_model_custom import PtModelCustom
     except ImportError as exc:  # pragma: no cover - depends on external code
+        sys.path[:] = original_path
         pytest.skip(f"upstream PopulationTransformer not importable: {exc}")
-    return PtModelCustom
+    try:
+        yield PtModelCustom
+    finally:
+        sys.path[:] = original_path
 
 
-def test_encoder_is_bit_exact_with_upstream():
+def test_encoder_is_bit_exact_with_upstream(upstream_pt_model):
     """Input embedding + Transformer reproduce upstream once weights are copied."""
-    PtModelCustom = _import_upstream_or_skip()
+    PtModelCustom = upstream_pt_model
     from omegaconf import OmegaConf
 
     torch.manual_seed(0)


### PR DESCRIPTION
Towards #1097.

Adds a braindecode-native port of **PopulationTransformer (PopT)** (Chau et al. 2024, [arXiv:2406.03044](https://arxiv.org/abs/2406.03044)), the third iEEG/sEEG model from #1097 after `Brant` (#1100) and `BrainBERT` (#1104).

### What it is

Unlike a per-channel encoder, PopT is a **population aggregator**: its input is a set of per-electrode feature vectors (typically the frozen embeddings of a channel-level foundation model such as `BrainBERT`) plus each electrode's integer anatomical coordinates. A `CLS` token summarises the population after a stack of Transformer encoder layers.

### Design

- Following the braindecode convention, the per-electrode feature vector plays the role of the `n_times` axis, so the model keeps the standard `(batch, n_chans, n_times)` signature (`n_chans` = number of electrodes, `n_times` = feature dimension, 768 for BrainBERT `stft` features).
- Electrode coordinates are read from `chs_info` and discretised to integer indices inside the model; without positions the electrodes fall back to distinct sequential indices.
- The input embedding, spatial position encoding and Transformer are ported weight-for-weight; only the classification head is a braindecode-native addition.

### Parity

The input embedding + Transformer are checked **bit-exact** against the upstream `PtModelCustom` (input embedding + spatial encoding + post-norm encoder), with the released `popt_brainbert_stft` weights copied over — `test_popt.py::test_encoder_is_bit_exact_with_upstream` (gated by `POPT_SRC`, skipped in CI without it). Reproduce with:

```bash
POPT_SRC=/path/to/PopulationTransformer pytest test/unit_tests/models/test_popt.py
```

### Notes

- The shared model suites (config / categorization / forward / serialization / HF roundtrip) pass for `PopulationTransformer`.
- Weight re-hosting on `braindecode/popt-pretrained` (so `PopulationTransformer.from_pretrained(...)` works out of the box) is a follow-up, as for the previous models.

cc @bruAristimunha
