### PR TITLE
FBLightConvNet ignores stride_factor, then dies with ZeroDivisionError on short windows

### DIFF
--- a/braindecode/models/fblightconvnet.py
+++ b/braindecode/models/fblightconvnet.py
@@ -219,10 +219,12 @@ class FBLightConvNet(EEGModuleMixin, nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
         Forward pass of the FBLightConvNet model.
+
         Parameters
         ----------
         x : torch.Tensor
             Input tensor with shape (batch_size, n_chans, n_times).
+
         Returns
         -------
         torch.Tensor

--- a/braindecode/models/fblightconvnet.py
+++ b/braindecode/models/fblightconvnet.py
@@ -116,7 +116,7 @@ class FBLightConvNet(EEGModuleMixin, nn.Module):
         n_bands=9,
         n_filters_spat: int = 32,
         n_dim: int = 3,
-        stride_factor: int = 4,
+        stride_factor: Optional[int] = None,
         win_len: int = 250,
         heads: int = 8,
         weight_softmax: bool = True,
@@ -134,6 +134,14 @@ class FBLightConvNet(EEGModuleMixin, nn.Module):
             sfreq=sfreq,
         )
         del n_outputs, n_chans, chs_info, n_times, input_window_seconds, sfreq
+
+        if stride_factor is not None:
+            warn(
+                "The parameter `stride_factor` is deprecated and ignored, it "
+                "will be removed in a future release. The temporal "
+                "segmentation of FBLightConvNet is set by `win_len`.",
+                DeprecationWarning,
+            )
 
         # Parameters
         self.n_bands = n_bands

--- a/braindecode/models/fblightconvnet.py
+++ b/braindecode/models/fblightconvnet.py
@@ -156,6 +156,13 @@ class FBLightConvNet(EEGModuleMixin, nn.Module):
         self.filter_parameters = filter_parameters or {}
 
         # Checkers
