### PR TITLE
Handle recordings shorter than n_windows in the sequence samplers

### DIFF
--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -275,7 +275,7 @@ class SequenceSampler(RecordingSampler):
         )
         # a typed array keeps the ids integer when a recording yields no sequence
         file_ids = [
-            np.full(len(inds), i, dtype=int) for i, inds in enumerate(start_inds)
+            np.full(len(inds), i, dtype=np.int64) for i, inds in enumerate(start_inds)
         ]
         return np.concatenate(start_inds), np.concatenate(file_ids)
 
@@ -343,7 +343,10 @@ class BalancedSequenceSampler(RecordingSampler):
         np.ndarray :
             Array of recording indices holding at least ``n_windows`` windows.
         """
-        n_windows_per_rec = self.info["index"].apply(len).values
+        n_windows_per_rec = self.info["index"].apply(len).to_numpy()
+        if n_windows_per_rec.size == 0:
+            raise ValueError("Cannot build sequences from empty metadata.")
+
         long_enough = np.flatnonzero(n_windows_per_rec >= self.n_windows)
         if len(long_enough) == 0:
             raise ValueError(

--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -5,6 +5,7 @@ Sampler classes.
 # Authors: Hubert Banville <hubert.jbanville@gmail.com>
 #          Theo Gnassounou <>
 #          Young Truong <dt.young112@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -296,6 +297,10 @@ class BalancedSequenceSampler(RecordingSampler):
     3. Sample a window of the corresponding class in the selected recording.
     4. Extract a sequence of windows around the sampled window.
 
+    Recordings holding fewer than ``n_windows`` windows cannot contain a full
+    sequence and are left out of step 1, as they are in
+    :class:`SequenceSampler`.
+
     Parameters
     ----------
     metadata : pd.DataFrame
@@ -322,6 +327,30 @@ class BalancedSequenceSampler(RecordingSampler):
         self.n_windows = n_windows
         self.n_sequences = n_sequences
         self.info_class = self._init_info(metadata, required_keys=["target"])
+        self.long_enough_recordings = self._find_long_enough_recordings()
+
+    def _find_long_enough_recordings(self):
+        """Return the indices of the recordings that can hold a full sequence.
+
+        Returns
+        -------
+        np.ndarray :
+            Array of recording indices holding at least ``n_windows`` windows.
+        """
+        n_windows_per_rec = self.info["index"].apply(len).values
+        long_enough = np.flatnonzero(n_windows_per_rec >= self.n_windows)
+        if len(long_enough) == 0:
+            raise ValueError(
+                f"No recording holds enough windows to build a sequence of "
+                f"{self.n_windows} windows. The longest recording has "
+                f"{n_windows_per_rec.max()} windows. Reduce n_windows to at "
+                f"most that value."
+            )
+        return long_enough
+
+    def sample_recording(self):
+        """Return a random recording index among the ones long enough."""
+        return self.rng.choice(self.long_enough_recordings)
 
     def sample_class(self, rec_ind=None):
         """Return a random class.

