### PR TITLE
Fix Mixup target handling in the criterion, the dataloader, and the estimator fit loop

### DIFF
--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -177,6 +177,14 @@ class Compose(Transform):
         return X, y
 
 
+def _as_mixed_target(y, lam_dtype):
+    # an untouched target is the same as being mixed with itself with lam of one
+    if isinstance(y, tuple):
+        return y
+    lam = torch.ones(y.shape[0], device=y.device, dtype=lam_dtype)
+    return y, y, lam
+
+
 class _AugmentationCollate:
     """Collate that applies a transform to each batch, with optional expansion.
 
@@ -194,7 +202,10 @@ class _AugmentationCollate:
         ``0`` (default) applies the transform in place (batch size unchanged).
         ``> 0`` keeps the clean originals and appends ``n_augmentation``
         independently transformed copies, returning ``(X, y)`` of
-        ``(1 + n_augmentation)`` times the original size.
+        ``(1 + n_augmentation)`` times the original size. When the transform
+        mixes targets, as :class:`braindecode.augmentation.Mixup` does, ``y``
+        stays the ``(y_a, y_b, lam)`` triple and the clean originals get a
+        mixing coefficient of one.
     """
 
     def __init__(self, transform, device=None, n_augmentation=0):
@@ -217,6 +228,13 @@ class _AugmentationCollate:
             aug_X, aug_y = self.transform(X, y)
             xs.append(aug_X)
             ys.append(aug_y)
+        if any(isinstance(aug_y, tuple) for aug_y in ys):
+            # a target-mixing transform such as Mixup returns (y_a, y_b, lam),
+            # so the parts are concatenated one by one and the untouched copies
+            # are given a mixing coefficient of one
+            lam_dtype = next(t[2].dtype for t in ys if isinstance(t, tuple))
+            ys = [_as_mixed_target(aug_y, lam_dtype) for aug_y in ys]
+            return torch.cat(xs), tuple(torch.cat(part) for part in zip(*ys))
         return torch.cat(xs), torch.cat(ys)
 
 

--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -3,6 +3,7 @@
 #          Bruno Aristimunha <b.aristimunha@gmail.com>
 #          Martin Wimpff <martin.wimpff@iss.uni-stuttgart.de>
 #          Valentin Iovene <val@too.gy>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 # License: BSD (3-clause)
 
 from numbers import Real

--- a/braindecode/augmentation/base.py
+++ b/braindecode/augmentation/base.py
@@ -179,8 +179,8 @@ class Compose(Transform):
 
 def _as_mixed_target(y, lam_dtype):
     # an untouched target is the same as being mixed with itself with lam of one
-    if isinstance(y, tuple):
-        return y
+    if isinstance(y, (tuple, list)) and len(y) == 3:
+        return tuple(y)
     lam = torch.ones(y.shape[0], device=y.device, dtype=lam_dtype)
     return y, y, lam
 
@@ -228,11 +228,16 @@ class _AugmentationCollate:
             aug_X, aug_y = self.transform(X, y)
             xs.append(aug_X)
             ys.append(aug_y)
-        if any(isinstance(aug_y, tuple) for aug_y in ys):
+        mixed_ys = [
+            aug_y
+            for aug_y in ys
+            if isinstance(aug_y, (tuple, list)) and len(aug_y) == 3
+        ]
+        if mixed_ys:
             # a target-mixing transform such as Mixup returns (y_a, y_b, lam),
             # so the parts are concatenated one by one and the untouched copies
             # are given a mixing coefficient of one
-            lam_dtype = next(t[2].dtype for t in ys if isinstance(t, tuple))
+            lam_dtype = mixed_ys[0][2].dtype
             ys = [_as_mixed_target(aug_y, lam_dtype) for aug_y in ys]
             return torch.cat(xs), tuple(torch.cat(part) for part in zip(*ys))
         return torch.cat(xs), torch.cat(ys)

