### PR TITLE
Use Dropout1d for the channel-wise dropout in BDTCN, TCN, BENDR

### DIFF
--- a/braindecode/models/bendr.py
+++ b/braindecode/models/bendr.py
@@ -1,3 +1,8 @@
+# Authors: Bruno Aristimunha <b.aristimunha@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
+#
+# License: BSD (3-clause)
+
 import copy
 
 import numpy as np
@@ -435,7 +440,9 @@ class _ConvEncoderBENDR(nn.Module):
                         padding=width
                         // 2,  # Correct padding for 'same' output length before stride
                     ),
-                    nn.Dropout2d(dropout),  # 2D dropout (matches paper specification)
+                    # channel-wise dropout (matches paper specification), on
+                    # (batch, channels, times) activations
+                    nn.Dropout1d(dropout),
                     nn.GroupNorm(
                         encoder_h // 2, encoder_h
                     ),  # Consider making num_groups configurable or ensure encoder_h is divisible by 2

--- a/braindecode/models/tcn.py
+++ b/braindecode/models/tcn.py
@@ -1,5 +1,6 @@
 # Authors: Patryk Chrabaszcz
 #          Lukas Gemein <l.gemein@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD-3
 import torch
@@ -236,7 +237,9 @@ class _TemporalBlock(nn.Module):
         )
         self.chomp1 = Chomp1d(padding)
         self.relu1 = activation()
