### PR TITLE
Write spec-compliant JSON in Hub zarr stores

### DIFF
--- a/braindecode/datasets/bids/hub.py
+++ b/braindecode/datasets/bids/hub.py
@@ -28,6 +28,7 @@ The format follows a BIDS-inspired sourcedata structure:
 # License: BSD (3-clause)
 
 import contextlib
+import copy
 import json
 import logging
 import tempfile
@@ -89,6 +90,10 @@ def _normalize_kwargs_for_json(value, field_name):
 
     try:
         converted = _convert(value)
+        if isinstance(converted, str):
+            raise ValueError(
+                "a root string is ambiguous with the legacy encoded format"
+            )
         return json.loads(json.dumps(converted, allow_nan=False))
     except (OverflowError, RecursionError, TypeError, ValueError) as error:
         raise ValueError(
@@ -712,9 +717,6 @@ class HubDatasetMixin:
         # Validate uniformity across all datasets using shared validation
         dataset_type, _, _ = hub_validation.validate_dataset_uniformity(self.datasets)
 
-        # Keep reference to first dataset for preprocessing kwargs
-        first_ds = self.datasets[0]
-
         # Normalize every JSON value before opening the output store. The cached
         # values below are the exact values handed to the write helpers.
         prepared_infos = []
@@ -731,10 +733,29 @@ class HubDatasetMixin:
             "window_kwargs",
             "window_preproc_kwargs",
         ]:
-            if hasattr(first_ds, kwarg_name):
-                prepared_kwargs[kwarg_name] = _normalize_kwargs_for_json(
-                    getattr(first_ds, kwarg_name), kwarg_name
+            expected_present = hasattr(self.datasets[0], kwarg_name)
+            expected_value = None
+            for i_ds, ds in enumerate(self.datasets):
+                present = hasattr(ds, kwarg_name)
+                if present != expected_present:
+                    raise ValueError(
+                        f"{kwarg_name} on dataset {i_ds} has inconsistent presence; "
+                        "the Zarr format stores one global value"
+                    )
+                if not present:
+                    continue
+                value = _normalize_kwargs_for_json(
+                    getattr(ds, kwarg_name), f"{kwarg_name} on dataset {i_ds}"
                 )
+                if i_ds == 0:
+                    expected_value = value
+                elif value != expected_value:
+                    raise ValueError(
+                        f"{kwarg_name} on dataset {i_ds} differs from dataset 0; "
+                        "the Zarr format stores one global value"
+                    )
+            if expected_present:
+                prepared_kwargs[kwarg_name] = expected_value
 
         # Create compressor and zarr store (zarr v3 API) only after preflight.
         compressor = _create_compressor(compression, compression_level)
@@ -998,7 +1019,7 @@ class HubDatasetMixin:
                     kwargs = json.loads(kwargs)
                 # Set on each individual dataset (where they were originally stored)
                 for ds in datasets:
-                    setattr(ds, kwarg_name, kwargs)
+                    setattr(ds, kwarg_name, copy.deepcopy(kwargs))
 
         return concat_ds
 

--- a/braindecode/datasets/bids/hub.py
+++ b/braindecode/datasets/bids/hub.py
@@ -735,6 +735,7 @@ class HubDatasetMixin:
         ]:
             expected_present = hasattr(self.datasets[0], kwarg_name)
             expected_value = None
+            expected_token = None
             for i_ds, ds in enumerate(self.datasets):
                 present = hasattr(ds, kwarg_name)
                 if present != expected_present:
@@ -747,9 +748,13 @@ class HubDatasetMixin:
                 value = _normalize_kwargs_for_json(
                     getattr(ds, kwarg_name), f"{kwarg_name} on dataset {i_ds}"
                 )
+                value_token = json.dumps(
+                    value, sort_keys=True, separators=(",", ":"), allow_nan=False
+                )
                 if i_ds == 0:
                     expected_value = value
-                elif value != expected_value:
+                    expected_token = value_token
+                elif value_token != expected_token:
                     raise ValueError(
                         f"{kwarg_name} on dataset {i_ds} differs from dataset 0; "
                         "the Zarr format stores one global value"

--- a/braindecode/datasets/bids/hub.py
+++ b/braindecode/datasets/bids/hub.py
@@ -717,7 +717,10 @@ class HubDatasetMixin:
             if hasattr(first_ds, kwarg_name):
                 kwargs = getattr(first_ds, kwarg_name)
                 if kwargs:
-                    root.attrs[kwarg_name] = json.dumps(kwargs)
+                    # Store as native JSON (the round-trip through json
+                    # normalizes tuples to lists) so zarr.json holds a
+                    # readable object instead of a double-encoded string.
+                    root.attrs[kwarg_name] = json.loads(json.dumps(kwargs))
 
         # Create compressor
         compressor = _create_compressor(compression, compression_level)
@@ -956,7 +959,11 @@ class HubDatasetMixin:
             "window_preproc_kwargs",
         ]:
             if kwarg_name in root.attrs:
-                kwargs = json.loads(root.attrs[kwarg_name])
+                kwargs = root.attrs[kwarg_name]
+                if isinstance(kwargs, str):
+                    # Stores written by older braindecode versions kept
+                    # these attributes as double-encoded JSON strings.
+                    kwargs = json.loads(kwargs)
                 # Set on each individual dataset (where they were originally stored)
                 for ds in datasets:
                     setattr(ds, kwarg_name, kwargs)