--- a/braindecode/samplers/base.py
+++ b/braindecode/samplers/base.py
@@ -220,6 +220,9 @@ class DistributedRecordingSampler(DistributedSampler):
 class SequenceSampler(RecordingSampler):
     """Sample sequences of consecutive windows.
 
+    Recordings holding fewer than ``n_windows`` windows cannot contain a full
+    sequence and contribute none.
+
     Parameters
     ----------
     metadata : pd.DataFrame
@@ -228,7 +231,7 @@ class SequenceSampler(RecordingSampler):
         Number of consecutive windows in a sequence.
     n_windows_stride : int
         Number of windows between two consecutive sequences.
-    random : bool
+    randomize : bool
         If True, sample sequences randomly. If False, sample sequences in
         order.
     random_state : np.random.RandomState | int | None
@@ -270,7 +273,10 @@ class SequenceSampler(RecordingSampler):
             .apply(lambda x: x[: end_offset : self.n_windows_stride])
             .values
         )
-        file_ids = [[i] * len(inds) for i, inds in enumerate(start_inds)]
+        # a typed array keeps the ids integer when a recording yields no sequence
+        file_ids = [
+            np.full(len(inds), i, dtype=int) for i, inds in enumerate(start_inds)
+        ]
         return np.concatenate(start_inds), np.concatenate(file_ids)
 
     def __len__(self):

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -56,18 +56,18 @@ Bug fixes
   range empty and raised ``ValueError: high <= 0`` on the first sequence that
   landed there. :class:`braindecode.samplers.SequenceSampler` already skips
   those recordings. A clear error now names the longest recording when none of
-  them can hold a sequence. By `Sarthak Tayal`_.
+  them can hold a sequence (:gh:`1125` by `Sarthak Tayal`_).
 
 - Keep ``file_ids`` of :class:`braindecode.samplers.SequenceSampler` integer.
   The ids were built from untyped lists, so an empty list coming from a
   recording too short for a sequence turned the concatenated array into
-  ``float64``, against the documented dtype and unusable as an index. By
-  `Sarthak Tayal`_.
+  ``float64``, against the documented dtype and unusable as an index
+  (:gh:`1125` by `Sarthak Tayal`_).
 
 - Document the ``randomize`` parameter of
   :class:`braindecode.samplers.SequenceSampler` under its own name. The
-  docstring described it as ``random``, which no signature accepts. By
-  `Sarthak Tayal`_.
+  docstring described it as ``random``, which no signature accepts
+  (:gh:`1125` by `Sarthak Tayal`_).
 
 Code health
 ============

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -50,6 +50,25 @@ Bug fixes
   which no longer exposes the ``eegprep.utils`` namespace used for sampling-rate
   validation (:gh:`1123` by `Bruno Aristimunha`_).
 
+- Leave recordings shorter than ``n_windows`` out of the draw in
+  :class:`braindecode.samplers.BalancedSequenceSampler` instead of failing on
+  them. Such a recording holds no valid sequence start, which made the sampling
+  range empty and raised ``ValueError: high <= 0`` on the first sequence that
+  landed there. :class:`braindecode.samplers.SequenceSampler` already skips
+  those recordings. A clear error now names the longest recording when none of
+  them can hold a sequence. By `Sarthak Tayal`_.
+
+- Keep ``file_ids`` of :class:`braindecode.samplers.SequenceSampler` integer.
+  The ids were built from untyped lists, so an empty list coming from a
+  recording too short for a sequence turned the concatenated array into
+  ``float64``, against the documented dtype and unusable as an index. By
+  `Sarthak Tayal`_.
+
+- Document the ``randomize`` parameter of
+  :class:`braindecode.samplers.SequenceSampler` under its own name. The
+  docstring described it as ``random``, which no signature accepts. By
+  `Sarthak Tayal`_.
+
 Code health
 ============
 

--- a/test/unit_tests/samplers/test_samplers.py
+++ b/test/unit_tests/samplers/test_samplers.py
@@ -4,6 +4,7 @@ Test for samplers.
 
 # Authors: Hubert Banville <hubert.jbanville@gmail.com>
 #          Young Truong <dt.young112@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -478,3 +479,58 @@ def test_balanced_sequence_sampler_no_targets(windows_ds):
     md = windows_ds.get_metadata().drop(columns="target")
     with pytest.raises(ValueError):
         BalancedSequenceSampler(md, 10, n_sequences=5, random_state=87)
+
+
+def _sequence_metadata(windows_per_recording):
+    """Build a windows metadata frame with one recording per given length."""
+    rows = []
+    for subject, n_windows in enumerate(windows_per_recording):
+        for i_window in range(n_windows):
+            rows.append(
+                {
+                    "i_window_in_trial": i_window,
+                    "i_start_in_trial": i_window * 100,
+                    "i_stop_in_trial": i_window * 100 + 100,
+                    "target": i_window % 2,
+                    "subject": subject,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+@pytest.mark.parametrize("windows_per_recording", [[10, 10], [10, 3], [3, 10], [3, 2]])
+def test_sequence_sampler_file_ids_stay_integer(windows_per_recording):
+    """A recording too short for a sequence must not float the file ids."""
+    md = _sequence_metadata(windows_per_recording)
+    sampler = SequenceSampler(md, n_windows=5, n_windows_stride=1)
+
+    assert sampler.file_ids.dtype == np.int64
+    assert sampler.start_inds.dtype == np.int64
+
+    expected = sum(max(0, n - 5 + 1) for n in windows_per_recording)
+    assert len(sampler) == expected
+    assert len(sampler.file_ids) == expected
+
+
+def test_balanced_sequence_sampler_skips_short_recordings():
+    """A recording shorter than n_windows is left out rather than sampled."""
+    md = _sequence_metadata([10, 3])
+    sampler = BalancedSequenceSampler(md, 5, n_sequences=50, random_state=87)
+
+    assert list(sampler.long_enough_recordings) == [0]
+
+    seqs = list(sampler)
+    assert len(seqs) == 50
+    assert all(len(seq) == 5 for seq in seqs)
+    for seq in seqs:
+        assert all(np.diff(seq) == 1)
+        # every window has to come from the recording that is long enough
+        assert md.iloc[list(seq)]["subject"].nunique() == 1
+        assert md.iloc[list(seq)]["subject"].iloc[0] == 0
+
+
+def test_balanced_sequence_sampler_all_recordings_too_short():
+    """No recording able to hold a sequence is reported clearly."""
+    md = _sequence_metadata([3, 2])
+    with pytest.raises(ValueError, match="longest recording has 3 windows"):
+        BalancedSequenceSampler(md, 5, n_sequences=5, random_state=87)

--- a/test/unit_tests/samplers/test_samplers.py
+++ b/test/unit_tests/samplers/test_samplers.py
@@ -495,7 +495,16 @@ def _sequence_metadata(windows_per_recording):
                     "subject": subject,
                 }
             )
-    return pd.DataFrame(rows)
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "i_window_in_trial",
+            "i_start_in_trial",
+            "i_stop_in_trial",
+            "target",
+            "subject",
+        ],
+    )
 
 
 @pytest.mark.parametrize("windows_per_recording", [[10, 10], [10, 3], [3, 10], [3, 2]])
@@ -504,7 +513,7 @@ def test_sequence_sampler_file_ids_stay_integer(windows_per_recording):
     md = _sequence_metadata(windows_per_recording)
     sampler = SequenceSampler(md, n_windows=5, n_windows_stride=1)
 
-    assert sampler.file_ids.dtype == np.int64
+    assert sampler.file_ids.dtype == np.dtype(np.int64)
     assert sampler.start_inds.dtype == np.int64
 
     expected = sum(max(0, n - 5 + 1) for n in windows_per_recording)
@@ -534,3 +543,18 @@ def test_balanced_sequence_sampler_all_recordings_too_short():
     md = _sequence_metadata([3, 2])
     with pytest.raises(ValueError, match="longest recording has 3 windows"):
         BalancedSequenceSampler(md, 5, n_sequences=5, random_state=87)
+
+
+def test_balanced_sequence_sampler_rejects_empty_metadata():
+    """Schema-valid empty metadata is rejected with a deliberate error."""
+    metadata = _sequence_metadata([])
+
+    with pytest.raises(
+        ValueError, match="Cannot build sequences from empty metadata"
+    ):
+        BalancedSequenceSampler(
+            metadata,
+            n_windows=5,
+            n_sequences=5,
+            random_state=87,
+        )


### PR DESCRIPTION

## Summary

A recording holding fewer than `n_windows` windows cannot contain a full sequence. `SequenceSampler` skips such a recording. `BalancedSequenceSampler` did not, and failed once its draw landed there. The same input also changed the dtype of `SequenceSampler.file_ids`. This pull request brings the two classes into agreement and settles the dtype.

Closes #1124

## 1. `BalancedSequenceSampler` failed on a short recording

`_sample_seq_start_ind` derives the range of valid sequence starts from the length of the chosen recording.

```python
min_pos = max(0, win_ind_in_rec - self.n_windows + 1)
max_pos = min(len_rec_inds - self.n_windows, win_ind_in_rec)
start_ind = rec_inds[self.rng.randint(min_pos, max_pos + 1)]
```

With `len_rec_inds` below `n_windows`, `max_pos` goes negative and `randint` receives a high bound of zero or less, which raises `ValueError: high <= 0`. Step 1 of the documented procedure draws a recording uniformly across every available one, so the failure was a matter of when rather than whether, and it surfaced partway through an epoch rather than at construction.

Recordings that cannot hold a sequence are now left out of that draw, which is what `SequenceSampler` already does with the same input. The eligible indices are resolved once in the constructor and exposed as `long_enough_recordings`. When none of them qualify, a `ValueError` names the length of the longest recording, which points at the value of `n_windows` that would work.

The window count involved is not small in practice. The U-Sleep procedure this sampler is modelled on uses sequences of 35 windows, which a truncated or short sleep recording falls under easily.

## 2. `file_ids` left its documented dtype

The ids were built as untyped Python lists.

```python
file_ids = [[i] * len(inds) for i, inds in enumerate(start_inds)]
```

A recording contributing no sequence produced an empty list, and `np.concatenate` fell back to `float64` for it, carrying the whole array along. The attribute is documented as `np.ndarray of ints`, and its stated purpose, grouping sequences by their source file, wants integers. A float array cannot index, and `np.bincount` rejects it. `start_inds` beside it kept `int64`, being sliced from a typed array, so the two attributes disagreed.

Each block is now allocated as a typed array, which holds the dtype whatever the mix of recording lengths.

## 3. `SequenceSampler` documented a parameter name that does not exist

The docstring listed `random : bool`, while the signature takes `randomize`. The sleep staging examples pass `randomize=True`. The parameter is now documented under the name the signature accepts.

Both class docstrings also record that a recording shorter than `n_windows` contributes no sequence.

## Behaviour

Recordings long enough to hold a sequence are sampled exactly as before, and the draw for a given seed is unchanged when every recording qualifies. The change is confined to inputs that previously ended in a `ValueError` or in a float id array.
