### PR TITLE
predict_trials and cropped train scoring fail when the module is passed as a name or a class

### DIFF
--- a/braindecode/classifier.py
+++ b/braindecode/classifier.py
@@ -228,8 +228,9 @@ class EEGClassifier(_EEGNeuralNet, NeuralNetClassifier):
             if return_targets:
                 return preds, X.get_metadata()["target"].to_numpy()
             return preds
+        self.check_is_fitted()
         return predict_trials(
-            module=self.module,
+            module=self.module_,
             dataset=X,
             return_targets=return_targets,
             batch_size=self.batch_size,

--- a/braindecode/eegneuralnet.py
+++ b/braindecode/eegneuralnet.py
@@ -1,5 +1,6 @@
 # Authors: Bruno Aristimunha <b.aristimunha@gmail.com>
 #          Pierre Guetschel <pierre.guetschel@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/braindecode/eegneuralnet.py
+++ b/braindecode/eegneuralnet.py
@@ -126,7 +126,8 @@ class _EEGNeuralNet(NeuralNet, abc.ABC):
                 self._last_window_inds_ = None
 
     def predict_with_window_inds_and_ys(self, dataset):
-        self.module.eval()
+        # self.module can still be a name or a class, self.module_ is the built one
+        self.module_.eval()
         preds = []
         i_window_in_trials = []
         i_window_stops = []

--- a/braindecode/eegneuralnet.py
+++ b/braindecode/eegneuralnet.py
@@ -143,7 +143,7 @@ class _EEGNeuralNet(NeuralNet, abc.ABC):
             i_window_in_trials.append(i[0].cpu().numpy())
             i_window_stops.append(i[2].cpu().numpy())
             with torch.no_grad():
-                preds.append(to_numpy(self.module.forward(X.to(self.device))))
+                preds.append(to_numpy(self.module_.forward(X.to(self.device))))
             window_ys.append(y.cpu().numpy())
         preds = np.concatenate(preds)
         i_window_in_trials = np.concatenate(i_window_in_trials)

--- a/braindecode/regressor.py
+++ b/braindecode/regressor.py
@@ -172,8 +172,9 @@ class EEGRegressor(_EEGNeuralNet, NeuralNetRegressor):
             if return_targets:
                 return preds, np.concatenate([X[i][1] for i in range(len(X))])
             return preds
+        self.check_is_fitted()
         return predict_trials(
-            module=self.module,
+            module=self.module_,
             dataset=X,
             return_targets=return_targets,
             batch_size=self.batch_size,

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -50,11 +50,12 @@ Bug fixes
 ==========
 
 - Fix :meth:`braindecode.EEGClassifier.predict_trials`,
-  :meth:`braindecode.EEGRegressor.predict_trials` and the cropped train-side
-  scoring callbacks raising ``AttributeError`` or ``TypeError`` when the module
-  was passed as a model name or as an uninstantiated class. Those code paths
-  used the ``module`` constructor argument instead of the built ``module_``
-  attribute, so they only worked with an already instantiated module, which the
+  :meth:`braindecode.EEGRegressor.predict_trials` and
+  :class:`braindecode.training.scoring.CroppedTrialEpochScoring` on the training
+  set raising ``AttributeError`` or ``TypeError`` when the module was passed as a
+  model name or as an uninstantiated class. Those paths read the ``module``
+  constructor argument instead of the initialized ``module_`` attribute, so they
+  only worked when an already instantiated module was passed, which the
   documentation discourages. By `Sarthak Tayal`_.
 
 - Use ``nn.Dropout1d`` instead of ``nn.Dropout2d`` for the channel-wise dropout

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -49,6 +49,14 @@ Requirements
 Bug fixes
 ==========
 
+- Fix :meth:`braindecode.EEGClassifier.predict_trials`,
+  :meth:`braindecode.EEGRegressor.predict_trials` and the cropped train-side
+  scoring callbacks raising ``AttributeError`` or ``TypeError`` when the module
+  was passed as a model name or as an uninstantiated class. Those code paths
+  used the ``module`` constructor argument instead of the built ``module_``
+  attribute, so they only worked with an already instantiated module, which the
+  documentation discourages. By `Sarthak Tayal`_.
+
 - Use ``nn.Dropout1d`` instead of ``nn.Dropout2d`` for the channel-wise dropout
   inside :class:`braindecode.models.BDTCN`, ``braindecode.models.TCN`` and
   :class:`braindecode.models.BENDR`. Those layers receive

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -1,5 +1,6 @@
 # Authors: Maciej Sliwowski <maciek.sliwowski@gmail.com>
 #          Lukas Gemein <l.gemein@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD-3
 import logging

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -167,6 +167,28 @@ def slice_dataset(windows_dataset_channels):
 
 
 @pytest.fixture
+def cropped_windows_dataset():
+    # two trials of two overlapping windows each, what predict_trials expects
+    X = np.random.RandomState(20200101).rand(4, 3, 10).astype(np.float32)
+    metadata = pd.DataFrame(
+        [
+            (0, 0, 0, 9),
+            (0, 1, 2, 11),
+            (1, 0, 0, 9),
+            (1, 1, 2, 11),
+        ],
+        columns=["target", "i_window_in_trial", "i_start_in_trial", "i_stop_in_trial"],
+    )
+    epochs = mne.EpochsArray(
+        X,
+        info=mne.create_info(ch_names=["ch1", "ch2", "ch3"], sfreq=10, ch_types="eeg"),
+        metadata=metadata,
+    )
+    windows = WindowsDataset(windows=epochs, targets_from="metadata", description={})
+    return BaseConcatDataset([windows])
+
+
+@pytest.fixture
 def concat_dataset_metadata(windows_dataset_metadata):
     return BaseConcatDataset([windows_dataset_metadata, windows_dataset_metadata])
 

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -359,6 +359,21 @@ def test_predict_with_window_inds_and_ys_module_not_instantiated(
     assert results["window_ys"].shape[0] == 4
 
 
+def test_predict_trials_sets_eval_mode(eegneuralnet_cls, cropped_windows_dataset):
+    eegneuralnet = eegneuralnet_cls(
+        MockModuleCroppedPreds,
+        module__n_outputs=2,
+        module__n_chans=3,
+        module__n_times=250,
+        cropped=True,
+        batch_size=4,
+    )
+    eegneuralnet.initialize()
+    eegneuralnet.module_.train()
+    eegneuralnet.predict_trials(cropped_windows_dataset, return_targets=False)
+    assert not eegneuralnet.module_.training
+
+
 def test_predict_trials_not_initialized(eegneuralnet_cls, cropped_windows_dataset):
     eegneuralnet = eegneuralnet_cls(
         MockModuleCroppedPreds,

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -563,7 +563,7 @@ def test_module_name(eegneuralnet_cls):
         "ShallowFBCSPNet",
         module__n_outputs=4,
         module__n_chans=3,
-        module__n_times=250,
+        module__n_times=100,
         cropped=False,
     )
     net.initialize()

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -328,11 +328,14 @@ def test_predict_trials_module_not_instantiated(
     assert trial_preds.shape[0] == 2
     assert trial_preds.shape[1] == 2
     assert trial_targets.shape[0] == 2
-    # same thing the functional helper gives for the built module
+    # same thing the functional helper gives for the built module, same batching
     expected_preds, expected_targets = predict_trials(
-        eegneuralnet.module_, cropped_windows_dataset
+        eegneuralnet.module_,
+        cropped_windows_dataset,
+        batch_size=eegneuralnet.batch_size,
     )
-    np.testing.assert_allclose(trial_preds, expected_preds)
+    # float32 convolutions wobble a bit between backends, keep this loose
+    np.testing.assert_allclose(trial_preds, expected_preds, rtol=1e-4, atol=1e-5)
     np.testing.assert_array_equal(trial_targets, expected_targets)
 
 

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -28,6 +28,7 @@ from braindecode.models.base import EEGModuleMixin
 # from braindecode.models.util import models_dict
 from braindecode.models.shallow_fbcsp import ShallowFBCSPNet
 from braindecode.training import CroppedLoss
+from braindecode.training.scoring import predict_trials
 
 
 class MockDataset(torch.utils.data.Dataset):
@@ -327,6 +328,12 @@ def test_predict_trials_module_not_instantiated(
     assert trial_preds.shape[0] == 2
     assert trial_preds.shape[1] == 2
     assert trial_targets.shape[0] == 2
+    # same thing the functional helper gives for the built module
+    expected_preds, expected_targets = predict_trials(
+        eegneuralnet.module_, cropped_windows_dataset
+    )
+    np.testing.assert_allclose(trial_preds, expected_preds)
+    np.testing.assert_array_equal(trial_targets, expected_targets)
 
 
 def test_predict_with_window_inds_and_ys_module_not_instantiated(

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -170,13 +170,13 @@ def slice_dataset(windows_dataset_channels):
 @pytest.fixture
 def cropped_windows_dataset():
     # two trials of two overlapping windows each, what predict_trials expects
-    X = np.random.RandomState(20200101).rand(4, 3, 10).astype(np.float32)
+    X = np.random.RandomState(20200101).rand(4, 3, 250).astype(np.float32)
     metadata = pd.DataFrame(
         [
-            (0, 0, 0, 9),
-            (0, 1, 2, 11),
-            (1, 0, 0, 9),
-            (1, 1, 2, 11),
+            (0, 0, 0, 249),
+            (0, 1, 2, 251),
+            (1, 0, 0, 249),
+            (1, 1, 2, 251),
         ],
         columns=["target", "i_window_in_trial", "i_start_in_trial", "i_stop_in_trial"],
     )
@@ -313,7 +313,7 @@ def test_predict_trials_module_not_instantiated(
         module,
         module__n_outputs=2,
         module__n_chans=3,
-        module__n_times=10,
+        module__n_times=250,
         cropped=True,
         criterion=CroppedLoss,
         criterion__loss_function=nll_loss,
@@ -333,7 +333,7 @@ def test_predict_trials_not_initialized(eegneuralnet_cls, cropped_windows_datase
         MockModuleCroppedPreds,
         module__n_outputs=2,
         module__n_chans=3,
-        module__n_times=10,
+        module__n_times=250,
         cropped=True,
         batch_size=4,
     )
@@ -532,7 +532,7 @@ def test_module_name(eegneuralnet_cls):
         "ShallowFBCSPNet",
         module__n_outputs=4,
         module__n_chans=3,
-        module__n_times=100,
+        module__n_times=250,
         cropped=False,
     )
     net.initialize()

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -328,6 +328,29 @@ def test_predict_trials_module_not_instantiated(
     assert trial_targets.shape[0] == 2
 
 
+def test_predict_with_window_inds_and_ys_module_not_instantiated(
+    eegneuralnet_cls, cropped_windows_dataset
+):
+    # this is the path the cropped train scoring callbacks go through
+    eegneuralnet = eegneuralnet_cls(
+        MockModuleCroppedPreds,
+        module__n_outputs=2,
+        module__n_chans=3,
+        module__n_times=250,
+        cropped=True,
+        criterion=CroppedLoss,
+        criterion__loss_function=nll_loss,
+        optimizer=optim.Adam,
+        batch_size=4,
+    )
+    eegneuralnet.initialize()
+    results = eegneuralnet.predict_with_window_inds_and_ys(cropped_windows_dataset)
+    assert results["preds"].shape[0] == 4
+    assert results["i_window_in_trials"].shape[0] == 4
+    assert results["i_window_stops"].shape[0] == 4
+    assert results["window_ys"].shape[0] == 4
+
+
 def test_predict_trials_not_initialized(eegneuralnet_cls, cropped_windows_dataset):
     eegneuralnet = eegneuralnet_cls(
         MockModuleCroppedPreds,

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -67,6 +67,33 @@ class MockModuleFinalLayer(MockModuleReturnMockedPreds):
         return self.final_layer(x).reshape(x.shape[0], self.n_outputs)
 
 
+class MockModuleCroppedPreds(EEGModuleMixin, torch.nn.Module):
+    # keeps the time axis so the output looks like a cropped/dense prediction
+    def __init__(
+        self,
+        n_outputs=None,
+        n_chans=None,
+        chs_info=None,
+        n_times=None,
+        input_window_seconds=None,
+        sfreq=None,
+    ):
+        super().__init__(
+            n_outputs=n_outputs,
+            n_chans=n_chans,
+            chs_info=chs_info,
+            n_times=n_times,
+            input_window_seconds=input_window_seconds,
+            sfreq=sfreq,
+        )
+        self.final_layer = torch.nn.Conv1d(
+            self.n_chans, self.n_outputs, self.n_times - 1
+        )
+
+    def forward(self, x):
+        return self.final_layer(x)
+
+
 @pytest.fixture(params=[EEGClassifier, EEGRegressor])
 def eegneuralnet_cls(request):
     return request.param

--- a/test/unit_tests/test_eegneuralnet.py
+++ b/test/unit_tests/test_eegneuralnet.py
@@ -13,6 +13,7 @@ import torch
 from scipy.special import softmax
 from sklearn.base import clone
 from skorch.callbacks import LRScheduler
+from skorch.exceptions import NotInitializedError
 from skorch.helper import SliceDataset
 from skorch.utils import to_tensor
 from torch import optim
@@ -299,6 +300,45 @@ def test_predict_trials(eegneuralnet_cls, preds):
         match="This method was designed to predict " "trials in cropped mode.",
     ):
         eegneuralnet.predict_trials(MockDataset(), return_targets=False)
+
+
+@pytest.mark.parametrize("as_string", [False, True])
+def test_predict_trials_module_not_instantiated(
+    eegneuralnet_cls, cropped_windows_dataset, as_string
+):
+    # module given as a name or a class, so only module_ holds the built model
+    module = "ShallowFBCSPNet" if as_string else MockModuleCroppedPreds
+    kwargs = dict(module__final_conv_length=2) if as_string else dict()
+    eegneuralnet = eegneuralnet_cls(
+        module,
+        module__n_outputs=2,
+        module__n_chans=3,
+        module__n_times=10,
+        cropped=True,
+        criterion=CroppedLoss,
+        criterion__loss_function=nll_loss,
+        optimizer=optim.Adam,
+        batch_size=4,
+        **kwargs,
+    )
+    eegneuralnet.initialize()
+    trial_preds, trial_targets = eegneuralnet.predict_trials(cropped_windows_dataset)
+    assert trial_preds.shape[0] == 2
+    assert trial_preds.shape[1] == 2
+    assert trial_targets.shape[0] == 2
+
+
+def test_predict_trials_not_initialized(eegneuralnet_cls, cropped_windows_dataset):
+    eegneuralnet = eegneuralnet_cls(
+        MockModuleCroppedPreds,
+        module__n_outputs=2,
+        module__n_chans=3,
+        module__n_times=10,
+        cropped=True,
+        batch_size=4,
+    )
+    with pytest.raises(NotInitializedError):
+        eegneuralnet.predict_trials(cropped_windows_dataset)
 
 
 def test_clonable(eegneuralnet_cls, preds):

--- a/test/unit_tests/training/test_scoring.py
+++ b/test/unit_tests/training/test_scoring.py
@@ -20,6 +20,7 @@ from braindecode.datasets.moabb import MOABBDataset
 from braindecode.datasets.xy import create_from_X_y
 from braindecode.models import ShallowFBCSPNet
 from braindecode.preprocessing import create_windows_from_events
+from braindecode.training import CroppedLoss
 from braindecode.training.scoring import (
     CroppedTimeSeriesEpochScoring,
     CroppedTrialEpochScoring,
@@ -482,6 +483,49 @@ def test_predict_trials():
         "same result as '.predict'.",
     ):
         clf.predict_trials(windows_ds2)
+
+
+def test_cropped_train_scoring_module_not_instantiated():
+    # cropped train scoring reads the built module, so a class must work here
+    set_random_seeds(seed=20200114, cuda=False)
+    n_trials, n_chans, n_times = 8, 3, 400
+    X = np.random.RandomState(20200114).randn(n_trials, n_chans, n_times)
+    X = X.astype(np.float32)
+    y = np.array([0, 1] * (n_trials // 2))
+
+    probe = ShallowFBCSPNet(
+        n_chans=n_chans, n_outputs=2, n_times=n_times, final_conv_length=2
+    )
+    probe.to_dense_prediction_model()
+    n_preds_per_input = probe.get_output_shape()[2]
+
+    windows_ds = create_from_X_y(
+        X,
+        y,
+        drop_last_window=False,
+        sfreq=100.0,
+        window_size_samples=n_times,
+        window_stride_samples=n_preds_per_input,
+    )
+
+    clf = EEGClassifier(
+        ShallowFBCSPNet,
+        module__n_chans=n_chans,
+        module__n_outputs=2,
+        module__n_times=n_times,
+        module__final_conv_length=2,
+        cropped=True,
+        criterion=CroppedLoss,
+        criterion__loss_function=torch.nn.functional.nll_loss,
+        optimizer=optim.AdamW,
+        train_split=None,
+        batch_size=2,
+        max_epochs=1,
+        classes=[0, 1],
+        callbacks=["accuracy"],
+    )
+    clf.fit(windows_ds, y=None)
+    assert "train_accuracy" in clf.history[-1]
 
 
 def test_post_epoch_train_scoring_uses_batch(monkeypatch):

--- a/test/unit_tests/training/test_scoring.py
+++ b/test/unit_tests/training/test_scoring.py
@@ -1,6 +1,7 @@
 # Authors: Maciej Sliwowski <maciek.sliwowski@gmail.com>
 #          Lukas Gemein <l.gemein@gmail.com>
 #          Robin Tibor Schirrmeister <robintibor@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD-3
 


### PR DESCRIPTION
`EEGClassifier.predict_trials`, `EEGRegressor.predict_trials` and the cropped train-side scoring callbacks read the `module` constructor argument instead than the initialized `module_` attribute. skorch stores the built model in `module_`, while `module` keeps whatever was passed in. When a model name or an uninstantiated class is passed, those code paths therefore operate on a string or a class instead of a model, and raise before doing any work.

This is important for braind ecode because passing a name or a class is the form the documentation recommends. The `EEGClassifier` docstring states that an uninstantiated class should be preferred when passing a torch module directly, and model names are the documented shorthand.

heres some of the affected code:

- `braindecode/eegneuralnet.py`, `_EEGNeuralNet.predict_with_window_inds_and_ys`, which calls `self.module.eval()` and `self.module.forward(...)`. This method is the one `CroppedTrialEpochScoring` and `CroppedTimeSeriesEpochScoring` call at the end of every epoch when `on_train=True`.
- `braindecode/classifier.py`, `EEGClassifier.predict_trials`, which passes `module=self.module`.
- `braindecode/regressor.py`, `EEGRegressor.predict_trials`, which passes `module=self.module`.

### Steps to reproduce

```python
import numpy as np

from braindecode import EEGClassifier
from braindecode.datasets import create_from_X_y
from braindecode.models import ShallowFBCSPNet

n_trials, n_chans, n_times = 6, 4, 400
X = np.random.RandomState(0).randn(n_trials, n_chans, n_times).astype(np.float32)
y = np.random.RandomState(1).randint(0, 2, n_trials)

probe = ShallowFBCSPNet(
    n_chans=n_chans, n_outputs=2, n_times=n_times, final_conv_length=2
)
probe.to_dense_prediction_model()
n_preds = probe.get_output_shape()[2]

windows = create_from_X_y(
    X,
    y,
    drop_last_window=False,
    sfreq=100.0,
    window_size_samples=n_times,
    window_stride_samples=n_preds,
)

clf = EEGClassifier(
    "ShallowFBCSPNet",
    module__n_chans=n_chans,
    module__n_outputs=2,
    module__n_times=n_times,
    module__final_conv_length=2,
    cropped=True,
    batch_size=2,
    train_split=None,
)
clf.initialize()
clf.predict_trials(windows)
```

the current bvehavior:

The snippet above fails with:

```
AttributeError: 'str' object has no attribute 'eval'
```

Passing `ShallowFBCSPNet` as a class instead of the name fails with:

```
TypeError: Module.eval() missing 1 required positional argument: 'self'
```

Fitting in cropped mode with a train-side scoring callback, for example `callbacks=["accuracy"]`, fails with the same `TypeError` at the end of the first epoch.

Expected behaviour

All three cases should run against the initialized model and return the trialwise predictions, exactly as they do today when an already instantiated module is passed.

and some extra context

Only an already instantiated module works today, which is why this has gone unnoticed. `examples/advanced_training/bcic_iv_4_ecog_cropped.py` instantiates the model before handing it to `EEGRegressor`, and `test_predict_trials` in `test/unit_tests/training/test_scoring.py` does the same, so no existing example or test exercises the broken form.

