### PR TITLE
Fix EEGPrep 0.3 compatibility

### DIFF
--- a/braindecode/preprocessing/eegprep_preprocess.py
+++ b/braindecode/preprocessing/eegprep_preprocess.py
@@ -517,7 +517,7 @@ class EEGPrep(EEGPrepBasePreprocessor):
         # do a check if the data has a supported sampling rate
         if self.burst_removal_cutoff is not None:
             supported_rates = (100, 128, 200, 250, 256, 300, 500, 512)
-            cur_srate = int(eegprep.utils.round_mat(eeg["srate"]))
+            cur_srate = int(np.floor(float(eeg["srate"]) + 0.5))
             if cur_srate not in supported_rates:
                 # note: technically the method will run if you disable this error,
                 #   but you're likely getting (potentially quite) suboptimal results

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -43,7 +43,9 @@ Requirements
 Bug fixes
 ==========
 
-- None yet
+- Keep :class:`braindecode.preprocessing.EEGPrep` compatible with EEGPrep 0.3,
+  which no longer exposes the ``eegprep.utils`` namespace used for sampling-rate
+  validation. By `Bruno Aristimunha`_.
 
 Code health
 ============

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -45,7 +45,7 @@ Bug fixes
 
 - Keep :class:`braindecode.preprocessing.EEGPrep` compatible with EEGPrep 0.3,
   which no longer exposes the ``eegprep.utils`` namespace used for sampling-rate
-  validation. By `Bruno Aristimunha`_.
+  validation (:gh:`1123` by `Bruno Aristimunha`_).
 
 Code health
 ============

--- a/test/unit_tests/preprocessing/test_eegprep_preprocessor.py
+++ b/test/unit_tests/preprocessing/test_eegprep_preprocessor.py
@@ -3,6 +3,7 @@
 # License: BSD-3
 
 import copy
+from types import SimpleNamespace
 
 import mne
 import numpy as np
@@ -705,6 +706,24 @@ def test_missing_eegprep_raises_error(base_concat_ds, monkeypatch):
     error_message = str(exc_info.value)
     assert "pip install braindecode[eegprep]" in error_message, \
         f"Expected installation instructions in error message, got: {error_message}"
+
+
+def test_eegprep_does_not_require_utils_namespace(monkeypatch):
+    """Support EEGPrep 0.3, which no longer exports ``eegprep.utils``."""
+    import braindecode.preprocessing.eegprep_preprocess as eegprep_module
+
+    fake_eegprep = SimpleNamespace(
+        clean_artifacts=lambda eeg, **kwargs: (eeg,),
+    )
+    monkeypatch.setattr(eegprep_module, "eegprep", fake_eegprep)
+    eeg = {"data": np.zeros((1, 10)), "srate": 250.0, "chanlocs": []}
+
+    result = EEGPrep(
+        bad_channel_reinterpolate=False,
+        common_avg_ref=False,
+    ).apply_eeg(eeg, raw=None)
+
+    assert result["srate"] == 250.0
 
 
 @pytest.mark.skipif(not EEGPREP_AVAILABLE, reason="eegprep not installed")


### PR DESCRIPTION
## Summary

EEGPrep 0.3 removed its public `eegprep.utils` namespace. `EEGPrep.apply_eeg` still used `eegprep.utils.round_mat` when validating sampling rates, so the executable EEGPrep cleaning tutorial and user code now fail with an `AttributeError`.

This replaces that call with the equivalent NumPy half-up rounding and adds a regression test whose EEGPrep stub intentionally has no `utils` namespace.

## Validation

- `pre-commit run --files braindecode/preprocessing/eegprep_preprocess.py test/unit_tests/preprocessing/test_eegprep_preprocessor.py docs/whats_new.rst`
- `python -m pytest test/unit_tests/preprocessing/test_eegprep_preprocessor.py -q` (16 passed)
- Direct compatibility-path check against the EEGPrep 0.3.0 wheel (where `hasattr(eegprep, "utils")` is false)