+        if self.n_times < self.win_len:
+            raise ValueError(
+                f"Time dimension ({self.n_times}) is shorter than win_len "
+                f"({self.win_len}), so the model cannot build a single "
+                f"temporal window. Pass a longer input or lower `win_len`."
+            )
+
         self.n_times_truncated = self.n_times
         if self.n_times % self.win_len != 0:
             warn(

--- a/braindecode/models/fblightconvnet.py
+++ b/braindecode/models/fblightconvnet.py
@@ -1,3 +1,7 @@
+# Authors: Sarthak Tayal <sarthaktayal2@gmail.com>
+#
+# License: BSD-3
+
 from __future__ import annotations
 
 from typing import Optional

--- a/braindecode/models/fblightconvnet.py
+++ b/braindecode/models/fblightconvnet.py
@@ -65,15 +65,18 @@ class FBLightConvNet(EEGModuleMixin, nn.Module):
 
     Parameters
     ----------
-    n_bands : int or None or list of tuple of int, default=8
+    n_bands : int or None or list of tuple of int, default=9
         Number of frequency bands or a list of frequency band tuples. If a list of tuples is provided,
         each tuple defines the lower and upper bounds of a frequency band.
     n_filters_spat : int, default=32
         Number of spatial filters in the depthwise convolutional layer.
     n_dim : int, default=3
         Number of dimensions for the temporal reduction layer.
-    stride_factor : int, default=4
-        Stride factor used for reshaping the temporal dimension.
+    win_len : int, default=250
+        Length in samples of the non-overlapping temporal windows the signal is
+        split into before the variance based feature extraction. The number of
+        windows passed to the attention module is ``n_times // win_len``, so
+        ``n_times`` has to be at least ``win_len``.
     activation : nn.Module, default=nn.ELU
         Activation function class to apply after convolutional layers.
     verbose : bool, default=False
@@ -86,6 +89,9 @@ class FBLightConvNet(EEGModuleMixin, nn.Module):
         If True, applies softmax to the attention weights.
     bias : bool, default=False
         If True, includes a bias term in the convolutional layers.
+    stride_factor : int or None, default=None
+        Deprecated and ignored, it will be removed in a future release. The
+        temporal segmentation of this model is controlled by ``win_len``.
 
     References
     ----------

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -35,6 +35,12 @@ Enhancements
 API and behavior changes
 ========================
 
+- The ``stride_factor`` parameter of :class:`braindecode.models.FBLightConvNet`
+  is deprecated and will be removed in a future release. The model never read
+  it, its temporal segmentation is set by ``win_len``, and the reference
+  implementation has no such parameter. Passing it now emits a
+  ``DeprecationWarning`` and keeps being ignored. By `Sarthak Tayal`_.
+
 - Interpolated models (e.g. ``InterpolatedBIOT``, ``InterpolatedLaBraM``) are no
   longer included in :data:`braindecode.models.util.models_dict`; they now live
   in the separate :data:`braindecode.models.util.interpolated_models_dict`
@@ -48,6 +54,13 @@ Requirements
 
 Bug fixes
 ==========
+
+- Raise a clear ``ValueError`` in :class:`braindecode.models.FBLightConvNet`
+  when ``n_times`` is shorter than ``win_len``. The temporal attention kernel
+  is sized as ``n_times // win_len``, so a short window produced an empty
+  kernel and the constructor died with a ``ZeroDivisionError`` coming from the
+  weight initialisation. The docstring now also documents ``win_len`` and
+  reports the correct ``n_bands`` default of 9. By `Sarthak Tayal`_.
 
 - Use ``nn.Dropout1d`` instead of ``nn.Dropout2d`` for the channel-wise dropout
   inside :class:`braindecode.models.BDTCN`, ``braindecode.models.TCN`` and

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -47,6 +47,7 @@ from braindecode.models import (
     EEGTCNet,
     EMG2QwertyNet,
     FBCNet,
+    FBLightConvNet,
     FBMSNet,
     HybridNet,
     IFNet,
@@ -2588,6 +2589,51 @@ def test_fbmsnet_invalid_temporal_layer():
             temporal_layer='InvalidLayer',
             sfreq=250,
         )
+
+
+@pytest.mark.parametrize("win_len, n_windows", [(100, 10), (250, 4), (500, 2)])
+def test_fblightconvnet_win_len_sets_number_of_windows(win_len, n_windows):
+    model = FBLightConvNet(
+        n_chans=8,
+        n_outputs=3,
+        n_times=1000,
+        sfreq=250,
+        win_len=win_len,
+    )
+    assert model.attn_conv.kernel_size == n_windows
+
+
+def test_fblightconvnet_stride_factor_is_deprecated_and_ignored():
+    kwargs = dict(n_chans=8, n_outputs=3, n_times=1000, sfreq=250)
+
+    set_random_seeds(2025, cuda=False)
+    default = FBLightConvNet(**kwargs).eval()
+
+    with pytest.warns(DeprecationWarning, match="stride_factor"):
+        set_random_seeds(2025, cuda=False)
+        passed = FBLightConvNet(stride_factor=17, **kwargs).eval()
+
+    # stride_factor never reached a layer, so the two models agree exactly
+    assert passed.attn_conv.kernel_size == default.attn_conv.kernel_size
+    x = torch.randn(2, 8, 1000)
+    with torch.no_grad():
+        assert torch.equal(passed(x), default(x))
+
+
+def test_fblightconvnet_default_build_is_not_deprecated():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        FBLightConvNet(n_chans=8, n_outputs=3, n_times=1000, sfreq=250)
+    assert not [w for w in caught if issubclass(w.category, DeprecationWarning)]
+
+
+@pytest.mark.parametrize("n_times", [200, 249])
+def test_fblightconvnet_window_shorter_than_win_len(n_times):
+    # used to reach xavier_uniform_ with an empty kernel and die on a
+    # division by zero
+    with pytest.raises(ValueError, match="shorter than win_len"):
+        FBLightConvNet(n_chans=8, n_outputs=3, n_times=n_times, sfreq=250)
+
 
 def test_initialize_weights_linear():
     linear = nn.Linear(10, 5)


### PR DESCRIPTION
`braindecode.models.FBLightConvNet` takes a `stride_factor` argument, stores it on the instance, never reads it again. The temporal segmentation of this model is set by `win_len`, which is missing from the class docstring. The docstring lists `n_bands` with a default of 8. The constructor uses 9.

The reference implementation this model is adapted from, `Ma-Xinzhi/LightConvNet`, has no `stride_factor` argument. Its constructor reads:

```python
def __init__(self, num_classes=4, num_samples=1000, num_channels=22,
             num_bands=9, embed_dim=32, win_len=250, num_heads=4,
             weight_softmax=True, bias=False)
```

Segmentation happens through `out.reshape([*out.shape[0:2], -1, self.win_len])`. The parameter reads as a leftover from the sibling filterbank models `FBCNet`, `FBMSNet`, where `stride_factor` does drive the reshape.

ignored parameter

```python
from braindecode.models import FBLightConvNet

kw = dict(n_chans=8, n_outputs=3, n_times=1000, sfreq=250)
a = FBLightConvNet(stride_factor=1, **kw)
b = FBLightConvNet(stride_factor=999, **kw)
```

Both models come out with the same architecture, producing bit identical outputs under a fixed seed. Anyone tuning `stride_factor` on this model is tuning nothing. The same knob on `FBCNet` moves `final_layer.in_features` from 576 to 1440.

Crash on short windows

The temporal attention kernel is sized `n_times // win_len`. A window shorter than `win_len` makes that expression 0, the attention weight is allocated with a zero length axis, weight initialisation then divides by a zero fan:

```python
FBLightConvNet(n_chans=8, n_outputs=3, n_times=200, sfreq=250)
```

```
File "braindecode/models/fblightconvnet.py", line 181, in __init__
    self.attn_conv = _LightweightConv1d(
File "braindecode/models/fblightconvnet.py", line 287, in _init_parameters
    nn.init.xavier_uniform_(self.weight)
File "torch/nn/init.py", line 465, in xavier_uniform_
    std = gain * math.sqrt(2.0 / float(fan_in + fan_out))
ZeroDivisionError: division by zero
```

The traceback lands inside `torch/nn/init.py`, giving no hint that `win_len` is the knob to change. Any window under one second at 250 Hz hits this.

fix::

Deprecate `stride_factor`, keeping it in the signature to avoid breaking existing calls. Document `win_len`, including the constraint on `n_times`. Correct the `n_bands` default in the docstring. Raise a `ValueError` naming `n_times` alongside `win_len` when the window is too short.