--- a/braindecode/augmentation/functional.py
+++ b/braindecode/augmentation/functional.py
@@ -1065,13 +1065,11 @@ def mixup(
     batch_size, n_channels, n_times = X.shape
 
     X_mix = torch.zeros((batch_size, n_channels, n_times)).to(device)
-    y_a = torch.arange(batch_size).to(device)
-    y_b = torch.arange(batch_size).to(device)
+    y_a = y.clone()
+    y_b = y[idx_perm].clone()
 
     for idx in range(batch_size):
         X_mix[idx] = lam[idx] * X[idx] + (1 - lam[idx]) * X[idx_perm[idx]]
-        y_a[idx] = y[idx]
-        y_b[idx] = y[idx_perm[idx]]
 
     return X_mix, (y_a, y_b, lam)
 

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -1068,16 +1068,18 @@ class Mixup(Transform):
         device = X.device
         batch_size, _, _ = X.shape
 
+        # lam follows the dtype of X, numpy draws float64 and that would leak
+        # into the mixed signal and into the loss returned by mixup_criterion
         if self.alpha > 0:
             if self.beta_per_sample:
                 lam = torch.as_tensor(
                     self.rng.beta(self.alpha, self.alpha, batch_size)
-                ).to(device)
+                ).to(device=device, dtype=X.dtype)
             else:
-                lam = torch.ones(batch_size).to(device)
+                lam = torch.ones(batch_size, dtype=X.dtype).to(device)
                 lam *= self.rng.beta(self.alpha, self.alpha)
         else:
-            lam = torch.ones(batch_size).to(device)
+            lam = torch.ones(batch_size, dtype=X.dtype).to(device)
 
         idx_perm = torch.as_tensor(
             self.rng.permutation(

--- a/braindecode/training/losses.py
+++ b/braindecode/training/losses.py
@@ -80,7 +80,7 @@ def mixup_criterion(preds, target):
     ----------
     preds : torch.Tensor
         Predictions from the model.
-    target : torch.Tensor | tuple of torch.Tensor
+    target : torch.Tensor | tuple of torch.Tensor | list of torch.Tensor
         For predictions without mixup, the targets as a tensor. If mixup has
         been applied, a tuple or list containing the targets of the two mixed
         samples and the mixing coefficients as tensors. A plain tensor is

--- a/braindecode/training/losses.py
+++ b/braindecode/training/losses.py
@@ -1,6 +1,7 @@
 # Authors: Robin Schirrmeister <robintibor@gmail.com>
 #          Maciej Sliwowski <maciek.sliwowski@gmail.com>
 #          Mohammed Fattouh <mo.fattouh@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -79,10 +80,11 @@ def mixup_criterion(preds, target):
     ----------
     preds : torch.Tensor
         Predictions from the model.
-    target : torch.Tensor | list of torch.Tensor
+    target : torch.Tensor | tuple of torch.Tensor
         For predictions without mixup, the targets as a tensor. If mixup has
-        been applied, a list containing the targets of the two mixed
-        samples and the mixing coefficients as tensors.
+        been applied, a tuple or list containing the targets of the two mixed
+        samples and the mixing coefficients as tensors. A plain tensor is
+        always read as targets, whatever the batch size is.
 
     Returns
     -------
@@ -96,7 +98,8 @@ def mixup_criterion(preds, target):
        Online: https://arxiv.org/abs/1710.09412
     .. [2] https://github.com/facebookresearch/mixup-cifar10/blob/master/train.py
     """
-    if len(target) == 3:
+    # only a mixup target is a container, a plain target tensor of length 3 is not
+    if isinstance(target, (tuple, list)) and len(target) == 3:
         # unpack target
         y_a, y_b, lam = target
         # compute loss per sample

--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -387,23 +387,18 @@ class ThrowAwayIndexLoader(object):
             if isinstance(x, dict):
                 if hasattr(x["x"], "type"):
                     x["x"] = x["x"].type(torch.float32)
-                if hasattr(y, "type"):
-                    y = (
-                        y.type(torch.float32)
-                        if self.is_regression
-                        else y.type(torch.int64)
-                    )
             elif hasattr(x, "type"):
                 x = x.type(torch.float32)
-                # a target-mixing transform such as Mixup hands over a
-                # (y_a, y_b, lam) tuple, which is already typed and has nothing
-                # to cast, same guard as the dict branch above
-                if hasattr(y, "type"):
-                    y = (
-                        y.type(torch.float32)
-                        if self.is_regression
-                        else y.type(torch.int64)
-                    )
+            target_dtype = torch.float32 if self.is_regression else torch.int64
+            if isinstance(y, (tuple, list)) and len(y) == 3:
+                y_a, y_b, lam = y
+                y = (
+                    y_a.type(target_dtype),
+                    y_b.type(target_dtype),
+                    lam.type(torch.float32),
+                )
+            elif hasattr(y, "type"):
+                y = y.type(target_dtype)
             yield x, y
 
 

--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -1,4 +1,5 @@
 # Authors: Robin Schirrmeister <robintibor@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 import glob
@@ -394,10 +395,15 @@ class ThrowAwayIndexLoader(object):
                     )
             elif hasattr(x, "type"):
                 x = x.type(torch.float32)
-                if self.is_regression:
-                    y = y.type(torch.float32)
-                else:
-                    y = y.type(torch.int64)
+                # a target-mixing transform such as Mixup hands over a
+                # (y_a, y_b, lam) tuple, which is already typed and has nothing
+                # to cast, same guard as the dict branch above
+                if hasattr(y, "type"):
+                    y = (
+                        y.type(torch.float32)
+                        if self.is_regression
+                        else y.type(torch.int64)
+                    )
             yield x, y
 
 

--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -387,18 +387,23 @@ class ThrowAwayIndexLoader(object):
             if isinstance(x, dict):
                 if hasattr(x["x"], "type"):
                     x["x"] = x["x"].type(torch.float32)
+                cast_target = True
             elif hasattr(x, "type"):
                 x = x.type(torch.float32)
-            target_dtype = torch.float32 if self.is_regression else torch.int64
-            if isinstance(y, (tuple, list)) and len(y) == 3:
-                y_a, y_b, lam = y
-                y = (
-                    y_a.type(target_dtype),
-                    y_b.type(target_dtype),
-                    lam.type(torch.float32),
-                )
-            elif hasattr(y, "type"):
-                y = y.type(target_dtype)
+                cast_target = True
+            else:
+                cast_target = False
+            if cast_target:
+                target_dtype = torch.float32 if self.is_regression else torch.int64
+                if isinstance(y, (tuple, list)) and len(y) == 3:
+                    y_a, y_b, lam = y
+                    y = (
+                        y_a.type(target_dtype),
+                        y_b.type(target_dtype),
+                        lam.type(torch.float32),
+                    )
+                elif hasattr(y, "type"):
+                    y = y.type(target_dtype)
             yield x, y
 
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -43,7 +43,27 @@ Requirements
 Bug fixes
 ==========
 
-- None yet
+- Fix :func:`braindecode.training.mixup_criterion` treating a plain target
+  tensor of three elements as a mixup ``(y_a, y_b, lam)`` triple. The branch
+  was selected on ``len(target) == 3``, which is also true for the targets of
+  any batch holding three windows, so a validation batch or a last partial
+  batch of that size failed with ``Expected input batch_size (3) to match
+  target batch_size (0)``. The mixup branch is now selected on the container
+  type. By `Sarthak Tayal`_.
+
+- Keep the mixing coefficient of :class:`braindecode.augmentation.Mixup` on the
+  dtype of the batch. With ``beta_per_sample=True`` it came straight from numpy
+  as ``float64``, which upcast the loss returned by
+  :func:`braindecode.training.mixup_criterion` to ``float64`` while the model
+  stayed in ``float32``. By `Sarthak Tayal`_.
+
+- Let :class:`braindecode.augmentation.AugmentedDataLoader` used with
+  ``n_augmentation`` greater than zero carry the targets of a transform that
+  mixes them. Batches were concatenated as plain tensors, so combining that
+  option with :class:`braindecode.augmentation.Mixup` raised ``expected Tensor
+  as element 1 in argument 0, but got tuple``. The triple parts are now
+  concatenated one by one and the clean originals get a mixing coefficient of
+  one. By `Sarthak Tayal`_.
 
 Code health
 ============

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -65,6 +65,14 @@ Bug fixes
   concatenated one by one and the clean originals get a mixing coefficient of
   one. By `Sarthak Tayal`_.
 
+- Let :class:`braindecode.EEGClassifier` and :class:`braindecode.EEGRegressor`
+  train with a transform that mixes targets. The loader wrapper cast every
+  target with ``y.type(...)``, so a batch carrying the ``(y_a, y_b, lam)``
+  triple of :class:`braindecode.augmentation.Mixup` stopped the fit with
+  ``'tuple' object has no attribute 'type'`` before the first batch was seen.
+  The cast is now guarded the same way the channel-position branch next to it
+  already was. By `Sarthak Tayal`_.
+
 Code health
 ============
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -70,8 +70,8 @@ Bug fixes
   target with ``y.type(...)``, so a batch carrying the ``(y_a, y_b, lam)``
   triple of :class:`braindecode.augmentation.Mixup` stopped the fit with
   ``'tuple' object has no attribute 'type'`` before the first batch was seen.
-  The cast is now guarded the same way the channel-position branch next to it
-  already was. By `Sarthak Tayal`_.
+  The triple parts now follow the same classification/regression dtype contract
+  as a plain target. By `Sarthak Tayal`_.
 
 Code health
 ============

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -1,4 +1,5 @@
 # Authors: Cédric Rommel <cedric.rommel@inria.fr>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -9,8 +10,9 @@ import torch
 from sklearn.utils import check_random_state
 
 from braindecode.augmentation.base import AugmentedDataLoader, Compose, Transform
-from braindecode.augmentation.transforms import SmoothTimeMask
+from braindecode.augmentation.transforms import Mixup, SmoothTimeMask
 from braindecode.datasets import create_from_mne_epochs
+from braindecode.training.losses import mixup_criterion
 
 
 def dummy_k_operation(X, y, k):
@@ -236,6 +238,51 @@ def test_augmented_data_loader_negative_n_augmentation():
     dataset = TensorDataset(torch.randn(4, 4, 20), torch.arange(4))
     with pytest.raises(ValueError, match="n_augmentation"):
         AugmentedDataLoader(dataset, n_augmentation=-1, batch_size=4)
+
+
+@pytest.mark.parametrize("beta_per_sample", [False, True])
+def test_augmented_data_loader_n_augmentation_mixup(beta_per_sample):
+    """``n_augmentation`` keeps the ``(y_a, y_b, lam)`` triple Mixup returns."""
+    from torch.utils.data import TensorDataset
+
+    n_samples, n_chans, n_times, batch_size = 8, 4, 20, 8
+    X = torch.randn(n_samples, n_chans, n_times)
+    y = torch.arange(n_samples) % 2
+
+    loader = AugmentedDataLoader(
+        TensorDataset(X, y),
+        transforms=Mixup(alpha=0.5, beta_per_sample=beta_per_sample, random_state=0),
+        batch_size=batch_size,
+        n_augmentation=2,
+        shuffle=False,
+    )
+    batch_X, batch_y = next(iter(loader))
+
+    assert batch_X.shape == (3 * batch_size, n_chans, n_times)
+    assert isinstance(batch_y, tuple) and len(batch_y) == 3
+    y_a, y_b, lam = batch_y
+    assert y_a.shape == y_b.shape == lam.shape == (3 * batch_size,)
+    # The clean block is untouched and mixed with itself with a coefficient of one.
+    assert torch.equal(batch_X[:batch_size], X)
+    assert torch.equal(y_a[:batch_size], y)
+    assert torch.equal(y_b[:batch_size], y)
+    assert torch.all(lam[:batch_size] == 1.0)
+    # The loss can consume the batch, which needs one single dtype for lam.
+    preds = torch.log_softmax(torch.randn(3 * batch_size, 2), dim=1)
+    assert torch.isfinite(mixup_criterion(preds, batch_y))
+
+
+@pytest.mark.parametrize("beta_per_sample", [False, True])
+def test_mixup_lam_follows_batch_dtype(beta_per_sample):
+    """``lam`` stays on the dtype of the batch so the loss is not upcast."""
+    X = torch.randn(6, 3, 20)
+    y = torch.arange(6) % 2
+
+    _, out_y = Mixup(alpha=0.5, beta_per_sample=beta_per_sample, random_state=0)(X, y)
+    assert out_y[2].dtype == X.dtype
+
+    preds = torch.log_softmax(torch.randn(6, 2), dim=1)
+    assert mixup_criterion(preds, out_y).dtype == preds.dtype
 
 
 @pytest.mark.network

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 from sklearn.utils import check_random_state
 
+from braindecode import EEGRegressor
 from braindecode.augmentation.base import (
     AugmentedDataLoader,
     Compose,
@@ -36,6 +37,31 @@ class DummyTransform(Transform):
 
     def get_augmentation_params(self, X, y):
         return {"k": self.k}
+
+
+class _TinyMixupRegressor(torch.nn.Module):
+    def __init__(self, n_chans=2, n_times=20, n_outputs=1):
+        super().__init__()
+        self.linear = torch.nn.Linear(n_chans * n_times, n_outputs)
+
+    def forward(self, x):
+        return self.linear(x.flatten(start_dim=1))
+
+
+class _RecordingMixupMSELoss(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.seen_targets = []
+
+    def forward(self, preds, target):
+        y_a, y_b, lam = target
+        self.seen_targets.append(
+            tuple(part.detach().cpu().clone() for part in (y_a, y_b, lam))
+        )
+        lam = lam.reshape(lam.shape[0], *([1] * (preds.ndim - 1)))
+        return (
+            lam * torch.square(preds - y_a) + (1 - lam) * torch.square(preds - y_b)
+        ).mean()
 
 
 @pytest.fixture
@@ -307,6 +333,60 @@ def test_mixup_lam_follows_batch_dtype(beta_per_sample):
 
     preds = torch.log_softmax(torch.randn(6, 2), dim=1)
     assert mixup_criterion(preds, out_y).dtype == preds.dtype
+
+
+@pytest.mark.parametrize("beta_per_sample", [False, True])
+@pytest.mark.parametrize("n_augmentation", [0, 2])
+def test_eegregressor_mixup_preserves_fractional_targets(
+    beta_per_sample, n_augmentation
+):
+    """The public fit boundary keeps fractional ``(B, 1)`` mixed targets."""
+    batch_size, n_chans, n_times = 6, 2, 20
+    X = torch.randn(batch_size, n_chans, n_times)
+    y = torch.tensor(
+        [0.25, 1.75, -2.5, 3.125, 4.875, -5.25], dtype=torch.float64
+    ).reshape(batch_size, 1)
+
+    regressor = EEGRegressor(
+        _TinyMixupRegressor,
+        criterion=_RecordingMixupMSELoss,
+        optimizer=torch.optim.SGD,
+        lr=0.01,
+        iterator_train=AugmentedDataLoader,
+        iterator_train__transforms=Mixup(
+            alpha=0.5,
+            beta_per_sample=beta_per_sample,
+            random_state=0,
+        ),
+        iterator_train__n_augmentation=n_augmentation,
+        iterator_train__shuffle=False,
+        iterator_train__drop_last=False,
+        batch_size=batch_size,
+        max_epochs=1,
+        train_split=None,
+        verbose=0,
+    )
+
+    regressor.fit(X, y)
+
+    assert len(regressor.criterion_.seen_targets) == 1
+    y_a, y_b, lam = regressor.criterion_.seen_targets[0]
+    n_copies = n_augmentation + 1
+    expected_y = y.to(torch.float32)
+    expected_y_a = expected_y.repeat(n_copies, 1)
+    assert y_a.shape == y_b.shape == (n_copies * batch_size, 1)
+    assert y_a.dtype == y_b.dtype == torch.float32
+    assert torch.equal(y_a, expected_y_a)
+
+    expected_sorted = expected_y.sort(dim=0).values
+    for target_block in y_b.split(batch_size):
+        assert torch.equal(target_block.sort(dim=0).values, expected_sorted)
+
+    assert lam.shape == (n_copies * batch_size,)
+    assert lam.dtype == torch.float32
+    if n_augmentation:
+        assert torch.equal(lam[:batch_size], torch.ones(batch_size))
+    assert np.isfinite(regressor.history[-1, "train_loss"])
 
 
 @pytest.mark.network

--- a/test/unit_tests/augmentation/test_base.py
+++ b/test/unit_tests/augmentation/test_base.py
@@ -9,7 +9,12 @@ import pytest
 import torch
 from sklearn.utils import check_random_state
 
-from braindecode.augmentation.base import AugmentedDataLoader, Compose, Transform
+from braindecode.augmentation.base import (
+    AugmentedDataLoader,
+    Compose,
+    Transform,
+    _AugmentationCollate,
+)
 from braindecode.augmentation.transforms import Mixup, SmoothTimeMask
 from braindecode.datasets import create_from_mne_epochs
 from braindecode.training.losses import mixup_criterion
@@ -270,6 +275,25 @@ def test_augmented_data_loader_n_augmentation_mixup(beta_per_sample):
     # The loss can consume the batch, which needs one single dtype for lam.
     preds = torch.log_softmax(torch.randn(3 * batch_size, 2), dim=1)
     assert torch.isfinite(mixup_criterion(preds, batch_y))
+
+
+def test_augmentation_collate_accepts_list_mixed_target():
+    """List-form mixed targets follow the same expansion path as tuples."""
+    batch_size = 4
+    X = torch.randn(batch_size, 2, 10)
+    y = torch.arange(batch_size)
+
+    def list_mixup(batch_X, batch_y):
+        lam = torch.full((batch_X.shape[0],), 0.5, dtype=batch_X.dtype)
+        return batch_X, [batch_y, batch_y.flip(0), lam]
+
+    batch_X, batch_y = _AugmentationCollate(list_mixup, n_augmentation=1)(
+        list(zip(X, y))
+    )
+
+    assert batch_X.shape[0] == 2 * batch_size
+    assert isinstance(batch_y, tuple) and len(batch_y) == 3
+    assert all(part.shape == (2 * batch_size,) for part in batch_y)
 
 
 @pytest.mark.parametrize("beta_per_sample", [False, True])

--- a/test/unit_tests/augmentation/test_transforms.py
+++ b/test/unit_tests/augmentation/test_transforms.py
@@ -626,6 +626,67 @@ def test_mixup_transform(rng_seed, random_batch, alpha, beta_per_sample):
         assert torch.equal(X_t, X)
 
 
+@pytest.mark.parametrize("beta_per_sample", [False, True])
+@pytest.mark.parametrize("trailing_shape", [(), (1,), (2,)])
+@pytest.mark.parametrize("target_dtype", [torch.float32, torch.float64])
+def test_mixup_preserves_fractional_target_contract(
+    rng_seed,
+    random_batch,
+    beta_per_sample,
+    trailing_shape,
+    target_dtype,
+):
+    """Mixed targets preserve every target value, dimension, dtype, and device."""
+    X, _ = random_batch
+    batch_size = X.shape[0]
+    n_target_values = batch_size * max(1, np.prod(trailing_shape, dtype=int))
+    y = (
+        torch.arange(n_target_values, device=X.device, dtype=target_dtype)
+        .add(0.25)
+        .reshape(batch_size, *trailing_shape)
+    )
+
+    _, (y_a, y_b, lam) = Mixup(
+        alpha=0.5,
+        beta_per_sample=beta_per_sample,
+        random_state=rng_seed,
+    )(X, y)
+
+    assert torch.equal(y_a, y)
+    assert y_a.shape == y_b.shape == y.shape
+    assert y_a.dtype == y_b.dtype == target_dtype
+    assert y_a.device == y_b.device == y.device
+
+    expected_rows = y.reshape(batch_size, -1)
+    actual_rows = y_b.reshape(batch_size, -1)
+    expected_order = expected_rows[:, 0].argsort()
+    actual_order = actual_rows[:, 0].argsort()
+    assert torch.equal(actual_rows[actual_order], expected_rows[expected_order])
+    assert lam.shape == (batch_size,)
+    assert lam.dtype == X.dtype
+    assert lam.device == X.device
+
+
+@pytest.mark.parametrize("beta_per_sample", [False, True])
+def test_mixup_preserves_unbatched_fractional_target(beta_per_sample):
+    """An unbatched example keeps its fractional target after internal batching."""
+    X = torch.randn(3, 20)
+    y = torch.tensor(1.75, dtype=torch.float64)
+
+    transformed_X, (y_a, y_b, lam) = Mixup(
+        alpha=0.5,
+        beta_per_sample=beta_per_sample,
+        random_state=0,
+    )(X, y)
+
+    assert transformed_X.shape == X.shape
+    assert torch.equal(y_a, y.reshape(1))
+    assert torch.equal(y_b, y.reshape(1))
+    assert y_a.dtype == y_b.dtype == y.dtype
+    assert y_a.device == y_b.device == y.device
+    assert lam.shape == (1,)
+
+
 MONTAGE_10_20 = [
     "Fz",
     "FC3",

--- a/test/unit_tests/test_util.py
+++ b/test/unit_tests/test_util.py
@@ -1,5 +1,6 @@
 # Authors: Hubert Banville <hubert.jbanville@gmail.com>
 #          Bruno Aristimunha <b.aristimunha@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 # License: BSD-3
 
 import os
@@ -402,6 +403,22 @@ def test_throwaway_index_loader_backward_compat():
     x, yy, net = _route((X, y, crop))
     assert torch.is_tensor(x)
     assert net._last_window_inds_ is crop  # index stashed for scoring
+
+
+def test_throwaway_index_loader_keeps_mixup_target():
+    """A ``(y_a, y_b, lam)`` target is passed on instead of being cast."""
+    B, C, T = 4, 10, 200
+    X = torch.randn(B, C, T)
+    y_a = torch.zeros(B, dtype=torch.int64)
+    y_b = torch.ones(B, dtype=torch.int64)
+    lam = torch.full((B,), 0.3)
+
+    x, yy, _ = _route((X, (y_a, y_b, lam)))
+    assert torch.is_tensor(x) and x.dtype == torch.float32
+    assert isinstance(yy, tuple) and len(yy) == 3
+    assert torch.equal(yy[0], y_a)
+    assert torch.equal(yy[1], y_b)
+    assert torch.equal(yy[2], lam)
 
 
 def test_looks_like_channel_mask_dtypes():

--- a/test/unit_tests/test_util.py
+++ b/test/unit_tests/test_util.py
@@ -405,20 +405,23 @@ def test_throwaway_index_loader_backward_compat():
     assert net._last_window_inds_ is crop  # index stashed for scoring
 
 
-def test_throwaway_index_loader_keeps_mixup_target():
-    """A ``(y_a, y_b, lam)`` target is passed on instead of being cast."""
+@pytest.mark.parametrize(
+    "is_regression,target_dtype",
+    [(False, torch.int64), (True, torch.float32)],
+)
+def test_throwaway_index_loader_casts_mixup_target(is_regression, target_dtype):
+    """Mixed targets follow the same dtype contract as plain targets."""
     B, C, T = 4, 10, 200
     X = torch.randn(B, C, T)
-    y_a = torch.zeros(B, dtype=torch.int64)
-    y_b = torch.ones(B, dtype=torch.int64)
-    lam = torch.full((B,), 0.3)
+    y_a = torch.zeros(B, dtype=torch.float64)
+    y_b = torch.ones(B, dtype=torch.float64)
+    lam = torch.full((B,), 0.3, dtype=torch.float64)
 
-    x, yy, _ = _route((X, (y_a, y_b, lam)))
+    x, yy, _ = _route((X, (y_a, y_b, lam)), is_regression=is_regression)
     assert torch.is_tensor(x) and x.dtype == torch.float32
     assert isinstance(yy, tuple) and len(yy) == 3
-    assert torch.equal(yy[0], y_a)
-    assert torch.equal(yy[1], y_b)
-    assert torch.equal(yy[2], lam)
+    assert yy[0].dtype == yy[1].dtype == target_dtype
+    assert yy[2].dtype == torch.float32
 
 
 def test_looks_like_channel_mask_dtypes():

--- a/test/unit_tests/test_util.py
+++ b/test/unit_tests/test_util.py
@@ -406,10 +406,17 @@ def test_throwaway_index_loader_backward_compat():
 
 
 @pytest.mark.parametrize(
-    "is_regression,target_dtype",
-    [(False, torch.int64), (True, torch.float32)],
+    "is_regression,target_dtype,container",
+    [
+        (False, torch.int64, tuple),
+        (False, torch.int64, list),
+        (True, torch.float32, tuple),
+        (True, torch.float32, list),
+    ],
 )
-def test_throwaway_index_loader_casts_mixup_target(is_regression, target_dtype):
+def test_throwaway_index_loader_casts_mixup_target(
+    is_regression, target_dtype, container
+):
     """Mixed targets follow the same dtype contract as plain targets."""
     B, C, T = 4, 10, 200
     X = torch.randn(B, C, T)
@@ -417,11 +424,28 @@ def test_throwaway_index_loader_casts_mixup_target(is_regression, target_dtype):
     y_b = torch.ones(B, dtype=torch.float64)
     lam = torch.full((B,), 0.3, dtype=torch.float64)
 
-    x, yy, _ = _route((X, (y_a, y_b, lam)), is_regression=is_regression)
+    x, yy, _ = _route(
+        (X, container((y_a, y_b, lam))), is_regression=is_regression
+    )
     assert torch.is_tensor(x) and x.dtype == torch.float32
     assert isinstance(yy, tuple) and len(yy) == 3
     assert yy[0].dtype == yy[1].dtype == target_dtype
     assert yy[2].dtype == torch.float32
+
+
+def test_throwaway_index_loader_preserves_composite_input_target_dtype():
+    """Custom criteria keep float targets paired with composite model inputs."""
+    batch_size, n_chans, n_times = 4, 2, 20
+    x = (
+        torch.randn(batch_size, n_chans, n_times),
+        torch.randn(batch_size, n_chans, n_times),
+    )
+    y = torch.randint(0, 2, (batch_size,), dtype=torch.float32)
+
+    routed_x, routed_y, _ = _route((x, y))
+
+    assert routed_x is x
+    assert routed_y.dtype == torch.float32
 
 
 def test_looks_like_channel_mask_dtypes():

--- a/test/unit_tests/training/test_losses.py
+++ b/test/unit_tests/training/test_losses.py
@@ -1,5 +1,6 @@
 # Authors: Simon Brandt <simonbrandt@protonmail.com>
 #          Maciej Sliwowski <maciek.sliwowski@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD-3 (3-clause)
 
@@ -27,6 +28,29 @@ def test_mixup_criterion():
     target = y_a
     loss = mixup_criterion(preds, target)
     expected = -preds[:, 0].mean()
+    assert loss == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("n_samples", [1, 2, 3, 4])
+def test_mixup_criterion_plain_target(n_samples):
+    n_classes = 2
+    preds = torch.Tensor(np.random.RandomState(42).randn(n_samples, n_classes))
+    target = torch.zeros(n_samples, dtype=torch.int64)
+
+    loss = mixup_criterion(preds, target)
+    expected = -preds[:, 0].mean()
+    assert loss == pytest.approx(expected)
+
+
+def test_mixup_criterion_accepts_list_target():
+    n_samples = 3
+    y_a = torch.zeros(n_samples, dtype=torch.int64)
+    y_b = torch.ones(n_samples, dtype=torch.int64)
+    lam = torch.arange(0.1, 1, 1 / n_samples)
+    preds = torch.Tensor(np.random.RandomState(42).randn(n_samples, 2))
+
+    loss = mixup_criterion(preds, [y_a, y_b, lam])
+    expected = -(lam * preds[:, 0] + (1 - lam) * preds[:, 1]).mean()
     assert loss == pytest.approx(expected)
 
 


### PR DESCRIPTION
heres the summary

`braindecode.augmentation.Mixup` hands its targets over as a `(y_a, y_b, lam)` triple. Five points along that path mishandle the triple. One of them also misreads a target tensor, which reaches runs that never touch Mixup. This pull request addresses all five.

Closes #1121

1. `mixup_criterion` read a batch of three targets as a mixup triple

`braindecode/training/losses.py` selected the mixup branch with `len(target) == 3`. That condition holds for a plain target tensor whenever the batch carries three windows.

```python
preds = torch.log_softmax(torch.randn(3, 4), dim=1)
mixup_criterion(preds, torch.tensor([0, 1, 2]))
# ValueError: Expected input batch_size (3) to match target batch_size (0).
```

A batch of four returned a loss as expected. Any validation split holding three windows, and any last partial batch of three, reached this. The criterion is applied to validation batches as well, which means Mixup did not have to be in the pipeline.

The branch is now selected on the container type, since only a mixed target is a tuple or a list. The parameter description records that a plain tensor is read as targets at any batch size.

2. The loader wrapper of the estimators cast the triple

`ThrowAwayIndexLoader.__iter__` in `braindecode/util.py` cast every target with `y.type(...)`. The channel position branch directly above it guards that call with `hasattr(y, "type")`. This branch did not, which ended a fit with `AttributeError: 'tuple' object has no attribute 'type'` before the first batch was trained. Mixup combined with `EEGClassifier` or `EEGRegressor` therefore did not get off the ground.

The cast is now guarded the same way as the branch beside it. A mixed target is already typed by `Mixup`, which produces integer class labels together with a floating point coefficient, and has nothing to cast.

3. `AugmentedDataLoader` with `n_augmentation` could not expand a mixed batch

The expansion path concatenated the collected targets as plain tensors, which a mixed target is not, and raised `TypeError: expected Tensor as element 1 in argument 0, but got tuple`.

The three parts are now concatenated individually when any copy carries a triple. The clean originals are promoted to `(y, y, 1)`, which reduces the weighted sum in `mixup_criterion` to the plain loss on those samples, leaving their contribution unchanged. Transforms that return a plain target keep returning a plain tensor.

4. The mixing coefficient left the dtype of the batch

With `beta_per_sample=True`, `lam` came straight out of numpy as `float64`, while the batch and the model parameters stayed `float32`. The loss returned by `mixup_criterion` was then `float64`.

```text
beta_per_sample=False  lam float32  loss float32
beta_per_sample=True   lam float64  loss float64
```

`lam` now follows the dtype of the batch in both settings. This also lets the two halves in point 3 concatenate, since a clean coefficient and a mixed one share one dtype.

5. Mixup truncated regression targets and dropped their trailing dimensions

`braindecode/augmentation/functional.py` allocated `y_a` and `y_b` as one-dimensional integer `torch.arange(batch_size)` buffers before assigning the real targets. Fractional regression values such as `0.25` and `1.75` became `0` and `1`, while `(B, 1)` and multi-output targets were collapsed to `(B,)`.

With `n_augmentation=0`, a regressor could therefore train silently on corrupted targets after the estimator cast the integers back to floating point. With a positive expansion, the clean `(B, 1)` targets and mixed `(B,)` targets instead failed during concatenation.

The paired targets now come directly from the input target:

```python
y_a = y.clone()
y_b = y[idx_perm].clone()
```

This preserves every value, trailing dimension, dtype, and device while retaining the same sampled permutation. The regression coverage exercises scalar, `(B,)`, `(B, 1)`, and multi-output targets; both beta modes; `n_augmentation` zero and positive; partial batches; classification and regression fits; and two-worker serialization.
