### PR TITLE
Add LaBraM TopK SAE prototype

### DIFF
--- a/braindecode/mech-interp/validate_sae_labram_nmt.py
+++ b/braindecode/mech-interp/validate_sae_labram_nmt.py
@@ -1,0 +1,711 @@
+"""Validate the sparse-autoencoder utilities on LaBraM and the NMT corpus.
+
+This follows Lehn-Schioler et al. (arXiv:2605.13930) on public data: fine-tune a
+pretrained EEG transformer on a clinical target, freeze it, fit a Top-K SAE to
+one layer's residual stream, then substitute the reconstruction back in and
+re-measure the task with the model's own head.
+
+LaBraM is used rather than a smaller transformer because its tokens are exact
+non-overlapping one-second patches. That property is what a spectral decoder
+needs later -- it learns ``token embedding -> FFT of the matching raw patch``,
+a target that only exists when tokens are time-aligned. NMT also carries
+``pathological``, ``age`` and ``gender``, three of the paper's five TCAV
+concepts.
+
+Everything imports from ``braindecode.visualization``, so a successful run
+validates the library code rather than a parallel implementation.
+
+The full NMT archive is ~13.4 GB and is downloaded on first use. Pass
+``--data-root`` to point at an existing copy.
+
+Usage
+-----
+    python validate_sae_labram_nmt.py --n-recordings 400
+    python validate_sae_labram_nmt.py --data-root /data/nmt --layer 11
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+
+import numpy as np
+import torch
+from sklearn.metrics import roc_auc_score
+from torch import nn
+from torch.utils.data import DataLoader, Subset
+
+from braindecode.datasets import NMT
+from braindecode.models import Labram
+from braindecode.models.labram import LABRAM_CHANNEL_ORDER
+from braindecode.preprocessing import (
+    Preprocessor,
+    create_fixed_length_windows,
+    preprocess,
+)
+from braindecode.visualization import (
+    SparseAutoencoder,
+    capture_activations,
+    fit_sparse_autoencoder,
+    run_with_activation_substitution,
+    sae_diagnostics,
+)
+
+HF_REPO = "braindecode/labram-pretrained"
+SFREQ = 200
+EMBED_DIM = 200
+
+# NMT stores these names with the older 10-20 convention; LaBraM's 128-name
+# vocabulary only knows the modern ones, so T3/T4/T5/T6 must be renamed or they
+# resolve to no position embedding at all.
+CH_NAMES = [
+    "FP1",
+    "FP2",
+    "F7",
+    "F3",
+    "FZ",
+    "F4",
+    "F8",
+    "T3",
+    "C3",
+    "CZ",
+    "C4",
+    "T4",
+    "T5",
+    "P3",
+    "PZ",
+    "P4",
+    "T6",
+    "O1",
+    "O2",
+]
+RENAME = {"T3": "T7", "T4": "T8", "T5": "P7", "T6": "P8"}
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--data-root",
+        type=Path,
+        default=None,
+        help="directory holding Labels.csv; downloads if omitted",
+    )
+    p.add_argument("--cache", type=Path, default=Path("nmt_windows"))
+    p.add_argument("--n-recordings", type=int, default=400)
+    p.add_argument(
+        "--delete-raw-after-cache",
+        action="store_true",
+        help="delete --data-root once the window cache is written; "
+        "off by default, since it removes your data",
+    )
+    p.add_argument(
+        "--layers",
+        type=int,
+        nargs="+",
+        default=[11],
+        help="blocks to sweep; the fine-tune is shared across them",
+    )
+    p.add_argument(
+        "--ft-ckpt",
+        type=Path,
+        default=Path("labram_nmt_ft.pt"),
+        help="fine-tuned weights; reused when present",
+    )
+    p.add_argument(
+        "--expansions",
+        type=int,
+        nargs="+",
+        default=[8],
+        help="expansion ratios to sweep; k defaults to 8*E per cell",
+    )
+    p.add_argument("--k", type=int, default=None)  # defaults to 8 * expansion
+    p.add_argument("--finetune-epochs", type=int, default=10)
+    p.add_argument("--freeze-epochs", type=int, default=2)
+    p.add_argument("--sae-epochs", type=int, default=20)
+    p.add_argument(
+        "--sae-log-every",
+        type=int,
+        default=5,
+        help="print SAE loss/dead every N epochs; 0 to silence",
+    )
+    p.add_argument("--batch-size", type=int, default=16)
+    p.add_argument("--head-lr", type=float, default=1e-3)
+    p.add_argument("--full-lr", type=float, default=1e-4)
+    p.add_argument("--max-sae-tokens", type=int, default=2_000_000)
+    p.add_argument("--min-valid-auroc", type=float, default=0.75)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument(
+        "--resample-steps",
+        type=int,
+        nargs="+",
+        default=[500],
+        help="resampling intervals to sweep, in optimizer steps",
+    )
+    p.add_argument("--out", type=Path, default=Path("sae_labram_nmt_results.json"))
+    return p.parse_args()
+
+
+def _corpus_root(dataset):
+    """Directory holding the extracted recordings, from a recording path.
+
+    ``NMT`` picks its own download location, so the corpus root is only
+    discoverable after loading. Returns ``None`` if the layout is unfamiliar,
+    in which case nothing is deleted.
+    """
+    paths = dataset.description["path"]
+    if paths.empty:
+        return None
+    for parent in Path(paths.iloc[0]).parents:
+        if parent.name == "nmt_scalp_eeg_dataset":
+            return parent
+    return None
+
+
+def build_windows(args):
+    """Load NMT, preprocess to LaBraM's format, cut 15 s windows."""
+    from braindecode.datautil import load_concat_dataset
+
+    if args.cache.exists():
+        windows = load_concat_dataset(str(args.cache), preload=False)
+        print(f"loaded {len(windows)} windows from {args.cache}")
+        return windows
+
+    path = str(args.data_root) if args.data_root else None
+    if path is None:
+        print(
+            "downloading NMT (~13.4 GB archive, plus the same again "
+            "unzipped); pass --data-root to reuse an existing copy"
+        )
+    dataset = NMT(
+        path=path,
+        target_name="pathological",
+        recording_ids=list(range(args.n_recordings)),
+        preload=False,
+        n_jobs=1,
+    )
+    print(f"{len(dataset.datasets)} recordings loaded")
+
+    # NMT resolves the download location itself, so recover the corpus root
+    # from a recording path rather than assuming where it landed. Without this
+    # --delete-raw-after-cache could only clean up an explicit --data-root.
+    raw_root = _corpus_root(dataset)
+
+    # LaBraM's temporal embedding holds 16 positions, so 15 one-second patches
+    # is the longest window that needs no interpolation of the checkpoint.
+    window_samples = 15 * SFREQ
+    want = set(CH_NAMES)
+    keep = [
+        i
+        for i, d in enumerate(dataset.datasets)
+        if want.issubset(set(d.raw.ch_names))
+        and (d.raw.n_times - 1) / d.raw.info["sfreq"] >= 75
+    ]
+    if not keep:
+        raise SystemExit("no recording has the full 19-channel montage")
+    dataset = dataset.split(keep)["0"]
+    print(f"{len(dataset.datasets)} recordings have the full montage")
+
+    def crop_from(raw, tmin=60.0):
+        end = (raw.n_times - 1) / raw.info["sfreq"]
+        raw.crop(tmin=tmin, tmax=end, include_tmax=False)
+
+    preprocessors = [
+        Preprocessor(crop_from, tmin=60.0, apply_on_array=False),
+        # Pick before referencing so the average is not polluted by channels
+        # that are about to be dropped.
+        Preprocessor("pick_channels", ch_names=CH_NAMES, ordered=True),
+        Preprocessor("rename_channels", mapping=RENAME),
+        Preprocessor("set_eeg_reference", ref_channels="average", ch_type="eeg"),
+        Preprocessor(lambda d: d * 1e6, apply_on_array=True),  # V -> uV
+        Preprocessor(lambda x: np.clip(x, -800, 800), apply_on_array=True),
+        Preprocessor("resample", sfreq=SFREQ),
+    ]
+    # save_dir serialises each recording and reloads it lazily. Without it
+    # preprocess() holds every recording in memory at once -- MNE works in
+    # float64, so 400 recordings is tens of gigabytes of RAM.
+    pp_dir = args.cache.parent / f"{args.cache.name}_pp"
+    processed = preprocess(
+        dataset, preprocessors, n_jobs=1, save_dir=str(pp_dir), overwrite=True
+    )
+    windows = create_fixed_length_windows(
+        processed,
+        window_size_samples=window_samples,
+        window_stride_samples=window_samples,
+        drop_last_window=True,
+        n_jobs=1,
+    )
+    windows.save(str(args.cache), overwrite=True)
+    print(f"cached {len(windows)} windows to {args.cache}")
+
+    # Reload from the cache before touching anything on disk: the in-memory
+    # object still reads the preprocessed files lazily.
+    import shutil
+
+    del processed, dataset, windows
+    windows = load_concat_dataset(str(args.cache), preload=False)
+
+    # The preprocessed copy is an intermediate; the window cache is what later
+    # runs read, so it always goes.
+    shutil.rmtree(pp_dir, ignore_errors=True)
+    print(f"removed intermediate copy: {pp_dir}")
+
+    if args.delete_raw_after_cache and raw_root is not None:
+        shutil.rmtree(raw_root, ignore_errors=True)
+        print(f"removed raw recordings: {raw_root}")
+        # A downloaded run also leaves the archive behind, which is the larger
+        # of the two.
+        for archive in raw_root.parent.glob("NMT.zip*"):
+            size_gb = archive.stat().st_size / 1024**3
+            archive.unlink()
+            print(f"removed archive: {archive} ({size_gb:.1f} GB)")
+    return windows
+
+
+def channel_names(windows):
+    d0 = windows.datasets[0]
+    return d0.windows.ch_names if hasattr(d0, "windows") else d0.raw.ch_names
+
+
+def resolve_input_chans(ch_names):
+    """Indices into ``position_embedding``: 0 is [CLS], 1..128 the channels."""
+    canonical = {name.upper(): i for i, name in enumerate(LABRAM_CHANNEL_ORDER)}
+    missing = [c for c in ch_names if c.upper() not in canonical]
+    if missing:
+        raise SystemExit(f"not in LaBraM's vocabulary: {missing}")
+    idx = [0] + [canonical[c.upper()] + 1 for c in ch_names]
+    return torch.tensor(idx, dtype=torch.long)
+
+
+class LabramBinary(nn.Module):
+    """LaBraM with a scalar head on mean-pooled patch tokens."""
+
+    def __init__(self, encoder, input_chans):
+        super().__init__()
+        self.encoder = encoder
+        self.register_buffer("input_chans", input_chans)
+        self.head = nn.Linear(EMBED_DIM, 1)
+
+    def features(self, x):
+        tokens = self.encoder.forward_features(
+            x, input_chans=self.input_chans, return_all_tokens=True
+        )
+        return tokens[:, 1:, :].mean(dim=1)  # strip CLS, mean over channel x time
+
+    def forward(self, x):
+        return self.head(self.features(x)).squeeze(-1)
+
+
+def window_labels(windows):
+    """Labels without touching signal data; indexing a lazy dataset hits disk."""
+    return np.concatenate([np.asarray(d.y) for d in windows.datasets])
+
+
+def recording_of_window(windows):
+    sizes = [len(d) for d in windows.datasets]
+    return np.repeat(np.arange(len(sizes)), sizes)
+
+
+def stratified_group_split(groups, labels, seed, test_frac=0.2, valid_frac=0.2):
+    """Split by recording, stratified by label.
+
+    Grouping alone is not enough: an unstratified permutation lets the class
+    balance drift, and a validation set that holds one positive recording
+    reports how well the model recognises that recording rather than how well
+    it generalises.
+    """
+    rng = np.random.default_rng(seed)
+    rec_ids = np.unique(groups)
+    rec_label = np.array([labels[groups == r][0] for r in rec_ids])
+
+    train, valid, test = [], [], []
+    for cls in np.unique(rec_label):
+        cls_recs = rng.permutation(rec_ids[rec_label == cls])
+        n_test = max(1, int(round(test_frac * len(cls_recs))))
+        rest = cls_recs[n_test:]
+        n_valid = max(1, int(round(valid_frac * len(rest))))
+        test.extend(cls_recs[:n_test])
+        valid.extend(rest[:n_valid])
+        train.extend(rest[n_valid:])
+
+    parts = {
+        k: np.array(v) for k, v in (("train", train), ("valid", valid), ("test", test))
+    }
+    for a, b in (("train", "valid"), ("train", "test"), ("valid", "test")):
+        assert not (set(parts[a]) & set(parts[b])), f"{a}/{b} share a recording"
+    idx = {k: np.flatnonzero(np.isin(groups, v)) for k, v in parts.items()}
+    return idx, parts
+
+
+def measure_scale(windows, ids, n=64):
+    """Signal scale, estimated on the training split only."""
+    sample = torch.stack(
+        [torch.as_tensor(windows[i][0]) for i in ids[: min(n, len(ids))]]
+    ).float()
+    return float(np.percentile(np.abs(sample.numpy()), 99))
+
+
+@torch.no_grad()
+def evaluate(model, loader, device, groups=None):
+    """Window-level AUROC, plus recording level when groups are given."""
+    model.eval()
+    logits, ys = [], []
+    for batch in loader:
+        logits.append(model(batch[0].float().to(device)).cpu())
+        ys.append(batch[1])
+    model.train()
+    logits = torch.cat(logits).numpy()
+    ys = torch.cat(ys).numpy().astype(int)
+
+    window = roc_auc_score(ys, logits)
+    recording = float("nan")
+    if groups is not None:
+        recs = np.unique(groups)
+        scores = np.array([logits[groups == r].mean() for r in recs])
+        labels = np.array([ys[groups == r][0] for r in recs])
+        if len(np.unique(labels)) > 1:
+            recording = roc_auc_score(labels, scores)
+    return window, recording
+
+
+def finetune(model, loaders, groups, idx, args, device, pos_weight):
+    """Two-phase fine-tune, with selection restarting at the unfreeze boundary.
+
+    Head-phase validation scores are not comparable to full-model ones:
+    unfreezing raises the loss briefly while the encoder adapts. Letting a
+    lucky head-phase epoch win the comparison leaves the encoder at its
+    pretrained weights while the run reports itself as fine-tuned.
+    """
+    torch.manual_seed(args.seed)
+    loss_fn = nn.BCEWithLogitsLoss(pos_weight=pos_weight)
+    for p in model.encoder.parameters():
+        p.requires_grad = False
+    opt = torch.optim.AdamW(model.head.parameters(), lr=args.head_lr, weight_decay=0.01)
+
+    best, best_state, history = -1.0, None, []
+    for epoch in range(1, args.finetune_epochs + 1):
+        if epoch == args.freeze_epochs + 1:
+            for p in model.encoder.parameters():
+                p.requires_grad = True
+            opt = torch.optim.AdamW(
+                model.parameters(), lr=args.full_lr, weight_decay=0.05
+            )
+            best, best_state = -1.0, None
+            print(f"--- epoch {epoch}: encoder unfrozen, selection restarted ---")
+
+        model.train()
+        total = 0.0
+        for bi, batch in enumerate(loaders["train"]):
+            x, y = batch[0], batch[1]
+            loss = loss_fn(model(x.float().to(device)), y.float().to(device))
+            opt.zero_grad()
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            opt.step()
+            total += float(loss.detach())
+            if bi % 100 == 0:
+                print(
+                    f"  epoch {epoch:2d} batch {bi}/{len(loaders['train'])}", flush=True
+                )
+
+        win, rec = evaluate(model, loaders["valid"], device, groups[idx["valid"]])
+        phase = "head" if epoch <= args.freeze_epochs else "full"
+        history.append(
+            {
+                "epoch": epoch,
+                "phase": phase,
+                "loss": total / len(loaders["train"]),
+                "valid_window_auroc": win,
+                "valid_recording_auroc": rec,
+            }
+        )
+        print(
+            f"epoch {epoch:2d} [{phase}]  loss={total / len(loaders['train']):.4f}"
+            f"  valid_window={win:.4f}  valid_recording={rec:.4f}"
+        )
+
+        # Select on the recording-level score: the label is a property of the
+        # recording, not of any single 15 s window.
+        score = rec if not np.isnan(rec) else win
+        if score > best:
+            best = score
+            best_state = copy.deepcopy(
+                {k: v.cpu() for k, v in model.state_dict().items()}
+            )
+
+    model.load_state_dict(best_state)
+    return model.to(device), best, history
+
+
+@torch.no_grad()
+def collect_activations(model, loader, layer, device, max_tokens):
+    model.eval()
+    chunks, total = [], 0
+    for batch in loader:
+        captured = capture_activations(
+            model,
+            batch[0].float().to(device),
+            {"layer": layer},
+            forward_fn=model.features,
+        )
+        # Every token, CLS included. The dictionary has to cover whatever the
+        # substitution hook will later feed it, and that hook replaces the
+        # whole block output; training on a subset would leave the CLS token
+        # reconstructed by features that never saw one.
+        acts = captured["layer"]
+        flat = acts.reshape(-1, acts.shape[-1]).cpu()
+        chunks.append(flat)
+        total += flat.shape[0]
+        if total >= max_tokens:
+            break
+    return torch.cat(chunks)[:max_tokens]
+
+
+def substitution_auroc(model, loader, layer, sae, device, groups):
+    """AUROC with the layer replaced by its SAE reconstruction.
+
+    The fine-tuned head is reused unchanged. Refitting a probe under each
+    condition would let it re-adapt to whatever the SAE destroyed.
+    """
+    model.eval()
+    logits, ys = [], []
+    with torch.no_grad():
+        for batch in loader:
+            out = run_with_activation_substitution(
+                model,
+                batch[0].float().to(device),
+                layer,
+                lambda o: sae.reconstruct_activations(o),
+            )
+            logits.append(out.cpu())
+            ys.append(batch[1])
+    logits = torch.cat(logits).numpy()
+    ys = torch.cat(ys).numpy().astype(int)
+    window = roc_auc_score(ys, logits)
+    recs = np.unique(groups)
+    scores = np.array([logits[groups == r].mean() for r in recs])
+    labels = np.array([ys[groups == r][0] for r in recs])
+    recording = float("nan")
+    if len(np.unique(labels)) > 1:
+        recording = roc_auc_score(labels, scores)
+    return window, recording
+
+
+def main():
+    args = parse_args()
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    torch.manual_seed(args.seed)
+    print(f"device: {device}")
+
+    windows = build_windows(args)
+    ch_names = channel_names(windows)
+    groups = recording_of_window(windows)
+    labels = window_labels(windows)
+    idx, parts = stratified_group_split(groups, labels, args.seed)
+
+    loaders = {
+        name: DataLoader(
+            Subset(windows, ids), batch_size=args.batch_size, shuffle=(name == "train")
+        )
+        for name, ids in idx.items()
+    }
+    for name in ("train", "valid", "test"):
+        print(
+            f"{name:5s}: {len(parts[name]):3d} recordings, {len(idx[name]):6d} "
+            f"windows, {labels[idx[name]].mean():.1%} pathological"
+        )
+
+    p99 = measure_scale(windows, idx["train"])
+    print(f"\ntrain-split |x| p99 = {p99:.3f} uV")
+
+    input_chans = resolve_input_chans(ch_names).to(device)
+    encoder = Labram.from_pretrained(HF_REPO)
+    model = LabramBinary(encoder, input_chans).to(device)
+    n_patches = int(encoder.patch_embed[0].n_patchs)
+    print(
+        f"encoder: {n_patches} patches x {len(ch_names)} channels = "
+        f"{n_patches * len(ch_names)} tokens/window"
+    )
+
+    y_train = labels[idx["train"]]
+    pos_weight = torch.tensor(
+        (len(y_train) - y_train.sum()) / max(y_train.sum(), 1), dtype=torch.float32
+    ).to(device)
+    print(f"pos_weight: {pos_weight.item():.2f}\n")
+
+    # Fine-tuning is the expensive stage and is identical for every layer, so
+    # a sweep reuses one checkpoint rather than repeating it per layer.
+    if args.ft_ckpt.exists():
+        state = torch.load(args.ft_ckpt, map_location="cpu")
+        model.load_state_dict(state["state_dict"])
+        model = model.to(device)
+        best_valid, history = state["best_valid"], state["history"]
+        print(
+            f"loaded fine-tuned weights from {args.ft_ckpt} "
+            f"(valid recording AUROC {best_valid:.4f})"
+        )
+    else:
+        model, best_valid, history = finetune(
+            model, loaders, groups, idx, args, device, pos_weight
+        )
+        torch.save(
+            {
+                "state_dict": {k: v.cpu() for k, v in model.state_dict().items()},
+                "best_valid": best_valid,
+                "history": history,
+                "channels": ch_names,
+            },
+            args.ft_ckpt,
+        )
+        print(f"saved fine-tuned weights to {args.ft_ckpt}")
+    print(f"\nbest validation recording AUROC: {best_valid:.4f}")
+
+    # The gate reads validation and actually stops. Nothing about a model that
+    # cannot do the task is worth interpreting.
+    if best_valid < args.min_valid_auroc:
+        print(
+            f"BELOW GATE ({best_valid:.4f} < {args.min_valid_auroc:.2f}); "
+            "stopping before the SAE stage."
+        )
+        raise SystemExit(1)
+
+    results = {
+        "best_valid_recording_auroc": best_valid,
+        "finetune": history,
+        "splits": {k_: sorted(v.tolist()) for k_, v in parts.items()},
+        "cells": {},
+    }
+
+    def write_results():
+        """Persist after every cell so a crash costs one cell, not the sweep."""
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(results, indent=2, default=str))
+
+    n_cells = len(args.layers) * len(args.expansions) * len(args.resample_steps)
+    done = 0
+    bar = "=" * 62
+
+    for layer_idx in args.layers:
+        layer = model.encoder.blocks[layer_idx]
+
+        # Activations depend only on the layer, so they are collected once and
+        # reused for every (expansion, resample interval) cell at that layer.
+        # Re-extracting them per cell would dominate the runtime of the sweep.
+        train_acts = collect_activations(
+            model, loaders["train"], layer, device, args.max_sae_tokens
+        )
+        baselines = {
+            name: evaluate(model, loaders[name], device, groups[idx[name]])
+            for name in ("valid", "test")
+        }
+
+        for expansion in args.expansions:
+            for resample_steps in args.resample_steps:
+                done += 1
+                k = args.k if args.k is not None else 8 * expansion
+                n_feat = EMBED_DIM * expansion
+                cell = f"layer{layer_idx}_e{expansion}_r{resample_steps}"
+                print(f"\n{bar}\n[{done}/{n_cells}] {cell}\n{bar}", flush=True)
+                print(
+                    f"activations {tuple(train_acts.shape)} -> SAE "
+                    f"{EMBED_DIM} -> {n_feat}, k={k} "
+                    f"({len(train_acts) / n_feat:.0f} tokens/feature)"
+                )
+
+                # fit_sparse_autoencoder trains wherever the activations live,
+                # and two million rows of 200 floats is only ~1.6 GB, so move
+                # them to the GPU rather than training on CPU.
+                sae, sae_history = fit_sparse_autoencoder(
+                    train_acts.to(device),
+                    expansion=expansion,
+                    k=k,
+                    epochs=args.sae_epochs,
+                    batch_size=2048,
+                    lr=1e-3,
+                    seed=args.seed,
+                    verbose=args.sae_log_every,
+                    resample_steps=resample_steps,
+                )
+                sae = sae.to(device)
+                diagnostics = sae_diagnostics(sae, train_acts)
+                print(
+                    f"SAE loss {sae_history['loss'][-1]:.4f}  diagnostics {diagnostics}"
+                )
+
+                # A randomly initialised SAE with the same shape and
+                # normalisation is the control. If substituting it does not
+                # hurt, the measurement is insensitive and a small drop for
+                # the trained SAE means nothing.
+                random_sae = SparseAutoencoder.from_config(sae.get_config()).to(device)
+                random_sae.set_activation_normalization(
+                    sae.activation_mean, sae.activation_std
+                )
+
+                entry = {
+                    "layer": layer_idx,
+                    "expansion": expansion,
+                    "k": k,
+                    "n_features": n_feat,
+                    "resample_steps": resample_steps,
+                    "diagnostics": diagnostics,
+                    "tokens_per_feature": len(train_acts) / n_feat,
+                    "sae_loss": sae_history["loss"],
+                    "sae_dead": sae_history["dead"],
+                    "sae_resampled": sae_history["resampled"],
+                }
+                for name in ("valid", "test"):
+                    g = groups[idx[name]]
+                    b_win, b_rec = baselines[name]
+                    s_win, s_rec = substitution_auroc(
+                        model, loaders[name], layer, sae, device, g
+                    )
+                    r_win, r_rec = substitution_auroc(
+                        model, loaders[name], layer, random_sae, device, g
+                    )
+                    entry[name] = {
+                        "baseline": {"window": b_win, "recording": b_rec},
+                        "sae": {"window": s_win, "recording": s_rec},
+                        "random_sae": {"window": r_win, "recording": r_rec},
+                        "delta": {"window": b_win - s_win, "recording": b_rec - s_rec},
+                    }
+                    print(
+                        f"  {name:5s} baseline {b_rec:.4f}  SAE {s_rec:.4f}  "
+                        f"delta {b_rec - s_rec:+.4f}  random {r_rec:.4f}"
+                    )
+
+                results["cells"][cell] = entry
+                write_results()
+                del sae, random_sae
+                if device == "cuda":
+                    torch.cuda.empty_cache()
+
+        del train_acts
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    header = (
+        f"\n{'layer':>5} {'E':>3} {'resample':>9} {'dead':>7} "
+        f"{'alive':>6} {'R2':>8} {'dWin':>8} {'rand':>7}"
+    )
+    print(header)
+    for entry in results["cells"].values():
+        g = entry["diagnostics"]
+        print(
+            f"{entry['layer']:>5} {entry['expansion']:>3} "
+            f"{entry['resample_steps']:>9} {g['dead']:>6.2%} "
+            f"{entry['n_features'] * (1 - g['dead']):>6.0f} {g['r2']:>8.4f} "
+            f"{entry['test']['delta']['window']:>+8.4f} "
+            f"{entry['test']['random_sae']['window']:>7.4f}"
+        )
+
+    write_results()
+    print(f"\nwrote {args.out}")
+    print(
+        "Test-set window AUROC. A small delta only counts as evidence "
+        "where the random column is clearly worse."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/braindecode/visualization/__init__.py
+++ b/braindecode/visualization/__init__.py
@@ -20,19 +20,31 @@ from .metrics import (
     compute_metrics,
     compute_ssim_metrics,
 )
+from .sae import (
+    SparseAutoencoder,
+    capture_activations,
+    fit_sparse_autoencoder,
+    grouped_train_valid_test_split,
+    run_with_activation_substitution,
+    sae_diagnostics,
+)
 from .sanity import cascading_layer_reset, random_target
 from .topology import project_to_topomap
 
 __all__ = [
     "METRIC_NAMES",
     "SSIM_METRIC_NAMES",
+    "SparseAutoencoder",
     "amplitude_gradients",
     "amplitude_gradients_per_trial",
+    "capture_activations",
     "cascading_layer_reset",
     "compute_metrics",
     "compute_ssim_metrics",
     "deconvolution",
     "deep_lift",
+    "fit_sparse_autoencoder",
+    "grouped_train_valid_test_split",
     "guided_backprop",
     "input_x_gradient",
     "integrated_gradients",
@@ -41,5 +53,7 @@ __all__ = [
     "plot_confusion_matrix",
     "project_to_topomap",
     "random_target",
+    "run_with_activation_substitution",
+    "sae_diagnostics",
     "saliency",
 ]

--- a/braindecode/visualization/sae.py
+++ b/braindecode/visualization/sae.py
@@ -1,0 +1,898 @@
+# Authors: Vandit Shah <shahvanditt@gmail.com>
+#
+# License: BSD (3-clause)
+
+"""Sparse autoencoders over model activations.
+
+Implements the Top-K sparse autoencoder of Gao et al. (2024) together with
+the activation-capture and activation-substitution primitives needed to fit
+one to a layer of a trained model and then measure whether the resulting
+dictionary is faithful to what the model actually computes.
+
+A Top-K autoencoder decomposes an activation vector into a sparse
+combination of learned directions. Sparsity is structural rather than
+penalised: the encoder keeps only its ``k`` largest rectified outputs, so
+the number of active features per input is exactly known instead of being
+traded off against reconstruction error through an L1 coefficient.
+
+Applied to EEG foundation models by Lehn-Schioeler et al. (2026), who fit
+one autoencoder per transformer block and read the resulting features as
+candidate clinical concepts.
+
+References
+----------
+.. [Gao2024] Gao, L., la Tour, T. D., Tillman, H., Goh, G., Troll, R.,
+   Radford, A., Sutskever, I., Leike, J., & Wu, J. (2024). Scaling and
+   evaluating sparse autoencoders. arXiv:2406.04093.
+.. [LehnSchioeler2026] Lehn-Schioeler, W., Kjaer, M. R., Thapa, R., et al.
+   (2026). Mechanistic interpretability of EEG foundation models via sparse
+   autoencoders. arXiv:2605.13930.
+"""
+
+from collections.abc import Mapping
+from copy import deepcopy
+from warnings import warn
+
+import numpy as np
+import torch
+from torch import nn
+
+
+def _flatten_features(x, n_inputs):
+    """Collapse leading dimensions of ``x`` so the feature axis is last."""
+    if x.ndim == 1:
+        x = x.unsqueeze(0)
+    if x.shape[-1] != n_inputs:
+        raise ValueError(f"expected last dimension {n_inputs}, got {x.shape[-1]}")
+    leading_shape = x.shape[:-1]
+    return x.reshape(-1, n_inputs), leading_shape
+
+
+def _reshape_features(x, leading_shape):
+    """Restore the leading dimensions removed by :func:`_flatten_features`."""
+    return x.reshape(*leading_shape, x.shape[-1])
+
+
+def _detach_output(output):
+    """Detach every tensor in a possibly nested module output."""
+    if torch.is_tensor(output):
+        return output.detach()
+    if isinstance(output, tuple):
+        return tuple(_detach_output(item) for item in output)
+    if isinstance(output, list):
+        return [_detach_output(item) for item in output]
+    if isinstance(output, dict):
+        return {key: _detach_output(value) for key, value in output.items()}
+    return deepcopy(output)
+
+
+def _as_module_items(layers):
+    """Return ``(key, module)`` pairs from either a mapping or a sequence."""
+    if isinstance(layers, Mapping):
+        return list(layers.items())
+    return list(enumerate(layers))
+
+
+class SparseAutoencoder(nn.Module):
+    """Top-K sparse autoencoder over activation vectors.
+
+    Encodes an activation into ``n_inputs * expansion`` features, keeps only
+    the ``k`` largest, and decodes back. Sparsity is imposed by the top-k
+    mask rather than by an L1 penalty, so the number of active features per
+    input is exactly ``k`` whenever at least ``k`` encoder outputs are
+    positive [Gao2024]_.
+
+    Decoder columns are held at unit norm. Without that constraint the
+    reconstruction can be made arbitrarily good by shrinking the latent code
+    and growing the decoder, which leaves the feature magnitudes
+    uninterpretable.
+
+    Parameters
+    ----------
+    n_inputs : int
+        Width of the activation vectors, i.e. the model's embedding
+        dimension at the layer being decomposed.
+    expansion : int, default=8
+        Dictionary size relative to ``n_inputs``. The autoencoder learns
+        ``n_inputs * expansion`` features.
+    k : int or None, default=None
+        Number of active features per input. Defaults to ``8 * expansion``,
+        which holds the active fraction ``k / n_features`` constant as the
+        dictionary grows.
+
+    Raises
+    ------
+    ValueError
+        If ``k`` is outside ``[1, n_inputs * expansion]``.
+
+    Notes
+    -----
+    ``activation_mean`` and ``activation_std`` are registered buffers, so
+    the normalisation used at fit time survives a ``state_dict`` round trip.
+    They default to zero and one, making normalisation a no-op unless
+    :meth:`set_activation_normalization` is called.
+
+    References
+    ----------
+    .. [Gao2024] Gao, L., la Tour, T. D., Tillman, H., Goh, G., Troll, R.,
+       Radford, A., Sutskever, I., Leike, J., & Wu, J. (2024). Scaling and
+       evaluating sparse autoencoders. arXiv:2406.04093.
+    """
+
+    def __init__(self, n_inputs, expansion=8, k=None):
+        super().__init__()
+        self.n_inputs = int(n_inputs)
+        self.expansion = int(expansion)
+        self.n_features = self.n_inputs * self.expansion
+        self.k = int(k) if k is not None else min(self.n_features, 8 * self.expansion)
+        if not 1 <= self.k <= self.n_features:
+            raise ValueError(
+                "k must be between 1 and n_inputs * expansion "
+                f"({self.n_features}), got {self.k}"
+            )
+        if self.k == self.n_features:
+            warn(
+                "k equals n_inputs * expansion, so the autoencoder is dense. "
+                "Use a smaller k for sparse features.",
+                UserWarning,
+            )
+        self.encoder = nn.Linear(self.n_inputs, self.n_features)
+        self.decoder = nn.Linear(self.n_features, self.n_inputs)
+        self.register_buffer("activation_mean", torch.zeros(self.n_inputs))
+        self.register_buffer("activation_std", torch.ones(self.n_inputs))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        """Re-initialise encoder and decoder, then renormalise the decoder."""
+        self.encoder.reset_parameters()
+        self.decoder.reset_parameters()
+        self.normalize_decoder_()
+
+    def get_config(self):
+        """Return the constructor arguments needed to rebuild this module.
+
+        Returns
+        -------
+        dict
+            Keyword arguments accepted by :meth:`from_config`.
+        """
+        return dict(n_inputs=self.n_inputs, expansion=self.expansion, k=self.k)
+
+    @classmethod
+    def from_config(cls, config):
+        """Rebuild an autoencoder from a :meth:`get_config` dictionary.
+
+        Parameters
+        ----------
+        config : dict
+            Configuration as returned by :meth:`get_config`.
+
+        Returns
+        -------
+        SparseAutoencoder
+            A new instance with freshly initialised weights. Load a
+            ``state_dict`` into it to restore trained parameters.
+        """
+        return cls(**config)
+
+    def encode(self, x):
+        """Encode activations into a sparse feature code.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Activations of shape ``(..., n_inputs)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Feature code of shape ``(..., n_features)`` with at most ``k``
+            non-zero entries per row.
+        """
+        flat, leading_shape = _flatten_features(x, self.n_inputs)
+        # Rectify before the top-k mask, matching the reference implementation
+        # of [LehnSchioeler2026]_. This binds only when fewer than k encoder
+        # outputs are positive; above that the same k features are selected
+        # either way.
+        hidden = torch.relu(self.encoder(flat))
+        if self.k < hidden.shape[-1]:
+            values, indices = torch.topk(hidden, self.k, dim=-1)
+            masked = torch.zeros_like(hidden)
+            masked.scatter_(dim=-1, index=indices, src=values)
+            hidden = masked
+        return _reshape_features(hidden, leading_shape)
+
+    def decode(self, z):
+        """Decode a sparse feature code back to activation space.
+
+        Parameters
+        ----------
+        z : torch.Tensor
+            Feature code of shape ``(..., n_features)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Reconstructed activations of shape ``(..., n_inputs)``.
+        """
+        flat, leading_shape = _flatten_features(z, self.n_features)
+        recon = self.decoder(flat)
+        return _reshape_features(recon, leading_shape)
+
+    def forward(self, x):
+        """Encode and decode ``x``.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Activations of shape ``(..., n_inputs)``.
+
+        Returns
+        -------
+        recon : torch.Tensor
+            Reconstruction of shape ``(..., n_inputs)``.
+        latent : torch.Tensor
+            Sparse feature code of shape ``(..., n_features)``.
+        """
+        latent = self.encode(x)
+        recon = self.decode(latent)
+        return recon, latent
+
+    def normalize_decoder_(self, eps=1e-12):
+        """Rescale decoder columns to unit norm, in place.
+
+        Parameters
+        ----------
+        eps : float, default=1e-12
+            Lower bound on a column norm before division.
+
+        Returns
+        -------
+        SparseAutoencoder
+            ``self``, so the call can be chained.
+        """
+        with torch.no_grad():
+            weight = self.decoder.weight
+            norms = weight.norm(dim=0, keepdim=True).clamp_min(eps)
+            weight.div_(norms)
+        return self
+
+    def set_activation_normalization(self, mean, std, eps=1e-6):
+        """Store the per-dimension statistics used to normalise activations.
+
+        Parameters
+        ----------
+        mean : array-like
+            Per-dimension mean, of shape ``(n_inputs,)``.
+        std : array-like
+            Per-dimension standard deviation, of shape ``(n_inputs,)``.
+        eps : float, default=1e-6
+            Lower bound applied to ``std`` before storing it.
+
+        Returns
+        -------
+        SparseAutoencoder
+            ``self``, so the call can be chained.
+
+        Raises
+        ------
+        ValueError
+            If ``mean`` or ``std`` does not have shape ``(n_inputs,)``.
+        """
+        mean = torch.as_tensor(mean, dtype=self.activation_mean.dtype)
+        std = torch.as_tensor(std, dtype=self.activation_std.dtype)
+        if mean.shape != (self.n_inputs,) or std.shape != (self.n_inputs,):
+            raise ValueError(
+                "mean and std must both have shape "
+                f"({self.n_inputs},), got {tuple(mean.shape)} and {tuple(std.shape)}"
+            )
+        with torch.no_grad():
+            self.activation_mean.copy_(mean.to(self.activation_mean.device))
+            self.activation_std.copy_(std.clamp_min(eps).to(self.activation_std.device))
+        return self
+
+    def normalize_activations(self, x):
+        """Standardise raw activations with the stored statistics.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Raw activations of shape ``(..., n_inputs)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Standardised activations of the same shape.
+        """
+        return (x - self.activation_mean) / self.activation_std
+
+    def denormalize_activations(self, x):
+        """Invert :meth:`normalize_activations`.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Standardised activations of shape ``(..., n_inputs)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Activations back on the original scale.
+        """
+        return x * self.activation_std + self.activation_mean
+
+    def reconstruct_activations(self, x):
+        """Reconstruct raw activations, normalising and inverting internally.
+
+        This is the form needed by :func:`run_with_activation_substitution`,
+        which sees a layer's output on its original scale.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Raw activations of shape ``(..., n_inputs)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Reconstruction on the original scale, same shape as ``x``.
+        """
+        normalized = self.normalize_activations(x)
+        recon, _ = self(normalized)
+        return self.denormalize_activations(recon)
+
+    def resample_dead_features(
+        self, activations, dead_features, optimizer=None, seed=None
+    ):
+        """Point dead features at inputs the dictionary reconstructs poorly.
+
+        Features that stop firing contribute nothing and cannot recover on
+        their own, since they receive no gradient. Following Anthropic's
+        recipe, each is reassigned to a direction drawn from the activation
+        set with probability proportional to squared reconstruction error,
+        so a revived feature has something unexplained to claim.
+
+        Parameters
+        ----------
+        activations : torch.Tensor
+            Activations to draw replacement directions from, shape
+            ``(..., n_inputs)``. These should already be normalised if the
+            autoencoder was fitted on normalised activations.
+        dead_features : torch.Tensor
+            Either a boolean mask of length ``n_features`` or an integer
+            tensor of feature indices.
+        optimizer : torch.optim.Optimizer or None, default=None
+            If given, the optimizer state for the resampled rows is cleared.
+            Only those rows are touched; a global reset discards momentum
+            belonging to features that are training normally.
+        seed : int or None, default=None
+            Seed for the sampling, for reproducibility.
+
+        Returns
+        -------
+        int
+            Number of features resampled.
+
+        Raises
+        ------
+        ValueError
+            If the boolean mask has the wrong length, or if every feature is
+            marked dead so there is no live encoder norm to scale against.
+        """
+        flat, _ = _flatten_features(torch.as_tensor(activations), self.n_inputs)
+        dead = torch.as_tensor(dead_features, device=flat.device)
+        if dead.dtype == torch.bool:
+            if dead.numel() != self.n_features:
+                raise ValueError("boolean dead_features mask has wrong length")
+            dead_idx = dead.nonzero(as_tuple=False).flatten()
+        else:
+            dead_idx = dead.to(dtype=torch.long).flatten()
+        if dead_idx.numel() == 0:
+            return 0
+
+        alive_idx = torch.ones(self.n_features, dtype=torch.bool, device=flat.device)
+        alive_idx[dead_idx] = False
+        if not bool(alive_idx.any()):
+            raise ValueError("cannot resample when all features are dead")
+        alive_norm = self.encoder.weight[alive_idx].norm(dim=1).mean()
+
+        generator = None
+        if seed is not None:
+            generator = torch.Generator(device=flat.device)
+            generator.manual_seed(int(seed))
+
+        # Draw replacement directions in proportion to squared reconstruction
+        # error, not uniformly. A revived feature only survives if it has
+        # something unexplained to claim: pointed at an input the live features
+        # already reconstruct, it loses the top-k competition immediately, goes
+        # dead, and is resampled again, so the dictionary churns indefinitely
+        # instead of settling.
+        n_candidates = min(flat.shape[0], 8192)
+        candidate_idx = torch.randint(
+            0,
+            flat.shape[0],
+            (n_candidates,),
+            generator=generator,
+            device=flat.device,
+        )
+        candidates = flat[candidate_idx]
+        with torch.no_grad():
+            recon, _ = self(candidates)
+        err = (candidates - recon).pow(2).sum(dim=-1)
+        if float(err.sum()) <= 0.0:
+            # Nothing left to explain; fall back to a uniform draw.
+            err = torch.ones_like(err)
+        picks = torch.multinomial(
+            err / err.sum(), dead_idx.numel(), replacement=True, generator=generator
+        )
+        samples = candidates[picks]
+        sample_norm = samples.norm(dim=1, keepdim=True).clamp_min(1e-12)
+        directions = samples / sample_norm
+
+        # Break ties between features that drew the same row. Sampling is with
+        # replacement and concentrated on a few high-error rows, so duplicates
+        # are common; identical directions plus a zeroed bias and optimizer
+        # state make the gradients identical too, and the pair stays welded
+        # together for the rest of training as one feature in two slots.
+        noise = torch.randn(
+            directions.shape, generator=generator, device=directions.device
+        )
+        directions = directions + 1e-3 * noise
+        directions = directions / directions.norm(dim=1, keepdim=True).clamp_min(1e-12)
+
+        # Revived encoder rows are scaled well below the live norm. Given the
+        # full norm they would win the top-k competition immediately on the
+        # strength of their initialisation, seizing budget from trained
+        # features before having learned anything.
+        with torch.no_grad():
+            for slot, feature_idx in enumerate(dead_idx.tolist()):
+                direction = directions[slot]
+                self.decoder.weight[:, feature_idx].copy_(direction)
+                self.encoder.weight[feature_idx].copy_(0.2 * alive_norm * direction)
+                if self.encoder.bias is not None:
+                    self.encoder.bias[feature_idx].zero_()
+
+        if optimizer is not None:
+            self._reset_optimizer_state(optimizer, dead_idx)
+
+        return int(dead_idx.numel())
+
+    def _reset_optimizer_state(self, optimizer, dead_idx):
+        """Zero the optimizer state belonging to resampled features only."""
+        # The decoder bias is deliberately absent: it is the single shared
+        # reconstruction offset, not a per-feature parameter, so it has no
+        # slice belonging to a resampled feature. Clearing it would throw away
+        # momentum accumulated on behalf of every feature at once, on every
+        # resampling interval.
+        params = (
+            self.encoder.weight,
+            self.encoder.bias,
+            self.decoder.weight,
+        )
+        for param in params:
+            if param is None or param not in optimizer.state:
+                continue
+            state = optimizer.state[param]
+            for key, value in list(state.items()):
+                if torch.is_tensor(value) and value.shape == param.shape:
+                    if value.ndim == 2:
+                        if param is self.encoder.weight:
+                            value[dead_idx, :] = 0
+                        elif param is self.decoder.weight:
+                            value[:, dead_idx] = 0
+                    elif value.ndim == 1:
+                        if param is self.encoder.bias:
+                            value[dead_idx] = 0
+                elif torch.is_tensor(value) and value.ndim == 0:
+                    continue
+
+
+def fit_sparse_autoencoder(
+    activations,
+    n_inputs=None,
+    expansion=8,
+    k=None,
+    epochs=10,
+    batch_size=256,
+    lr=1e-3,
+    weight_decay=0.0,
+    seed=None,
+    normalize_activations=True,
+    resample_steps=500,
+    resample_until=0.8,
+    dead_rate=1e-5,
+    verbose=0,
+):
+    """Fit a Top-K sparse autoencoder to a tensor of activations.
+
+    Trains with mean squared reconstruction error only; sparsity comes from
+    the top-k mask. Decoder columns are renormalised after every step, and
+    features that stop firing are periodically resampled.
+
+    Parameters
+    ----------
+    activations : torch.Tensor
+        Activations of shape ``(..., n_inputs)``. Leading dimensions are
+        flattened, so a ``(n_windows, n_tokens, n_inputs)`` tensor is
+        treated as one row per token. Training runs on whichever device the
+        tensor already lives on.
+    n_inputs : int or None, default=None
+        Width of the activation vectors. Inferred from the last dimension
+        of ``activations`` when ``None``.
+    expansion : int, default=8
+        Dictionary size relative to ``n_inputs``.
+    k : int or None, default=None
+        Active features per input. Defaults to ``8 * expansion``.
+    epochs : int, default=10
+        Number of passes over the activation set.
+    batch_size : int, default=256
+        Rows per optimisation step.
+    lr : float, default=1e-3
+        Adam learning rate.
+    weight_decay : float, default=0.0
+        Adam weight decay.
+    seed : int or None, default=None
+        Seed for weight initialisation and resampling.
+    normalize_activations : bool, default=True
+        Standardise activations per dimension before fitting, and store the
+        statistics on the returned autoencoder.
+    resample_steps : int, default=500
+        Optimisation steps between dead-feature resampling. Set to ``0`` to
+        disable resampling.
+    resample_until : float, default=0.8
+        Fraction of training after which dead features are left alone.
+        Resampling to the final step leaves the last batch of revived
+        features untrained, so any diagnostic run afterwards scores them
+        cold and reports as dead what is merely newly seeded.
+    dead_rate : float, default=1e-5
+        Firing rate below which a feature counts as dead in the reported
+        history. A plain never-fired test is unusable at this scale, since
+        winning top-k once in two million rows is not evidence a feature is
+        alive, and the test then reads zero whatever the dictionary is doing.
+    verbose : int, default=0
+        Print interval in epochs. ``0`` keeps the fit silent.
+
+    Returns
+    -------
+    sae : SparseAutoencoder
+        The fitted autoencoder, carrying the normalisation statistics.
+    history : dict
+        ``loss`` and ``dead`` per epoch, and ``resampled`` per resampling
+        interval. The dead fraction is the one to watch: reconstruction
+        error keeps falling while features are still being revived and lost,
+        so a flat loss curve does not by itself mean the dictionary has
+        settled.
+
+    See Also
+    --------
+    sae_diagnostics : Reconstruction and sparsity statistics for a fitted model.
+    """
+    activations = torch.as_tensor(activations, dtype=torch.float32)
+    if activations.ndim == 1:
+        activations = activations.unsqueeze(0)
+    if n_inputs is None:
+        n_inputs = activations.shape[-1]
+    flat, _ = _flatten_features(activations, n_inputs)
+
+    if seed is not None:
+        torch.manual_seed(int(seed))
+
+    sae = SparseAutoencoder(n_inputs=n_inputs, expansion=expansion, k=k)
+    sae = sae.to(flat.device)
+    if normalize_activations:
+        act_mean = flat.mean(dim=0)
+        act_std = flat.std(dim=0).clamp_min(1e-6)
+        sae.set_activation_normalization(act_mean, act_std)
+        flat = sae.normalize_activations(flat)
+    optimizer = torch.optim.Adam(sae.parameters(), lr=lr, weight_decay=weight_decay)
+    history = {"loss": [], "dead": [], "resampled": []}
+    active_counts = torch.zeros(sae.n_features, device=flat.device)
+    steps_since_resample = 0
+    epochs = int(epochs)
+    steps_per_epoch = max(1, -(-flat.shape[0] // batch_size))
+    last_resample_step = int(resample_until * epochs * steps_per_epoch)
+    global_step = 0
+    for epoch in range(epochs):
+        perm = torch.randperm(flat.shape[0], device=flat.device)
+        losses = []
+        # Counted per epoch as well as per resampling interval: the interval
+        # counter is cleared on every resample, so on its own it cannot show
+        # whether the dictionary is still churning.
+        epoch_fires = torch.zeros(sae.n_features, device=flat.device)
+        n_resampled_epoch = 0
+        for start in range(0, flat.shape[0], batch_size):
+            batch = flat[perm[start : start + batch_size]]
+            recon, latent = sae(batch)
+            loss = torch.mean((recon - batch) ** 2)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+            sae.normalize_decoder_()
+            fired = (latent.detach() != 0).sum(dim=0)
+            active_counts += fired
+            epoch_fires += fired
+            steps_since_resample += 1
+            global_step += 1
+            if (
+                resample_steps
+                and steps_since_resample >= resample_steps
+                and global_step <= last_resample_step
+            ):
+                # Offset the seed per call, otherwise every resample draws the
+                # same rows and the revived features point the same way.
+                resample_seed = (
+                    None if seed is None else int(seed) + len(history["resampled"])
+                )
+                n_resampled = sae.resample_dead_features(
+                    flat, active_counts == 0, optimizer=optimizer, seed=resample_seed
+                )
+                history["resampled"].append(n_resampled)
+                n_resampled_epoch += n_resampled
+                active_counts.zero_()
+                steps_since_resample = 0
+            losses.append(float(loss.detach()))
+
+        epoch_loss = float(np.mean(losses))
+        dead = float((epoch_fires / flat.shape[0] < dead_rate).float().mean())
+        history["loss"].append(epoch_loss)
+        history["dead"].append(dead)
+        if verbose and (epoch % verbose == 0 or epoch == epochs - 1):
+            print(
+                f"  sae epoch {epoch + 1:3d}/{epochs}  loss={epoch_loss:.4f}  "
+                f"dead={dead:.2%}  resampled={n_resampled_epoch}",
+                flush=True,
+            )
+    return sae, history
+
+
+def sae_diagnostics(sae, activations, chunk_size=16384, dead_rate=1e-5):
+    """Return reconstruction and sparsity diagnostics for ``sae``.
+
+    Parameters
+    ----------
+    sae : SparseAutoencoder
+        A fitted autoencoder.
+    activations : torch.Tensor
+        Raw layer outputs of shape ``(..., n_inputs)``. They are normalised
+        with the statistics stored on ``sae``, which default to zero mean
+        and unit standard deviation, so passing already-normalised
+        activations to an autoencoder fitted with
+        ``normalize_activations=False`` is also correct.
+    chunk_size : int, default=16384
+        Rows per forward pass. The latent is ``expansion`` times wider than
+        the input, so a single pass over a large activation set needs many
+        times its own size in memory: two million rows against a
+        1600-feature dictionary is roughly 13 GB for the latent alone,
+        before the top-k mask doubles it.
+    dead_rate : float, default=1e-5
+        Firing rate below which a feature counts as dead. This is a rate
+        rather than a never-fired check because over a few million rows
+        almost every feature wins top-k at least once, so the stricter test
+        reports zero whatever the dictionary is doing.
+
+    Returns
+    -------
+    dict
+        ``l0``, the mean number of active features per row; ``dead``, the
+        fraction of features firing on less than ``dead_rate`` of rows; and
+        ``r2``, the fraction of activation variance reconstructed.
+
+    Notes
+    -----
+    ``r2`` measures reconstructed variance, which is not the same as
+    task relevance. A dictionary can reconstruct almost all the variance
+    while discarding the directions a downstream head relies on, and the
+    converse also occurs. Pair it with a substitution check built on
+    :func:`run_with_activation_substitution`.
+    """
+    activations = torch.as_tensor(activations, dtype=torch.float32)
+    flat, _ = _flatten_features(activations, sae.n_inputs)
+    device = sae.activation_mean.device
+    n_rows = flat.shape[0]
+
+    # r2 needs deviations from the global mean, so the mean is accumulated
+    # first rather than approximated per chunk.
+    with torch.no_grad():
+        mean = torch.zeros(sae.n_inputs, device=device)
+        for start in range(0, n_rows, chunk_size):
+            batch = flat[start : start + chunk_size].to(device)
+            mean += sae.normalize_activations(batch).sum(dim=0)
+        mean /= max(n_rows, 1)
+
+        fires = torch.zeros(sae.n_features, device=device)
+        active_total = 0.0
+        sse = torch.zeros((), device=device)
+        sst = torch.zeros((), device=device)
+        for start in range(0, n_rows, chunk_size):
+            batch = sae.normalize_activations(
+                flat[start : start + chunk_size].to(device)
+            )
+            recon, latent = sae(batch)
+            active = latent != 0
+            active_total += float(active.sum())
+            fires += active.sum(dim=0)
+            sse += torch.sum((recon - batch) ** 2)
+            sst += torch.sum((batch - mean) ** 2)
+
+    return {
+        "l0": active_total / max(n_rows, 1),
+        "dead": float((fires / max(n_rows, 1) < dead_rate).float().mean()),
+        "r2": float(1.0 - sse / sst.clamp_min(1e-12)),
+    }
+
+
+def capture_activations(model, x, layers, forward_fn=None, detach=True):
+    """Capture the outputs of one or more modules during a forward pass.
+
+    Hooks are registered before the forward pass and removed in a ``finally``
+    block, so they do not leak if the forward pass raises.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        The model to run.
+    x : torch.Tensor
+        Input passed to ``forward_fn``.
+    layers : torch.nn.Module or list of torch.nn.Module or dict
+        Modules whose outputs to capture. A single module is keyed ``0``, a
+        sequence is keyed by position, and a mapping keeps its own keys.
+    forward_fn : callable or None, default=None
+        Callable invoked as ``forward_fn(x)``. Defaults to ``model``. Use
+        this to reach a submodule's forward, for instance a backbone's
+        feature extractor rather than the full classifier.
+    detach : bool, default=True
+        Detach captured tensors from the autograd graph. Set to ``False``
+        only when gradients through the captured activations are needed.
+
+    Returns
+    -------
+    dict
+        One entry per requested module, keyed as described above.
+
+    See Also
+    --------
+    run_with_activation_substitution : Replace a layer's output instead.
+    """
+    forward_fn = model if forward_fn is None else forward_fn
+    if isinstance(layers, nn.Module):
+        items = [(0, layers)]
+    else:
+        items = _as_module_items(layers)
+    captured = {}
+    handles = []
+
+    def make_hook(key):
+        """Build a forward hook that stores its module's output under ``key``."""
+
+        def hook(_module, _inputs, output):
+            """Store this module's output, detaching it when asked."""
+            captured[key] = _detach_output(output) if detach else output
+
+        return hook
+
+    for key, module in items:
+        handles.append(module.register_forward_hook(make_hook(key)))
+
+    try:
+        forward_fn(x)
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    return captured
+
+
+def run_with_activation_substitution(model, x, layer, substitute_fn, forward_fn=None):
+    """Run ``model`` with the output of ``layer`` replaced.
+
+    The basis of a faithfulness check: substitute a sparse autoencoder's
+    reconstruction for a layer's output and re-measure the task with the
+    model's own head. A small change in the metric means the dictionary
+    captured what the model actually uses, whereas reconstruction error
+    alone only shows it captured the variance.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        The model to run.
+    x : torch.Tensor
+        Input passed to ``forward_fn``.
+    layer : torch.nn.Module
+        Module whose output is replaced.
+    substitute_fn : callable
+        Called with the layer's output; its return value is used instead.
+        For an autoencoder this is usually
+        :meth:`SparseAutoencoder.reconstruct_activations`, which handles
+        normalisation internally.
+    forward_fn : callable or None, default=None
+        Callable invoked as ``forward_fn(x)``. Defaults to ``model``.
+
+    Returns
+    -------
+    Any
+        Whatever ``forward_fn`` returns, computed with the substitution in
+        place.
+
+    See Also
+    --------
+    capture_activations : Record a layer's output instead of replacing it.
+    """
+    forward_fn = model if forward_fn is None else forward_fn
+
+    def hook(_module, _inputs, output):
+        """Return the substituted output in place of the module's own."""
+        return substitute_fn(output)
+
+    handle = layer.register_forward_hook(hook)
+    try:
+        return forward_fn(x)
+    finally:
+        handle.remove()
+
+
+def grouped_train_valid_test_split(
+    groups, train_size=0.7, valid_size=0.15, test_size=0.15, seed=0
+):
+    """Split sample indices by group without leaking a group across splits.
+
+    Windows from one recording or subject are far from independent, so a
+    random split over samples inflates every downstream score. This splits
+    over unique groups instead.
+
+    Parameters
+    ----------
+    groups : array-like
+        Group label per sample, for instance a recording or subject
+        identifier. Length equals the number of samples.
+    train_size : float, default=0.7
+        Fraction of groups assigned to the training split.
+    valid_size : float, default=0.15
+        Fraction of groups assigned to the validation split.
+    test_size : float, default=0.15
+        Fraction of groups assigned to the test split.
+    seed : int, default=0
+        Seed for the group shuffle.
+
+    Returns
+    -------
+    train_idx : numpy.ndarray
+        Sample indices of the training split.
+    valid_idx : numpy.ndarray
+        Sample indices of the validation split.
+    test_idx : numpy.ndarray
+        Sample indices of the test split.
+
+    Raises
+    ------
+    ValueError
+        If the three fractions do not sum to one, or if there are fewer
+        than three distinct groups.
+    """
+    fractions = np.array([train_size, valid_size, test_size], dtype=float)
+    if not np.isclose(fractions.sum(), 1.0):
+        raise ValueError("train_size + valid_size + test_size must equal 1")
+    groups = np.asarray(groups)
+    unique_groups = np.unique(groups)
+    if unique_groups.size < 3:
+        raise ValueError("need at least three groups for a train/valid/test split")
+    rng = np.random.default_rng(seed)
+    shuffled = unique_groups.copy()
+    rng.shuffle(shuffled)
+    n_groups = shuffled.size
+    counts = np.maximum(1, np.round(fractions * n_groups).astype(int))
+    while counts.sum() > n_groups:
+        for idx in np.argsort(-counts):
+            if counts.sum() == n_groups:
+                break
+            if counts[idx] > 1:
+                counts[idx] -= 1
+    while counts.sum() < n_groups:
+        counts[int(np.argmax(fractions))] += 1
+    n_train, n_valid, _ = counts.tolist()
+    train_groups = shuffled[:n_train]
+    valid_groups = shuffled[n_train : n_train + n_valid]
+    test_groups = shuffled[n_train + n_valid :]
+    train_idx = np.flatnonzero(np.isin(groups, train_groups))
+    valid_idx = np.flatnonzero(np.isin(groups, valid_groups))
+    test_idx = np.flatnonzero(np.isin(groups, test_groups))
+    return train_idx, valid_idx, test_idx

--- a/examples/advanced_training/plot_sae_interpretability.py
+++ b/examples/advanced_training/plot_sae_interpretability.py
@@ -1,0 +1,391 @@
+""".. _sae-interpretability-tutorial:
+
+Sparse Autoencoders for EEG Model Interpretability
+==================================================
+
+A trained network represents more concepts than it has dimensions, by letting
+them share directions and rarely co-activate. A Top-K sparse autoencoder
+undoes that packing: it re-expresses each activation as a combination of a
+few learned directions drawn from a much wider dictionary, so individual
+features stand a chance of meaning something on their own.
+
+Fitting one is easy. Knowing whether it kept what the model actually uses is
+the hard part, and it is what most of this example is about.
+
+We use the pretrained :class:`~braindecode.models.ShallowFBCSPNet` for
+subject 3 of BCI Competition IV 2a, the same checkpoint as
+:ref:`interpretability-tutorial`, and decompose its penultimate feature map:
+
+1. Load the pretrained classifier and measure its baseline performance.
+2. Capture the feature map with
+   :func:`~braindecode.visualization.capture_activations` and fit a Top-K
+   sparse autoencoder with
+   :func:`~braindecode.visualization.fit_sparse_autoencoder`.
+3. Read the dictionary's health with
+   :func:`~braindecode.visualization.sae_diagnostics`.
+4. Put the reconstruction back into the model with
+   :func:`~braindecode.visualization.run_with_activation_substitution` and
+   re-measure the task, against two controls.
+
+.. note::
+
+   Sparse autoencoders are usually discussed for transformer residual
+   streams, but nothing in the method requires one: any activation vector
+   will do. Here the vectors are the 40 spatio-temporal filter responses of
+   a convolutional network, which makes the point that these utilities apply
+   across braindecode's model zoo rather than only to its transformers.
+
+.. note::
+
+   The controls are what make step 4 mean anything. A preserved score after
+   substitution is also what an insensitive measurement looks like, so the
+   trained dictionary is compared against an untrained one of identical
+   shape, and against ablating the layer entirely.
+
+.. contents:: This example covers:
+   :local:
+   :depth: 2
+
+"""
+
+# Authors: Vandit Shah <shahvanditt@gmail.com>
+#
+# License: BSD (3-clause)
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from huggingface_hub import hf_hub_download
+from numpy import multiply
+from sklearn.metrics import roc_auc_score
+
+from braindecode import EEGClassifier
+from braindecode.datasets import MOABBDataset
+from braindecode.datautil import infer_signal_properties
+from braindecode.models import ShallowFBCSPNet
+from braindecode.preprocessing import (
+    Preprocessor,
+    create_windows_from_events,
+    exponential_moving_standardize,
+    preprocess,
+)
+from braindecode.util import set_random_seeds
+from braindecode.visualization import (
+    SparseAutoencoder,
+    capture_activations,
+    fit_sparse_autoencoder,
+    run_with_activation_substitution,
+    sae_diagnostics,
+)
+
+SEED = 20240205
+set_random_seeds(seed=SEED, cuda=False)
+
+######################################################################
+# Data
+# ----
+#
+# Subject 3 of BCI Competition IV 2a, four motor-imagery classes. The
+# preprocessing mirrors the recipe the published checkpoint was trained
+# with: keep EEG channels, convert V to µV, bandpass 4--38 Hz around the mu
+# and beta rhythms where motor imagery lives, then exponential moving
+# standardisation for per-channel drift. Changing any of it would put the
+# input off the distribution the weights expect.
+#
+# The split is cross-session: session ``"0train"`` for training and
+# ``"1test"``, recorded on a different day, for evaluation. That is the
+# harder regime, and deliberately so. On an easy task every condition below
+# would sit at ceiling and the comparison would tell us nothing.
+
+subject_id = 3
+dataset = MOABBDataset(dataset_name="BNCI2014_001", subject_ids=[subject_id])
+
+preprocess(
+    dataset,
+    [
+        Preprocessor("pick_types", eeg=True, meg=False, stim=False),
+        Preprocessor(lambda data: multiply(data, 1e6)),
+        Preprocessor("filter", l_freq=4.0, h_freq=38.0),
+        Preprocessor(
+            exponential_moving_standardize,
+            factor_new=1e-3,
+            init_block_size=1000,
+        ),
+    ],
+    n_jobs=1,
+)
+
+sfreq = dataset.datasets[0].raw.info["sfreq"]
+windows_dataset = create_windows_from_events(
+    dataset,
+    trial_start_offset_samples=int(-0.5 * sfreq),
+    trial_stop_offset_samples=0,
+    preload=True,
+)
+
+split_by_session = windows_dataset.split("session")
+train_set, valid_set = split_by_session["0train"], split_by_session["1test"]
+print(f"train {len(train_set)} trials, valid {len(valid_set)} trials")
+
+
+def as_arrays(windows):
+    """Stack a windows dataset into ``(X, y)`` arrays."""
+    xs = np.stack([windows[i][0] for i in range(len(windows))]).astype(np.float32)
+    ys = np.asarray([windows[i][1] for i in range(len(windows))], dtype=np.int64)
+    return xs, ys
+
+
+X_train, y_train = as_arrays(train_set)
+X_valid, y_valid = as_arrays(valid_set)
+
+######################################################################
+# Load the pretrained classifier
+# ------------------------------
+#
+# Everything downstream describes a model that performs the task, so the
+# classifier has to be a real one. Rather than train here, we load the
+# checkpoint braindecode publishes for this subject and preprocessing, which
+# keeps the docs build short and removes any doubt about whether the model
+# converged.
+
+signal_properties = infer_signal_properties(train_set, mode="classification")
+classifier = EEGClassifier(
+    ShallowFBCSPNet(
+        n_chans=signal_properties["n_chans"],
+        n_outputs=signal_properties["n_outputs"],
+        n_times=signal_properties["n_times"],
+        final_conv_length="auto",
+    ),
+    criterion=torch.nn.CrossEntropyLoss,
+    optimizer=torch.optim.AdamW,
+    classes=list(range(signal_properties["n_outputs"])),
+)
+classifier.initialize()  # builds the module without training
+
+repo_id = "braindecode/plot_bcic_iv_2a_moabb_trial"
+classifier.load_params(
+    f_params=hf_hub_download(repo_id, "params.safetensors"),
+    f_history=hf_hub_download(repo_id, "history.json"),
+    use_safetensors=True,
+)
+model = classifier.module_
+model.eval()
+
+
+def macro_auroc(model, x, y, layer=None, substitute_fn=None):
+    """One-vs-rest macro AUROC, optionally with a layer's output replaced.
+
+    Threshold-free, so it is unaffected by class balance.
+    """
+    with torch.no_grad():
+        inputs = torch.from_numpy(x)
+        if layer is None:
+            logits = model(inputs)
+        else:
+            logits = run_with_activation_substitution(
+                model, inputs, layer, substitute_fn
+            )
+        probs = logits.softmax(dim=-1).cpu().numpy()
+    return roc_auc_score(y, probs, multi_class="ovr", average="macro")
+
+
+baseline_valid = macro_auroc(model, X_valid, y_valid)
+print(f"Baseline validation AUROC: {baseline_valid:.3f}")
+
+######################################################################
+# Capture the feature map and fit the autoencoder
+# -----------------------------------------------
+#
+# :func:`~braindecode.visualization.capture_activations` attaches forward
+# hooks, runs the model, and removes them again even if the forward pass
+# raises. We tap ``model.drop``, the last module before the classification
+# head, so the dictionary describes exactly what the classifier reads.
+#
+# Its output is ``(trials, 40, time, 1)``: forty spatio-temporal filters
+# over 32 pooled time positions. The autoencoder expects the feature axis
+# last and one row per sample, so the tensor is permuted and flattened into
+# ``(trials × time, 40)``. Reversing that permutation is the only fiddly
+# part of applying an SAE to a convolutional feature map, and the
+# substitution below has to undo it exactly.
+#
+# Only training-split activations are used, so the evaluation stays honest.
+# Features that stop firing are periodically reassigned to directions the
+# dictionary reconstructs poorly, since a dead feature receives no gradient
+# and cannot recover on its own; ``resample_until`` stops that before the
+# end of training so the last revived features are not judged before they
+# have trained.
+
+layer = model.drop
+
+
+def to_tokens(activations):
+    """``(trials, features, time, 1)`` to ``(trials * time, features)``."""
+    return activations.squeeze(-1).permute(0, 2, 1).reshape(-1, activations.shape[1])
+
+
+train_acts = capture_activations(model, torch.from_numpy(X_train), {"layer": layer})[
+    "layer"
+]
+train_flat = to_tokens(train_acts)
+
+sae, history = fit_sparse_autoencoder(
+    train_flat,
+    expansion=4,
+    k=8,
+    epochs=60,
+    batch_size=128,
+    lr=1e-3,
+    seed=SEED,
+    resample_steps=100,
+    resample_until=0.8,
+)
+print(f"{train_flat.shape[0]} tokens of {train_flat.shape[1]} dims")
+print(f"{sae.n_features} dictionary features, k={sae.k}")
+print(f"Final reconstruction loss: {history['loss'][-1]:.4f}")
+
+######################################################################
+# Read the diagnostics
+# --------------------
+#
+# :func:`~braindecode.visualization.sae_diagnostics` reports three numbers:
+#
+# ``l0``
+#     Mean active features per token. Never above ``k``, and below it when
+#     fewer than ``k`` encoder outputs are positive for some tokens.
+#
+# ``dead``
+#     Fraction of features that essentially never fire. This is a firing
+#     *rate* threshold rather than a never-fired test: over a few million
+#     tokens almost every feature wins the top-k competition at least once,
+#     so the stricter test reports zero regardless of the dictionary's
+#     actual state.
+#
+# ``r2``
+#     Fraction of activation variance reconstructed.
+#
+# ``r2`` is the tempting number and the misleading one. It measures how much
+# *variance* survives, which is not how much of what the model *uses*
+# survives. Those come apart in both directions: a dictionary can
+# reconstruct nearly all the variance while dropping the directions the
+# classifier reads, and a poor reconstruction can still carry an easy label.
+# That is why the next section intervenes on the model instead of trusting
+# ``r2``.
+#
+# To make that concrete, the same diagnostics are printed for an untrained
+# autoencoder of identical shape. Compare the two rows before reading on.
+
+random_sae = SparseAutoencoder.from_config(sae.get_config())
+random_sae.set_activation_normalization(sae.activation_mean, sae.activation_std)
+
+print("trained SAE:", sae_diagnostics(sae, train_flat))
+print("random SAE: ", sae_diagnostics(random_sae, train_flat))
+
+######################################################################
+# The untrained dictionary has **no** dead features, and the trained one has
+# roughly half. Taken on its own ``dead`` would rank them backwards. Random
+# directions all fire precisely because none of them specialise: every token
+# lands somewhere in an arbitrary basis, so every feature gets its turn. A
+# trained dictionary concentrates the work in the features that earn it and
+# lets the rest fall silent.
+#
+# ``r2`` separates them correctly here, and its sign is worth noticing: the
+# untrained reconstruction scores below zero, meaning it is worse than
+# simply predicting the mean activation. Whether that matters for the task
+# is still a different question, and only the substitution answers it.
+
+######################################################################
+# Substitute the reconstruction, against controls
+# -----------------------------------------------
+#
+# The question is causal: with the feature map replaced by the
+# autoencoder's reconstruction, does the model still do its job?
+# :func:`~braindecode.visualization.run_with_activation_substitution` swaps
+# the output through a forward hook and reuses the trained classifier
+# unchanged. Refitting a head under each condition would let it re-adapt to
+# whatever the autoencoder damaged, which flatters the result.
+#
+# Two controls make the comparison interpretable:
+#
+# *random SAE*
+#     The untrained autoencoder built above with
+#     :meth:`~braindecode.visualization.SparseAutoencoder.from_config`, of
+#     identical shape, sparsity and normalisation, whose directions are
+#     arbitrary. Note that a random top-k dictionary is still a random
+#     *projection*, and projections preserve linear separability, so on an
+#     easy task this control passes and tells you nothing. It is informative
+#     here because cross-session motor imagery is not easy.
+#
+# *zeroed layer*
+#     The feature map replaced by zeros. This is the floor: it shows what
+#     the metric looks like when the layer contributes nothing, and confirms
+#     the substitution reaches the classifier at all.
+
+
+def substitute_with(module):
+    """Reconstruct through ``module``, restoring the conv layout."""
+
+    def substitute(output):
+        tokens = output.squeeze(-1).permute(0, 2, 1)
+        recon = module.reconstruct_activations(tokens)
+        return recon.permute(0, 2, 1).unsqueeze(-1)
+
+    return substitute
+
+
+scores = {
+    "baseline": baseline_valid,
+    "SAE": macro_auroc(
+        model, X_valid, y_valid, layer=layer, substitute_fn=substitute_with(sae)
+    ),
+    "random SAE": macro_auroc(
+        model, X_valid, y_valid, layer=layer, substitute_fn=substitute_with(random_sae)
+    ),
+    "zeroed layer": macro_auroc(
+        model,
+        X_valid,
+        y_valid,
+        layer=layer,
+        substitute_fn=lambda out: torch.zeros_like(out),
+    ),
+}
+
+print(f"\n{'condition':14s} {'AUROC':>7s} {'vs baseline':>12s}")
+for name, value in scores.items():
+    print(f"{name:14s} {value:>7.3f} {value - baseline_valid:>+12.3f}")
+
+######################################################################
+# Reading the result
+# ------------------
+#
+# The comparison that matters is the trained dictionary against the two
+# controls, not against the baseline alone.
+#
+# A small gap for the trained autoencoder means the handful of features it
+# keeps active per token span what the classifier reads. That claim only
+# holds if the controls visibly fail: if random directions cost as little as
+# the learned ones, the measurement cannot distinguish a good dictionary
+# from a meaningless one, and a near-zero gap says more about the task than
+# about the dictionary.
+#
+# This is a single site in a network with one representational stage, so it
+# shows the workflow rather than how faithfulness varies with depth. On a
+# deep transformer the same three calls are repeated per block, which is how
+# an operating layer gets chosen.
+
+fig, ax = plt.subplots(figsize=(6.0, 3.4))
+names = list(scores)
+values = [scores[name] for name in names]
+ax.bar(
+    np.arange(len(names)),
+    values,
+    0.6,
+    color=["0.3", "tab:blue", "tab:orange", "tab:red"],
+)
+ax.axhline(baseline_valid, color="0.3", linestyle="--", linewidth=1)
+ax.axhline(0.5, color="0.7", linestyle=":", linewidth=1)
+ax.set_ylim(0.4, 1.0)
+ax.set_ylabel("macro AUROC (validation)")
+ax.set_xticks(np.arange(len(names)))
+ax.set_xticklabels(names, fontsize="small")
+ax.set_title("Substituting the penultimate feature map")
+fig.tight_layout()

--- a/test/unit_tests/visualization/test_sae.py
+++ b/test/unit_tests/visualization/test_sae.py
@@ -1,0 +1,219 @@
+import io
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+from braindecode.visualization import (
+    SparseAutoencoder,
+    capture_activations,
+    fit_sparse_autoencoder,
+    grouped_train_valid_test_split,
+    run_with_activation_substitution,
+    sae_diagnostics,
+)
+
+
+class ToyNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = nn.Linear(4, 6)
+        self.head = nn.Linear(6, 2)
+
+    def forward(self, x):
+        x = self.block(x)
+        return self.head(x)
+
+
+class ExplodingNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = nn.Linear(4, 4)
+
+    def forward(self, x):
+        x = self.block(x)
+        raise RuntimeError("boom")
+
+
+def _make_positive_sae():
+    sae = SparseAutoencoder(n_inputs=4, expansion=2, k=3)
+    with torch.no_grad():
+        sae.encoder.weight.copy_(torch.arange(1, 33, dtype=torch.float32).view(8, 4))
+        sae.encoder.bias.fill_(0.5)
+        sae.decoder.weight.copy_(torch.randn_like(sae.decoder.weight))
+        sae.decoder.bias.zero_()
+    return sae
+
+
+def test_encode_returns_exact_k_nonzeros():
+    sae = _make_positive_sae()
+    x = torch.ones(2, 4)
+    latent = sae.encode(x)
+    assert latent.shape == (2, 8)
+    assert torch.equal((latent != 0).sum(dim=1), torch.full((2,), 3, dtype=torch.long))
+
+
+def test_decoder_normalization_and_diagnostics():
+    sae = SparseAutoencoder(n_inputs=4, expansion=2, k=2)
+    with torch.no_grad():
+        sae.decoder.weight.copy_(torch.randn_like(sae.decoder.weight))
+    sae.normalize_decoder_()
+    norms = sae.decoder.weight.norm(dim=0)
+    torch.testing.assert_close(norms, torch.ones_like(norms))
+
+    x = torch.randn(6, 4)
+    stats = sae_diagnostics(sae, x)
+    assert set(stats) == {"l0", "dead", "r2"}
+    assert stats["l0"] >= 0
+    assert 0.0 <= stats["dead"] <= 1.0
+
+
+def test_config_and_state_dict_roundtrip():
+    sae = SparseAutoencoder(n_inputs=4, expansion=2, k=3)
+    with torch.no_grad():
+        sae.encoder.weight.uniform_(-0.5, 0.5)
+    sae.set_activation_normalization(torch.arange(4.0), torch.arange(1.0, 5.0))
+    clone = SparseAutoencoder.from_config(sae.get_config())
+    clone.load_state_dict(sae.state_dict())
+
+    buf = io.BytesIO()
+    torch.save(sae.state_dict(), buf)
+    buf.seek(0)
+    reloaded = SparseAutoencoder.from_config(sae.get_config())
+    reloaded.load_state_dict(torch.load(buf))
+
+    torch.testing.assert_close(clone.encoder.weight, sae.encoder.weight)
+    torch.testing.assert_close(clone.activation_mean, sae.activation_mean)
+    torch.testing.assert_close(clone.activation_std, sae.activation_std)
+    torch.testing.assert_close(reloaded.decoder.bias, sae.decoder.bias)
+
+
+def test_capture_activations_returns_one_entry_and_cleans_hooks():
+    model = ToyNet().eval()
+    x = torch.randn(3, 4)
+    captured = capture_activations(model, x, {"block": model.block})
+    assert set(captured) == {"block"}
+    assert captured["block"].shape == (3, 6)
+    assert len(model.block._forward_hooks) == 0
+
+
+def test_capture_activations_cleans_up_on_exception():
+    model = ExplodingNet().eval()
+    x = torch.randn(2, 4)
+    with pytest.raises(RuntimeError, match="boom"):
+        capture_activations(model, x, [model.block])
+    assert len(model.block._forward_hooks) == 0
+
+
+def test_activation_substitution_identity_and_change():
+    model = ToyNet().eval()
+    x = torch.randn(4, 4)
+
+    baseline = model(x)
+    identity = run_with_activation_substitution(model, x, model.block, lambda out: out)
+    torch.testing.assert_close(identity, baseline)
+    assert len(model.block._forward_hooks) == 0
+
+    shifted = run_with_activation_substitution(
+        model, x, model.block, lambda out: out + 1.0
+    )
+    assert not torch.allclose(shifted, baseline)
+    assert len(model.block._forward_hooks) == 0
+
+
+def test_resample_dead_features_changes_only_dead_columns_and_resets_state():
+    sae = SparseAutoencoder(n_inputs=4, expansion=2, k=2)
+    optimizer = torch.optim.Adam(sae.parameters(), lr=1e-2)
+    x = torch.randn(12, 4)
+    recon, _ = sae(x)
+    loss = torch.mean((recon - x) ** 2)
+    loss.backward()
+    optimizer.step()
+
+    enc_before = sae.encoder.weight.detach().clone()
+    dec_before = sae.decoder.weight.detach().clone()
+    bias_before = sae.decoder.bias.detach().clone()
+    alive_norm = enc_before[2:].norm(dim=1).mean()
+    dead = torch.tensor([True, True, False, False, False, False, False, False])
+    changed = sae.resample_dead_features(x, dead, optimizer=optimizer, seed=0)
+
+    assert changed == 2
+    assert not torch.allclose(sae.encoder.weight[:2], enc_before[:2])
+    assert not torch.allclose(sae.decoder.weight[:, :2], dec_before[:, :2])
+    torch.testing.assert_close(sae.encoder.weight[2:], enc_before[2:])
+    torch.testing.assert_close(sae.decoder.weight[:, 2:], dec_before[:, 2:])
+    torch.testing.assert_close(sae.decoder.bias, bias_before)
+    torch.testing.assert_close(
+        sae.encoder.weight[:2].norm(dim=1), (0.2 * alive_norm).expand(2)
+    )
+    enc_state = optimizer.state[sae.encoder.weight]["exp_avg"]
+    dec_state = optimizer.state[sae.decoder.weight]["exp_avg"]
+    assert torch.count_nonzero(enc_state[:2]) == 0
+    assert torch.count_nonzero(dec_state[:, :2]) == 0
+    # Only the resampled slots are cleared; the rest keep their momentum.
+    assert torch.count_nonzero(enc_state[2:]) > 0
+
+
+def test_diagnostics_are_chunk_size_invariant():
+    # A single pass over a large activation set needs many times its own size,
+    # since the latent is `expansion` times wider than the input. Chunking must
+    # not change the answer.
+    sae = SparseAutoencoder(n_inputs=4, expansion=2, k=2)
+    x = torch.randn(200, 4)
+    whole = sae_diagnostics(sae, x, chunk_size=1000)
+    chunked = sae_diagnostics(sae, x, chunk_size=16)
+    for key in ("l0", "dead", "r2"):
+        assert abs(whole[key] - chunked[key]) < 1e-4, key
+
+
+def test_fit_sparse_autoencoder_resamples_dead_features():
+    x = torch.randn(8, 4)
+    sae, history = fit_sparse_autoencoder(
+        x,
+        expansion=2,
+        k=2,
+        epochs=1,
+        batch_size=4,
+        resample_steps=1,
+        seed=0,
+    )
+    # Two steps per epoch, but resample_until=0.8 leaves the last one alone so
+    # revived features are not scored before they have trained.
+    assert len(history["resampled"]) == 1
+    assert sae.activation_mean.shape == (4,)
+    assert sae.activation_std.shape == (4,)
+
+
+def test_resampling_stops_before_the_end_of_training():
+    x = torch.randn(8, 4)
+    _, cooled = fit_sparse_autoencoder(
+        x, expansion=2, k=2, epochs=1, batch_size=4, resample_steps=1, seed=0
+    )
+    _, full = fit_sparse_autoencoder(
+        x,
+        expansion=2,
+        k=2,
+        epochs=1,
+        batch_size=4,
+        resample_steps=1,
+        seed=0,
+        resample_until=1.0,
+    )
+    assert len(cooled["resampled"]) < len(full["resampled"])
+
+
+def test_grouped_split_keeps_groups_together():
+    groups = np.repeat(np.arange(6), 3)
+    train_idx, valid_idx, test_idx = grouped_train_valid_test_split(groups, seed=1)
+
+    train_groups = set(groups[train_idx])
+    valid_groups = set(groups[valid_idx])
+    test_groups = set(groups[test_idx])
+
+    assert train_groups.isdisjoint(valid_groups)
+    assert train_groups.isdisjoint(test_groups)
+    assert valid_groups.isdisjoint(test_groups)
+    assert sorted(train_idx.tolist() + valid_idx.tolist() + test_idx.tolist()) == list(
+        range(groups.size)
+    )


### PR DESCRIPTION
 ## Current Status

  The changes are contained in:

  braindecode/mech-interp/labram-activations.ipynb

  This is currently a demonstration intended to reproduce part of the workflow from Mechanistic Interpretability of EEG
  Foundation Models via Sparse Autoencoders (arXiv:2605.13930) using Braindecode’s LaBraM implementation and the public NMT Scalp EEG Dataset.

  The experiment was limited to 400 recordings because of Kaggle’s disk, memory, and runtime constraints. Intermediate preprocessing and activation files are deleted after use to remain within Kaggle’s available storage.

  ### Results

  - Fine-tuned LaBraM
      - Validation window AUROC: 0.7053
      - Test window AUROC: 0.6128
      - Test recording-level AUROC: 0.6696

  - Layer-11 Top-K SAE
      - Training activation tokens: 400,000
      - Input dimension: 200
      - Dictionary size: 1,600
      - Top-K value: 64
      - Reconstruction R²: 0.9578
      - Dead features: 0%
      - Average L0: 64

  - Native-head faithfulness
      - Window-level AUROC change: -0.0047
      - Recording-level AUROC change: -0.0040

The small AUROC changes suggest that replacing layer-11 activations with SAE reconstructions preserved most of the fine-tuned model’s task behavior in this run. Next steps are to  reproduce TCAV-based concept attribution, concept steering, spectral decoding back to EEG structure, and monosemanticity analysis.