### PR TITLE
test: mark physionet-downloading tests with network marker

### DIFF
--- a/test/acceptance_tests/test_cropped_decoding.py
+++ b/test/acceptance_tests/test_cropped_decoding.py
@@ -20,6 +20,7 @@ from braindecode.util import set_random_seeds
 
 
 @pytest.mark.skipif(sys.version_info != (3, 7), reason="Only for Python 3.7")
+@pytest.mark.network
 def test_cropped_decoding():
     # 5,6,7,10,13,14 are codes for executed and imagined hands/feet
     subject_id = 1

--- a/test/acceptance_tests/test_eeg_classifier.py
+++ b/test/acceptance_tests/test_eeg_classifier.py
@@ -60,6 +60,7 @@ def assert_deep_allclose(expected, actual, *args, **kwargs):
 
 
 @pytest.mark.skipif(sys.version_info != (3, 7), reason="Only for Python 3.7")
+@pytest.mark.network
 def test_eeg_classifier():
     # 5,6,7,10,13,14 are codes for executed and imagined hands/feet
     subject_id = 1

--- a/test/acceptance_tests/test_trialwise_decoding.py
+++ b/test/acceptance_tests/test_trialwise_decoding.py
@@ -33,6 +33,7 @@ class EpochsDataset(Dataset):
 
 
 @pytest.mark.skipif(sys.version_info != (3, 7), reason="Only for Python 3.7")
+@pytest.mark.network
 def test_trialwise_decoding():
     # 5,6,7,10,13,14 are codes for executed and imagined hands/feet
     subject_id = 1

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -150,6 +150,7 @@ def concat_windows_dataset():
         (1, False, False),
     ],
 )
+@pytest.mark.network
 def test_data_loader(
         dummy_transform, concat_windows_dataset, nb_transforms, no_list, dummy
 ):
@@ -166,11 +167,13 @@ def test_data_loader(
             break
 
 
+@pytest.mark.network
 def test_data_loader_exception(concat_windows_dataset):
     with pytest.raises(TypeError):
         AugmentedDataLoader(concat_windows_dataset, transforms="a", batch_size=128)
 
 
+@pytest.mark.network
 def test_dataset_with_transform(concat_windows_dataset):
     factor = 10
     transform = DummyTransform(k=factor)
@@ -235,6 +238,7 @@ def test_augmented_data_loader_negative_n_augmentation():
         AugmentedDataLoader(dataset, n_augmentation=-1, batch_size=4)
 
 
+@pytest.mark.network
 def test_single_input_aug(concat_windows_dataset):
     # Create single input without the batch dimension, just (channels, time)
     X, y, _ = concat_windows_dataset[0]

--- a/test/unit_tests/models/test_correctness.py
+++ b/test/unit_tests/models/test_correctness.py
@@ -5,9 +5,7 @@
 import mne
 import numpy as np
 import pytest
-import requests
 import torch
-from mne.datasets.eegbci.eegbci import EEGMI_URL
 from mne.io import concatenate_raws
 from skorch.callbacks import LRScheduler
 from skorch.helper import predefined_split
@@ -16,20 +14,6 @@ from braindecode.classifier import EEGClassifier
 from braindecode.datasets.xy import create_from_X_y
 from braindecode.models.biot import BIOT
 from braindecode.util import set_random_seeds
-
-
-def check_http_issue():
-    """Check if the EEGMI_URL is available."""
-    try:
-        response = requests.get(EEGMI_URL)
-        response.raise_for_status()
-        return False
-    except requests.HTTPError as http_err:
-        print(f'HTTP error occurred: {http_err}')
-        return True
-    except Exception as err:
-        print(f'Other error occurred: {err}')
-        return True
 
 
 @pytest.fixture()
@@ -83,9 +67,7 @@ def real_data():
 
 
 # TODO: adding this test for all the models when the issue #571 is closed
-@pytest.mark.skipif(check_http_issue(),
-                    reason="HTTP issue occurred, skipping test.")
-
+@pytest.mark.network
 def test_correctness_biot(real_data):
     seed = 20200220
     set_random_seeds(seed=seed, cuda=False)


### PR DESCRIPTION
## Summary
- Several tests (`test_base.py`, `test_correctness.py`, acceptance tests) call `mne.datasets.eegbci.load_data()` directly with no network guard, so a default `pytest` run (as CI does) always attempts a real download from `physionet.org` and times out when it's unreachable.
- The repo already has a `network` marker + `--run-network` opt-in skip mechanism (`pyproject.toml`, `test/conftest.py`), but it was only wired up for REVE/HuggingFace tests. This wires it up for the physionet-dependent tests too.
- Also removes `test_correctness.py`'s `check_http_issue()` helper, which made an unconditional, timeout-less `requests.get` call at collection time (a hang risk independent of the marker fix).

## Test plan
- [x] `pytest test/unit_tests/augmentation/test_base.py -v` — physionet-dependent tests now SKIPPED instead of erroring, full file runs in 0.33s
- [x] `pytest test/unit_tests/models/test_correctness.py -v` — skipped instantly, no HTTP call at collection
- [x] `pytest test/acceptance_tests/` — all pass/skip cleanly