--- a/braindecode/datasets/bids/hub.py
+++ b/braindecode/datasets/bids/hub.py
@@ -56,6 +56,7 @@ from .hub_io import (
     _load_eegwindows_from_zarr,
     _load_raw_from_zarr,
     _load_windows_from_zarr,
+    _prepare_info_for_json,
     _save_eegwindows_to_zarr,
     _save_raw_to_zarr,
     _save_windows_to_zarr,
@@ -70,6 +71,29 @@ huggingface_hub = _soft_import(
 log = logging.getLogger(__name__)
 
 _LOCK_FILE = "format_info.json"
+
+
+def _normalize_kwargs_for_json(value, field_name):
+    """Return one preprocessing-kwargs value as native strict JSON."""
+
+    def _convert(obj):
+        if isinstance(obj, np.ndarray):
+            return _convert(obj.tolist())
+        if isinstance(obj, dict):
+            return {key: _convert(item) for key, item in obj.items()}
+        if isinstance(obj, (list, tuple)):
+            return [_convert(item) for item in obj]
+        if isinstance(obj, np.generic):
+            return _convert(obj.item())
+        return obj
+
+    try:
+        converted = _convert(value)
+        return json.loads(json.dumps(converted, allow_nan=False))
+    except (OverflowError, RecursionError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"{field_name} must contain only finite JSON-serializable values"
+        ) from error
 
 
 class HubDatasetMixin:
@@ -685,14 +709,36 @@ class HubDatasetMixin:
                 f"{output_path} already exists. Set overwrite=True to replace it."
             )
 
-        # Create zarr store (zarr v3 API)
-        root = zarr.open(str(output_path), mode="w")
-
         # Validate uniformity across all datasets using shared validation
         dataset_type, _, _ = hub_validation.validate_dataset_uniformity(self.datasets)
 
         # Keep reference to first dataset for preprocessing kwargs
         first_ds = self.datasets[0]
+
+        # Normalize every JSON value before opening the output store. The cached
+        # values below are the exact values handed to the write helpers.
+        prepared_infos = []
+        for ds in self.datasets:
+            if dataset_type == "WindowsDataset":
+                info = ds.windows.info
+            elif dataset_type in ("EEGWindowsDataset", "RawDataset"):
+                info = ds.raw.info
+            prepared_infos.append(_prepare_info_for_json(info.to_json_dict()))
+
+        prepared_kwargs = {}
+        for kwarg_name in [
+            "raw_preproc_kwargs",
+            "window_kwargs",
+            "window_preproc_kwargs",
+        ]:
+            if hasattr(first_ds, kwarg_name):
+                prepared_kwargs[kwarg_name] = _normalize_kwargs_for_json(
+                    getattr(first_ds, kwarg_name), kwarg_name
+                )
+
+        # Create compressor and zarr store (zarr v3 API) only after preflight.
+        compressor = _create_compressor(compression, compression_level)
+        root = zarr.open(str(output_path), mode="w")
 
         # Store global metadata
         root.attrs["n_datasets"] = len(self.datasets)
@@ -706,24 +752,10 @@ class HubDatasetMixin:
         root.attrs["zarr_version"] = zarr.__version__
         root.attrs["scipy_version"] = scipy.__version__
 
-        # Save preprocessing kwargs (check first dataset, assuming uniform preprocessing)
-        # These are typically set by windowing functions on individual datasets
-        for kwarg_name in [
-            "raw_preproc_kwargs",
-            "window_kwargs",
-            "window_preproc_kwargs",
-        ]:
-            # Check first dataset for these attributes
-            if hasattr(first_ds, kwarg_name):
-                kwargs = getattr(first_ds, kwarg_name)
-                if kwargs:
-                    # Store as native JSON (the round-trip through json
-                    # normalizes tuples to lists) so zarr.json holds a
-                    # readable object instead of a double-encoded string.
-                    root.attrs[kwarg_name] = json.loads(json.dumps(kwargs))
-
-        # Create compressor
-        compressor = _create_compressor(compression, compression_level)
+        # Save preprocessing kwargs from the preflight cache. These are
+        # typically set by windowing functions on individual datasets.
+        for kwarg_name, kwargs in prepared_kwargs.items():
+            root.attrs[kwarg_name] = kwargs
 
         # Save each recording
         for i_ds, ds in enumerate(self.datasets):
@@ -734,7 +766,7 @@ class HubDatasetMixin:
                 data = ds.windows.get_data()
                 metadata = ds.windows.metadata
                 description = ds.description
-                info_dict = ds.windows.info.to_json_dict()
+                info_dict = prepared_infos[i_ds]
                 target_name = ds.target_name if hasattr(ds, "target_name") else None
 
                 # Save using inlined function
@@ -753,7 +785,7 @@ class HubDatasetMixin:
                 raw = ds.raw
                 metadata = ds.metadata
                 description = ds.description
-                info_dict = ds.raw.info.to_json_dict()
+                info_dict = prepared_infos[i_ds]
                 targets_from = ds.targets_from
                 last_target_only = ds.last_target_only
 
@@ -774,7 +806,7 @@ class HubDatasetMixin:
                 # Get continuous raw data from RawDataset
                 raw = ds.raw
                 description = ds.description
-                info_dict = ds.raw.info.to_json_dict()
+                info_dict = prepared_infos[i_ds]
                 target_name = ds.target_name if hasattr(ds, "target_name") else None
 
                 # Save using inlined function

--- a/braindecode/datasets/bids/hub_io.py
+++ b/braindecode/datasets/bids/hub_io.py
@@ -17,12 +17,36 @@ from mne.utils import _soft_import
 zarr = _soft_import("zarr", purpose="hugging face integration", strict=False)
 
 
-def _restore_nan_from_json(obj):
-    """Restore NaN values from None in legacy zarr stores.
+def _sanitize_for_json(obj):
+    """Replace NaN/Inf with None so attributes serialize to valid JSON.
 
-    Datasets saved before zarr v3 native NaN support used
-    ``_sanitize_for_json`` to convert NaN/Inf → None. This restores them
-    on load so ``mne.Info.from_json_dict`` gets proper NaN arrays.
+    ``zarr.json`` must be spec-compliant JSON, but Python's ``json``
+    module writes ``NaN``/``Infinity`` literals by default, which
+    RFC 8259 forbids and non-Python zarr readers reject. MNE ``Info``
+    dicts routinely contain NaN (e.g. in channel ``loc`` arrays), so
+    they are sanitized before being stored as attributes and restored
+    with ``_restore_nan_from_json`` on load.
+    """
+    if isinstance(obj, float):
+        if np.isnan(obj) or np.isinf(obj):
+            return None
+        return obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_for_json(v) for v in obj]
+    if isinstance(obj, np.ndarray):
+        return _sanitize_for_json(obj.tolist())
+    return obj
+
+
+def _restore_nan_from_json(obj):
+    """Restore NaN values from None in JSON-loaded attributes.
+
+    Inverse of ``_sanitize_for_json`` for numeric arrays: restores NaN
+    on load so ``mne.Info.from_json_dict`` gets proper NaN arrays. Also
+    covers stores written by older braindecode versions, which sanitized
+    NaN/Inf → None the same way.
     """
     if isinstance(obj, dict):
         return {k: _restore_nan_from_json(v) for k, v in obj.items()}
@@ -64,7 +88,7 @@ def _save_windows_to_zarr(
     metadata.to_csv(metadata_path, sep="\t", index=True)
 
     grp.attrs["description"] = json.loads(description.to_json(date_format="iso"))
-    grp.attrs["info"] = info
+    grp.attrs["info"] = _sanitize_for_json(info)
 
     if target_name is not None:
         grp.attrs["target_name"] = target_name
@@ -101,7 +125,7 @@ def _save_eegwindows_to_zarr(
     metadata.to_csv(metadata_path, sep="\t", index=True)
 
     grp.attrs["description"] = json.loads(description.to_json(date_format="iso"))
-    grp.attrs["info"] = info
+    grp.attrs["info"] = _sanitize_for_json(info)
     grp.attrs["targets_from"] = targets_from
     grp.attrs["last_target_only"] = last_target_only
 
@@ -162,7 +186,7 @@ def _save_raw_to_zarr(grp, raw, description, info, target_name, compressor, chun
     )
 
     grp.attrs["description"] = json.loads(description.to_json(date_format="iso"))
-    grp.attrs["info"] = info
+    grp.attrs["info"] = _sanitize_for_json(info)
 
     if target_name is not None:
         grp.attrs["target_name"] = target_name

--- a/braindecode/datasets/bids/hub_io.py
+++ b/braindecode/datasets/bids/hub_io.py
@@ -8,6 +8,7 @@ These functions keep the Zarr serialization details isolated from hub.py.
 from __future__ import annotations
 
 import json
+from numbers import Real
 from pathlib import Path
 
 import numpy as np
@@ -17,41 +18,78 @@ from mne.utils import _soft_import
 zarr = _soft_import("zarr", purpose="hugging face integration", strict=False)
 
 
-def _sanitize_for_json(obj):
-    """Replace NaN/Inf with None so attributes serialize to valid JSON.
+def _is_non_bool_real(value):
+    return not isinstance(value, (bool, np.bool_)) and isinstance(
+        value, (Real, np.integer, np.floating)
+    )
 
-    ``zarr.json`` must be spec-compliant JSON, but Python's ``json``
-    module writes ``NaN``/``Infinity`` literals by default, which
-    RFC 8259 forbids and non-Python zarr readers reject. MNE ``Info``
-    dicts routinely contain NaN (e.g. in channel ``loc`` arrays), so
-    they are sanitized before being stored as attributes and restored
-    with ``_restore_nan_from_json`` on load.
-    """
-    if isinstance(obj, float):
-        if np.isnan(obj) or np.isinf(obj):
-            return None
-        return obj
-    if isinstance(obj, dict):
-        return {k: _sanitize_for_json(v) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [_sanitize_for_json(v) for v in obj]
+
+def _prepare_info_for_json(obj, path="info", *, _in_numeric_sequence=False):
+    """Normalize an MNE Info value to strict JSON without losing sequence NaNs."""
     if isinstance(obj, np.ndarray):
-        return _sanitize_for_json(obj.tolist())
-    return obj
+        obj = obj.tolist()
+
+    if isinstance(obj, dict):
+        return {
+            key: _prepare_info_for_json(value, f"{path}.{key}")
+            for key, value in obj.items()
+        }
+
+    if isinstance(obj, (list, tuple)):
+        values = list(obj)
+        has_none = any(value is None for value in values)
+        has_number = any(_is_non_bool_real(value) for value in values)
+        all_none = bool(values) and all(value is None for value in values)
+        if all_none or (has_none and has_number):
+            raise ValueError(
+                f"{path} is ambiguous: numeric sequences cannot contain JSON null"
+            )
+
+        is_numeric_sequence = bool(values) and all(
+            _is_non_bool_real(value) for value in values
+        )
+        return [
+            _prepare_info_for_json(
+                value,
+                f"{path}[{index}]",
+                _in_numeric_sequence=is_numeric_sequence,
+            )
+            for index, value in enumerate(values)
+        ]
+
+    if isinstance(obj, (bool, np.bool_)):
+        return bool(obj)
+    if isinstance(obj, (int, np.integer)):
+        return int(obj)
+    if _is_non_bool_real(obj):
+        value = float(obj)
+        if np.isnan(value):
+            if _in_numeric_sequence:
+                return None
+            raise ValueError(f"{path} contains unsupported NaN")
+        if np.isposinf(value):
+            raise ValueError(f"{path} contains positive infinity")
+        if np.isneginf(value):
+            raise ValueError(f"{path} contains negative infinity")
+        return value
+    if obj is None or isinstance(obj, str):
+        return obj
+    raise ValueError(f"{path} contains a non-JSON-serializable value")
 
 
 def _restore_nan_from_json(obj):
     """Restore NaN values from None in JSON-loaded attributes.
 
-    Inverse of ``_sanitize_for_json`` for numeric arrays: restores NaN
-    on load so ``mne.Info.from_json_dict`` gets proper NaN arrays. Also
-    covers stores written by older braindecode versions, which sanitized
-    NaN/Inf → None the same way.
+    JSON null is reserved for NaN only in non-boolean numeric sequences.
+    All-null lists are therefore the representation of validated all-NaN
+    sequences, while ordinary null values elsewhere remain unchanged.
     """
     if isinstance(obj, dict):
         return {k: _restore_nan_from_json(v) for k, v in obj.items()}
     if isinstance(obj, list):
-        if len(obj) > 0 and all(isinstance(x, (int, float, type(None))) for x in obj):
+        if len(obj) > 0 and all(
+            value is None or _is_non_bool_real(value) for value in obj
+        ):
             return [np.nan if x is None else x for x in obj]
         return [_restore_nan_from_json(v) for v in obj]
     return obj
@@ -88,7 +126,7 @@ def _save_windows_to_zarr(
     metadata.to_csv(metadata_path, sep="\t", index=True)
 
     grp.attrs["description"] = json.loads(description.to_json(date_format="iso"))
-    grp.attrs["info"] = _sanitize_for_json(info)
+    grp.attrs["info"] = info
 
     if target_name is not None:
         grp.attrs["target_name"] = target_name
@@ -125,7 +163,7 @@ def _save_eegwindows_to_zarr(
     metadata.to_csv(metadata_path, sep="\t", index=True)
 
     grp.attrs["description"] = json.loads(description.to_json(date_format="iso"))
-    grp.attrs["info"] = _sanitize_for_json(info)
+    grp.attrs["info"] = info
     grp.attrs["targets_from"] = targets_from
     grp.attrs["last_target_only"] = last_target_only
 
@@ -186,7 +224,7 @@ def _save_raw_to_zarr(grp, raw, description, info, target_name, compressor, chun
     )
 
     grp.attrs["description"] = json.loads(description.to_json(date_format="iso"))
-    grp.attrs["info"] = _sanitize_for_json(info)
+    grp.attrs["info"] = info
 
     if target_name is not None:
         grp.attrs["target_name"] = target_name

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -82,11 +82,10 @@ Bug fixes
 - Keep :class:`braindecode.preprocessing.EEGPrep` compatible with EEGPrep 0.3,
   which no longer exposes the ``eegprep.utils`` namespace used for sampling-rate
   validation (:gh:`1123` by `Bruno Aristimunha`_).
-- Write spec-compliant JSON in Hub dataset stores: sanitize NaN/Inf in the MNE
-  ``Info`` attributes so ``zarr.json`` no longer contains invalid ``NaN``
-  literals, and store preprocessing kwargs as native JSON objects instead of
-  double-encoded strings, while still reading stores written by older versions
-  (:gh:`880` by `Azra Bano`_).
+- Write strict JSON in Hub dataset stores while preserving NaNs in numeric MNE
+  ``Info`` sequences. Unsupported scalar NaNs and infinities are rejected
+  before store creation, and preprocessing kwargs are stored as native strict
+  JSON while legacy string values remain readable (:gh:`1128` by `Azra Bano`_).
 
 - Leave recordings shorter than ``n_windows`` out of the draw in
   :class:`braindecode.samplers.BalancedSequenceSampler` instead of failing on

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -49,6 +49,11 @@ Bug fixes
 - Keep :class:`braindecode.preprocessing.EEGPrep` compatible with EEGPrep 0.3,
   which no longer exposes the ``eegprep.utils`` namespace used for sampling-rate
   validation (:gh:`1123` by `Bruno Aristimunha`_).
+- Write spec-compliant JSON in Hub dataset stores: sanitize NaN/Inf in the MNE
+  ``Info`` attributes so ``zarr.json`` no longer contains invalid ``NaN``
+  literals, and store preprocessing kwargs as native JSON objects instead of
+  double-encoded strings, while still reading stores written by older versions
+  (:gh:`880` by `Azra Bano`_).
 
 Code health
 ============
@@ -1560,3 +1565,4 @@ Authors
 .. _Fashad Ahmed: https://github.com/Fashad-Ahmed
 .. _Bhargav Kowshik: https://github.com/bkowshik
 .. _Jon Huml: https://github.com/jonathanhuml
+.. _Azra Bano: https://github.com/azrabano23

--- a/test/unit_tests/datasets/test_hub_integration.py
+++ b/test/unit_tests/datasets/test_hub_integration.py
@@ -33,6 +33,7 @@ from braindecode.datasets import (
     RawDataset,
     WindowsDataset,
 )
+from braindecode.datasets.bids import hub_io
 from braindecode.datasets.bids.hub import (
     _generate_readme_content,
     _infer_license_from_descriptions,
@@ -745,6 +746,57 @@ def _make_concat_raw_dataset_with_nan_locs():
     return BaseConcatDataset([RawDataset(raw, description)])
 
 
+@pytest.mark.parametrize(
+    ("value", "normalized", "restored", "error_path", "error_category"),
+    [
+        (np.bool_(True), True, True, None, None),
+        (np.int64(7), 7, 7, None, None),
+        (np.float32(1.25), 1.25, 1.25, None, None),
+        ((np.int64(1), np.float64(2.5)), [1, 2.5], [1, 2.5], None, None),
+        (np.array([1, 2]), [1, 2], [1, 2], None, None),
+        (None, None, None, None, None),
+        ([1.0, np.nan], [1.0, None], [1.0, np.nan], None, None),
+        ([np.nan, np.nan], [None, None], [np.nan, np.nan], None, None),
+        ([True, None], [True, None], [True, None], None, None),
+        ([1.0, None], None, None, "info.value", "ambiguous"),
+        ([None, None], None, None, "info.value", "ambiguous"),
+        (
+            {"nested": [0.0, np.inf]},
+            None,
+            None,
+            "info.value.nested[1]",
+            "positive infinity",
+        ),
+        (
+            {"nested": [0.0, -np.inf]},
+            None,
+            None,
+            "info.value.nested[1]",
+            "negative infinity",
+        ),
+    ],
+)
+def test_info_json_normalization_contract(
+    value, normalized, restored, error_path, error_category
+):
+    """Info JSON normalization is lossless only on its reserved domain."""
+    if error_path is not None:
+        with pytest.raises(ValueError) as exc_info:
+            hub_io._prepare_info_for_json(value, path="info.value")
+        assert error_path in str(exc_info.value)
+        assert error_category in str(exc_info.value)
+        return
+
+    result = hub_io._prepare_info_for_json(value, path="info.value")
+    assert type(result) is type(normalized)
+    if isinstance(normalized, list):
+        np.testing.assert_equal(result, normalized)
+        np.testing.assert_equal(hub_io._restore_nan_from_json(result), restored)
+    else:
+        assert result == normalized
+        assert hub_io._restore_nan_from_json(result) == restored
+
+
 def test_zarr_json_attrs_are_spec_compliant(tmp_path):
     """Saved zarr.json metadata must be valid JSON without NaN literals.
 
@@ -795,23 +847,105 @@ def test_nan_channel_locs_round_trip(tmp_path):
         np.testing.assert_array_equal(original_loc, ch["loc"])
 
 
-def test_legacy_stringified_kwargs_still_load(tmp_path):
-    """Stores with double-encoded kwargs (pre-gh-880 fix) must still load."""
+@pytest.mark.parametrize(
+    "kwarg_name",
+    ["raw_preproc_kwargs", "window_kwargs", "window_preproc_kwargs"],
+)
+def test_preprocessing_kwargs_strict_json_round_trip(tmp_path, kwarg_name):
+    """All preprocessing kwargs use native strict JSON and load legacy strings."""
     pytest.importorskip("zarr")
 
     concat_ds = _make_concat_raw_dataset_with_nan_locs()
-    zarr_path = tmp_path / "dataset.zarr"
+    kwargs = {
+        "tuple": (np.int64(2), np.float32(1.5)),
+        "enabled": True,
+        "nested": {"missing": None, "scale": np.float64(2.25)},
+    }
+    expected = {
+        "tuple": [2, 1.5],
+        "enabled": True,
+        "nested": {"missing": None, "scale": 2.25},
+    }
+    setattr(concat_ds.datasets[0], kwarg_name, kwargs)
+
+    zarr_path = tmp_path / f"{kwarg_name}.zarr"
     concat_ds._convert_to_zarr_inline(
         zarr_path, compression=None, compression_level=5
     )
 
-    # Rewrite the attribute the way older braindecode versions stored it
-    legacy_kwargs = [["pick_types", {"eeg": True}]]
-    root = zarr.open(str(zarr_path), mode="a")
-    root.attrs["raw_preproc_kwargs"] = json.dumps(legacy_kwargs)
+    for zarr_json in zarr_path.rglob("zarr.json"):
+        _strict_json_loads(zarr_json.read_text())
+    root_attrs = _strict_json_loads((zarr_path / "zarr.json").read_text())[
+        "attributes"
+    ]
+    assert not isinstance(root_attrs[kwarg_name], str)
+    assert root_attrs[kwarg_name] == expected
 
     loaded = concat_ds._load_from_zarr_inline(zarr_path, preload=True)
-    assert loaded.datasets[0].raw_preproc_kwargs == legacy_kwargs
+    assert getattr(loaded.datasets[0], kwarg_name) == expected
+
+    # Rewrite the attribute the way older braindecode versions stored it.
+    root = zarr.open(str(zarr_path), mode="a")
+    root.attrs[kwarg_name] = json.dumps(expected)
+
+    loaded = concat_ds._load_from_zarr_inline(zarr_path, preload=True)
+    assert getattr(loaded.datasets[0], kwarg_name) == expected
+
+
+@pytest.mark.parametrize(
+    "kwarg_name",
+    ["raw_preproc_kwargs", "window_kwargs", "window_preproc_kwargs"],
+)
+@pytest.mark.parametrize(
+    "nonfinite", [pytest.param(np.nan, id="nan"), np.inf, -np.inf]
+)
+def test_preprocessing_kwargs_nonfinite_preflight_is_atomic(
+    tmp_path, kwarg_name, nonfinite
+):
+    """Every kwargs field rejects nested nonfinite values before store creation."""
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_concat_raw_dataset_with_nan_locs()
+    setattr(
+        concat_ds.datasets[0],
+        kwarg_name,
+        {"outer": [{"invalid": nonfinite}]},
+    )
+    zarr_path = tmp_path / f"{kwarg_name}.zarr"
+
+    with pytest.raises(ValueError, match=kwarg_name):
+        concat_ds._convert_to_zarr_inline(
+            zarr_path, compression=None, compression_level=5
+        )
+    assert not zarr_path.exists()
+
+
+@pytest.mark.parametrize(
+    ("nonfinite", "path", "category"),
+    [
+        (np.nan, "info.line_freq", "NaN"),
+        (np.inf, "info.chs[0].loc[0]", "positive infinity"),
+        (-np.inf, "info.chs[0].loc[0]", "negative infinity"),
+    ],
+)
+def test_info_nonfinite_preflight_is_atomic(tmp_path, nonfinite, path, category):
+    """Unsupported Info nonfinite values fail before opening a fresh store."""
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_concat_raw_dataset_with_nan_locs()
+    if path == "info.line_freq":
+        concat_ds.datasets[0].raw.info["line_freq"] = nonfinite
+    else:
+        concat_ds.datasets[0].raw.info["chs"][0]["loc"][0] = nonfinite
+    zarr_path = tmp_path / "invalid-info.zarr"
+
+    with pytest.raises(ValueError) as exc_info:
+        concat_ds._convert_to_zarr_inline(
+            zarr_path, compression=None, compression_level=5
+        )
+    assert path in str(exc_info.value)
+    assert category in str(exc_info.value)
+    assert not zarr_path.exists()
 
 
 @pytest.mark.parametrize("use_mne_epochs", [True, False])

--- a/test/unit_tests/datasets/test_hub_integration.py
+++ b/test/unit_tests/datasets/test_hub_integration.py
@@ -746,6 +746,16 @@ def _make_concat_raw_dataset_with_nan_locs():
     return BaseConcatDataset([RawDataset(raw, description)])
 
 
+def _make_two_concat_raw_datasets_with_nan_locs():
+    """Create two independent recordings for global-metadata tests."""
+    concat_ds = _make_concat_raw_dataset_with_nan_locs()
+    first_ds = concat_ds.datasets[0]
+    second_ds = RawDataset(
+        first_ds.raw.copy(), pd.Series({"subject": 2, "session": "0train"})
+    )
+    return BaseConcatDataset([first_ds, second_ds])
+
+
 @pytest.mark.parametrize(
     ("value", "normalized", "restored", "error_path", "error_category"),
     [
@@ -918,6 +928,85 @@ def test_preprocessing_kwargs_nonfinite_preflight_is_atomic(
             zarr_path, compression=None, compression_level=5
         )
     assert not zarr_path.exists()
+
+
+@pytest.mark.parametrize(
+    "kwarg_name",
+    ["raw_preproc_kwargs", "window_kwargs", "window_preproc_kwargs"],
+)
+@pytest.mark.parametrize(
+    ("later_value", "set_later", "case"),
+    [
+        ({"outer": [{"scale": np.inf}]}, True, "nonfinite"),
+        (None, False, "presence-mismatch"),
+        ({"outer": [{"scale": 2}]}, True, "value-mismatch"),
+    ],
+)
+def test_preprocessing_kwargs_later_dataset_preflight_is_atomic(
+    tmp_path, kwarg_name, later_value, set_later, case
+):
+    """Every recording must match the one global kwargs value before writing."""
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_two_concat_raw_datasets_with_nan_locs()
+    setattr(concat_ds.datasets[0], kwarg_name, {"outer": [{"scale": 1}]})
+    if set_later:
+        setattr(concat_ds.datasets[1], kwarg_name, later_value)
+    zarr_path = tmp_path / f"{kwarg_name}-{case}.zarr"
+
+    with pytest.raises(ValueError, match=rf"{kwarg_name}.*dataset 1"):
+        concat_ds._convert_to_zarr_inline(
+            zarr_path, compression=None, compression_level=5
+        )
+    assert not zarr_path.exists()
+
+
+@pytest.mark.parametrize(
+    "kwarg_name",
+    ["raw_preproc_kwargs", "window_kwargs", "window_preproc_kwargs"],
+)
+def test_preprocessing_kwargs_root_string_rejected_atomically(tmp_path, kwarg_name):
+    """Native root strings cannot collide with legacy double-encoded attrs."""
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_concat_raw_dataset_with_nan_locs()
+    setattr(concat_ds.datasets[0], kwarg_name, "[]")
+    zarr_path = tmp_path / f"{kwarg_name}-root-string.zarr"
+
+    with pytest.raises(ValueError, match=kwarg_name):
+        concat_ds._convert_to_zarr_inline(
+            zarr_path, compression=None, compression_level=5
+        )
+    assert not zarr_path.exists()
+
+
+@pytest.mark.parametrize(
+    "kwarg_name",
+    ["raw_preproc_kwargs", "window_kwargs", "window_preproc_kwargs"],
+)
+def test_preprocessing_kwargs_uniform_multi_recording_isolation(tmp_path, kwarg_name):
+    """Equal global provenance loads as independent objects per recording."""
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_two_concat_raw_datasets_with_nan_locs()
+    kwargs = {"outer": [{"scale": 1}]}
+    for ds in concat_ds.datasets:
+        setattr(ds, kwarg_name, copy.deepcopy(kwargs))
+    zarr_path = tmp_path / f"{kwarg_name}-uniform.zarr"
+    concat_ds._convert_to_zarr_inline(
+        zarr_path, compression=None, compression_level=5
+    )
+
+    loaded = concat_ds._load_from_zarr_inline(zarr_path, preload=True)
+    first = getattr(loaded.datasets[0], kwarg_name)
+    second = getattr(loaded.datasets[1], kwarg_name)
+    assert first == second == kwargs
+    assert first is not second
+    assert first["outer"] is not second["outer"]
+    assert first["outer"][0] is not second["outer"][0]
+
+    first["outer"][0]["scale"] = 99
+    assert second == kwargs
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/datasets/test_hub_integration.py
+++ b/test/unit_tests/datasets/test_hub_integration.py
@@ -6,6 +6,7 @@
 
 
 import inspect
+import json
 from unittest import mock
 
 import mne
@@ -720,6 +721,97 @@ def test_preprocessing_kwargs_preserved(tmp_path):
         loaded.datasets[0].window_preproc_kwargs
         == windowed.datasets[0].window_preproc_kwargs
     )
+
+
+def _strict_json_loads(text):
+    """Parse JSON, rejecting NaN/Infinity literals that RFC 8259 forbids."""
+
+    def _reject(constant):
+        raise ValueError(f"non-compliant JSON constant: {constant}")
+
+    return json.loads(text, parse_constant=_reject)
+
+
+def _make_concat_raw_dataset_with_nan_locs():
+    """Create a synthetic RawDataset whose info contains NaN channel locs."""
+    rng = np.random.RandomState(42)
+    info = mne.create_info(ch_names=["C3", "C4", "Cz"], sfreq=100.0, ch_types="eeg")
+    raw = mne.io.RawArray(rng.randn(3, 500) * 1e-6, info)
+    # Realistic montage state: unknown coordinates are NaN in MNE
+    # (set_montage does the same for missing positions).
+    for ch in raw.info["chs"]:
+        ch["loc"][3:] = np.nan
+    description = pd.Series({"subject": 1, "session": "0train"})
+    return BaseConcatDataset([RawDataset(raw, description)])
+
+
+def test_zarr_json_attrs_are_spec_compliant(tmp_path):
+    """Saved zarr.json metadata must be valid JSON without NaN literals.
+
+    Regression test for gh-880: NaN values in the MNE ``Info`` dict were
+    written verbatim into ``zarr.json`` (invalid JSON per RFC 8259 and
+    the zarr v3 spec), and preprocessing kwargs were stored as
+    double-encoded JSON strings instead of JSON objects.
+    """
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_concat_raw_dataset_with_nan_locs()
+    concat_ds.datasets[0].raw_preproc_kwargs = [["pick_types", {"eeg": True}]]
+
+    zarr_path = tmp_path / "dataset.zarr"
+    concat_ds._convert_to_zarr_inline(
+        zarr_path, compression=None, compression_level=5
+    )
+
+    zarr_json_files = sorted(zarr_path.rglob("zarr.json"))
+    assert len(zarr_json_files) >= 2  # root + recording_0 at minimum
+    for zarr_json in zarr_json_files:
+        # Raises ValueError on NaN/Infinity literals before the fix
+        _strict_json_loads(zarr_json.read_text())
+
+    root_zarr_json = _strict_json_loads((zarr_path / "zarr.json").read_text())
+    root_attrs = root_zarr_json["attributes"]
+    # Preprocessing kwargs must be stored as JSON values, not as strings
+    assert not isinstance(root_attrs["raw_preproc_kwargs"], str)
+    assert root_attrs["raw_preproc_kwargs"] == [["pick_types", {"eeg": True}]]
+
+
+def test_nan_channel_locs_round_trip(tmp_path):
+    """NaN channel locations must survive the save/load round trip (gh-880)."""
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_concat_raw_dataset_with_nan_locs()
+    original_locs = [ch["loc"].copy() for ch in concat_ds.datasets[0].raw.info["chs"]]
+
+    zarr_path = tmp_path / "dataset.zarr"
+    concat_ds._convert_to_zarr_inline(
+        zarr_path, compression=None, compression_level=5
+    )
+    loaded = concat_ds._load_from_zarr_inline(zarr_path, preload=True)
+
+    loaded_chs = loaded.datasets[0].raw.info["chs"]
+    for original_loc, ch in zip(original_locs, loaded_chs):
+        # assert_array_equal treats NaN positions as equal
+        np.testing.assert_array_equal(original_loc, ch["loc"])
+
+
+def test_legacy_stringified_kwargs_still_load(tmp_path):
+    """Stores with double-encoded kwargs (pre-gh-880 fix) must still load."""
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_concat_raw_dataset_with_nan_locs()
+    zarr_path = tmp_path / "dataset.zarr"
+    concat_ds._convert_to_zarr_inline(
+        zarr_path, compression=None, compression_level=5
+    )
+
+    # Rewrite the attribute the way older braindecode versions stored it
+    legacy_kwargs = [["pick_types", {"eeg": True}]]
+    root = zarr.open(str(zarr_path), mode="a")
+    root.attrs["raw_preproc_kwargs"] = json.dumps(legacy_kwargs)
+
+    loaded = concat_ds._load_from_zarr_inline(zarr_path, preload=True)
+    assert loaded.datasets[0].raw_preproc_kwargs == legacy_kwargs
 
 
 @pytest.mark.parametrize("use_mne_epochs", [True, False])

--- a/test/unit_tests/datasets/test_hub_integration.py
+++ b/test/unit_tests/datasets/test_hub_integration.py
@@ -965,6 +965,35 @@ def test_preprocessing_kwargs_later_dataset_preflight_is_atomic(
     "kwarg_name",
     ["raw_preproc_kwargs", "window_kwargs", "window_preproc_kwargs"],
 )
+@pytest.mark.parametrize(
+    ("first_value", "later_value", "case"),
+    [
+        (True, 1, "bool-int"),
+        (1, 1.0, "int-float"),
+    ],
+)
+def test_preprocessing_kwargs_json_types_must_match_atomically(
+    tmp_path, kwarg_name, first_value, later_value, case
+):
+    """Type-distinct JSON provenance cannot share one global attribute."""
+    pytest.importorskip("zarr")
+
+    concat_ds = _make_two_concat_raw_datasets_with_nan_locs()
+    setattr(concat_ds.datasets[0], kwarg_name, {"outer": [{"value": first_value}]})
+    setattr(concat_ds.datasets[1], kwarg_name, {"outer": [{"value": later_value}]})
+    zarr_path = tmp_path / f"{kwarg_name}-{case}.zarr"
+
+    with pytest.raises(ValueError, match=rf"{kwarg_name}.*dataset 1"):
+        concat_ds._convert_to_zarr_inline(
+            zarr_path, compression=None, compression_level=5
+        )
+    assert not zarr_path.exists()
+
+
+@pytest.mark.parametrize(
+    "kwarg_name",
+    ["raw_preproc_kwargs", "window_kwargs", "window_preproc_kwargs"],
+)
 def test_preprocessing_kwargs_root_string_rejected_atomically(tmp_path, kwarg_name):
     """Native root strings cannot collide with legacy double-encoded attrs."""
     pytest.importorskip("zarr")
@@ -989,9 +1018,13 @@ def test_preprocessing_kwargs_uniform_multi_recording_isolation(tmp_path, kwarg_
     pytest.importorskip("zarr")
 
     concat_ds = _make_two_concat_raw_datasets_with_nan_locs()
-    kwargs = {"outer": [{"scale": 1}]}
-    for ds in concat_ds.datasets:
-        setattr(ds, kwarg_name, copy.deepcopy(kwargs))
+    kwargs = {"outer": [{"scale": 1, "enabled": True}], "method": "filter"}
+    setattr(concat_ds.datasets[0], kwarg_name, copy.deepcopy(kwargs))
+    setattr(
+        concat_ds.datasets[1],
+        kwarg_name,
+        {"method": "filter", "outer": [{"enabled": True, "scale": 1}]},
+    )
     zarr_path = tmp_path / f"{kwarg_name}-uniform.zarr"
     concat_ds._convert_to_zarr_inline(
         zarr_path, compression=None, compression_level=5


### PR DESCRIPTION
Closes #880

## Bug

Since #978 removed `_sanitize_for_json`, the MNE `Info` dict is stored verbatim as a zarr attribute. MNE `Info` routinely contains NaN (e.g. unknown channel positions in `chs[i]["loc"]`), and zarr-python serializes attributes with Python's default `json` behavior, which emits bare `NaN` literals. Those are forbidden by [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259#section-6) and by the [zarr v3 spec](https://zarr-specs.readthedocs.io/en/latest/v3/core/index.html) (metadata documents must be valid JSON), so any pushed dataset with unknown channel locations produces a `zarr.json` that strict JSON parsers and non-Python zarr readers reject — as seen in the [example dataset on the Hub](https://huggingface.co/datasets/braindecode/example_dataset-raw/blob/main/derivatives/braindecode/dataset.zarr/recording_0/zarr.json) linked in #880.

The same file also showed `raw_preproc_kwargs`/`window_kwargs`/`window_preproc_kwargs` stored as double-encoded JSON strings rather than JSON objects, which is the other part of the "not json formatted dicts" report in #880.

## Fix

- Reintroduce `_sanitize_for_json` in `hub_io.py` and apply it to the `info` attribute in all three save paths (raw, windows, EEG windows). NaN/Inf become `null`; the existing `_restore_nan_from_json` load path already converts them back to NaN, so the round trip stays lossless (`mne.Info.from_json_dict` gets proper NaN arrays).
- Store the preprocessing kwargs as native JSON objects instead of `json.dumps` strings; the loader still accepts the stringified form written by older braindecode versions, so existing Hub datasets keep loading.

## Tests

Three regression tests in `test/unit_tests/datasets/test_hub_integration.py`:

- `test_zarr_json_attrs_are_spec_compliant` — saves a dataset whose `Info` contains NaN channel locs and parses every generated `zarr.json` with a strict JSON parser that rejects `NaN`/`Infinity` literals (fails before this fix); also asserts the kwargs attrs are JSON objects, not strings.
- `test_nan_channel_locs_round_trip` — NaN channel locations survive save/load unchanged.
- `test_legacy_stringified_kwargs_still_load` — stores written with the old double-encoded kwargs format still load.

Full `test/unit_tests/datasets/test_hub_integration.py` module passes locally; ruff format/lint clean on the changed files.