-        self.dropout1 = nn.Dropout2d(drop_prob)
+        # activations are (batch, channels, times), dropout2d only masks
+        # channel-wise there through a deprecated fallback
+        self.dropout1 = nn.Dropout1d(drop_prob)
 
         self.conv2 = weight_norm(
             nn.Conv1d(
@@ -250,7 +253,7 @@ class _TemporalBlock(nn.Module):
         )
         self.chomp2 = Chomp1d(padding)
         self.relu2 = activation()
-        self.dropout2 = nn.Dropout2d(drop_prob)
+        self.dropout2 = nn.Dropout1d(drop_prob)
 
         self.downsample = (
             nn.Conv1d(n_inputs, n_outputs, 1) if n_inputs != n_outputs else None

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -49,6 +49,14 @@ Requirements
 Bug fixes
 ==========
 
+- Use ``nn.Dropout1d`` instead of ``nn.Dropout2d`` for the channel-wise dropout
+  inside :class:`braindecode.models.BDTCN`, ``braindecode.models.TCN`` and
+  :class:`braindecode.models.BENDR`. Those layers receive
+  ``(batch, channels, times)`` activations, which ``nn.Dropout2d`` only handles
+  through a deprecated fallback that warns on every forward pass and is
+  scheduled to be reinterpreted as unbatched input, masking batch items rather
+  than channels. The masking behaviour is unchanged. By `Sarthak Tayal`_.
+
 - Clarify that :func:`braindecode.training.scoring.predict_trials`,
   :meth:`braindecode.EEGClassifier.predict_trials`, and
   :meth:`braindecode.EEGRegressor.predict_trials` return ground-truth dataset

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -9,6 +9,7 @@
 #
 # License: BSD-3
 
+import warnings
 from collections import OrderedDict
 from functools import partial
 from unittest import mock
@@ -21,6 +22,7 @@ from sklearn.utils import check_random_state
 from torch import nn
 
 from braindecode.models import (
+    BDTCN,
     BENDR,
     BIOT,
     DGCNN,
@@ -4060,3 +4062,47 @@ def test_emg2qwerty_feature_flags():
     assert isinstance(bundle_t, dict) and torch.equal(bundle_t["features"], out_t[1])
     assert m_t.get_config()["return_feature"] is True
     assert m_t.get_output_shape() == (1, emissions.shape[1], 99)
+
+
+@pytest.mark.parametrize("model_cls", [BDTCN, BENDR])
+def test_channel_dropout_on_1d_activations(model_cls):
+    """BDTCN and BENDR drop whole channels of a ``(batch, channels, times)``
+    tensor, so the dropout modules must be ``nn.Dropout1d``. ``nn.Dropout2d``
+    routes 3D input to the channel-wise path only through a deprecated
+    fallback that warns on every forward pass."""
+    model = model_cls(
+        n_chans=8, n_outputs=2, n_times=256, sfreq=100.0, drop_prob=0.5
+    ).train()
+
+    assert any(isinstance(m, nn.Dropout1d) for m in model.modules())
+    assert not any(isinstance(m, nn.Dropout2d) for m in model.modules())
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        model(torch.randn(4, 8, 256))
+    assert not [w for w in caught if "dropout2d" in str(w.message)]
+
+
+def test_tcn_bai_variant_channel_dropout():
+    """The Bai et al. ``TCN`` shares the residual block with ``BDTCN``, so it
+    gets the same channel-wise dropout module."""
+    model = TCN(n_chans=8, n_outputs=2, n_blocks=2, n_filters=5, drop_prob=0.5)
+    assert any(isinstance(m, nn.Dropout1d) for m in model.modules())
+    assert not any(isinstance(m, nn.Dropout2d) for m in model.modules())
+
+
+def test_dropout1d_masks_channels_not_batch_items():
+    """The channel-wise dropout used by BDTCN and BENDR zeroes rows of the
+    channel axis, independently per batch item. Under the announced
+    ``nn.Dropout2d`` semantics for 3D input the same tensor would be read as
+    unbatched and whole batch items would be dropped instead."""
+    set_random_seeds(2024, cuda=False)
+    out = nn.Dropout1d(0.5).train()(torch.ones(64, 16, 32))
+
+    # A dropped entry covers the full time axis of one (batch item, channel)
+    # pair.
+    zeroed = out.abs().sum(dim=-1) == 0
+    assert zeroed.any() and not zeroed.all()
+    # At least one batch item keeps some channels and loses others, which
+    # cannot happen when the mask is drawn over the batch axis.
+    assert (zeroed.any(dim=1) & ~zeroed.all(dim=1)).any()


### PR DESCRIPTION
Problem
`_TemporalBlock` in `braindecode/models/tcn.py` applies `nn.Dropout2d` to activations
shaped `(batch, channels, times)`. `_ConvEncoderBENDR` in `braindecode/models/bendr.py`
does the same after each `nn.Conv1d` stage. PyTorch routes 3D input to `Dropout2d`
through a deprecated compatibility path, which warns at each forward pass:

```
dropout2d: Received a 3D input to dropout2d and assuming that channel-wise 1D dropout
behavior is desired - input is interpreted as shape (N, C, L), where C is the channel dim.
This behavior will change in a future release to interpret the input as one without a batch
dimension, i.e. shape (C, H, W). To maintain the 1D channel-wise dropout behavior, please
switch to using dropout1d instead.
```

On current master a single training forward pass raises six of these warnings in
`BDTCN`, six in `BENDR`:

```python
import warnings, torch
from braindecode.models import BDTCN, BENDR

for cls in (BDTCN, BENDR):
    model = cls(n_chans=8, n_outputs=2, n_times=256, sfreq=100.0).train()
    with warnings.catch_warnings(record=True) as caught:
        warnings.simplefilter("always")
        model(torch.randn(4, 8, 256))
    print(cls.__name__, len([w for w in caught if "dropout2d" in str(w.message)]))
# BDTCN 6
# BENDR 6
```

Beyond the noise, the announced reinterpretation reads dimension 0 as the channel axis.
Masking would then drop whole batch items in place of feature channels, changing the
training behaviour of these models with nothing surfacing at runtime.

So, the change

`nn.Dropout2d` becomes `nn.Dropout1d` at the call sites receiving 3D activations:

| File | Site | Models |
| --- | --- | --- |
| `braindecode/models/tcn.py` | `_TemporalBlock.dropout1`, `_TemporalBlock.dropout2` | `BDTCN`, `TCN` |
| `braindecode/models/bendr.py` | `_ConvEncoderBENDR` encoder stages | `BENDR`, `InterpolatedBENDR` |

Call sites receiving 4D activations keep `nn.Dropout2d`, namely `ATCNet`, `TIDNet`.


#424 records the reason `Dropout2d` sits in the TCN residual block. The goal is masking
complete channels in place of single points. The BENDR encoder mirrors the reference
`dn3_ext.py` implementation, which places dropout after `nn.Conv1d` with the same
channel-masking intent. `nn.Dropout1d` expresses that semantic directly on `(N, C, L)`
input, with no deprecation attached. It is available since torch 1.12, well below the
`torch>=2.0` floor declared in `pyproject.toml`