### PR TITLE
FIX preserve source annotation rows in event-window metadata

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -59,6 +59,7 @@ def _html_row(label, value):
 
 _METADATA_INTERNAL_COLS = {
     "i_window_in_trial",
+    "i_trial_in_dataset",
     "i_start_in_trial",
     "i_stop_in_trial",
     "target",
@@ -1373,6 +1374,20 @@ class BaseConcatDataset(ConcatDataset, HubDatasetMixin, Generic[T]):
                 "Metadata dataframe can only be computed when all "
                 "datasets are WindowsDataset."
             )
+
+        for ds in self.datasets:
+            if hasattr(ds, "_windows") and ds._windows is not None:
+                df = ds._windows.metadata
+            else:
+                df = ds.metadata
+            if (
+                "i_trial_in_dataset" in df.columns
+                and "i_trial_in_dataset" in ds.description
+            ):
+                raise ValueError(
+                    "Dataset descriptions cannot contain the reserved window "
+                    "metadata key 'i_trial_in_dataset'."
+                )
 
         all_dfs = list()
         for ds in self.datasets:

--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -354,6 +354,13 @@ def create_windows_from_events(
     -------
     windows_datasets: BaseConcatDataset[WindowsDataset | EEGWindowsDataset]
         Concatenated datasets of WindowsDataset containing the extracted windows.
+
+    Notes
+    -----
+    Event-window metadata contains the recording-local annotation row
+    ``i_trial_in_dataset``. This name is reserved: a same-named annotation
+    extra is discarded with a warning, and a same-named dataset description
+    cannot be combined by :meth:`BaseConcatDataset.get_metadata`.
     """
     on_last_window = _resolve_on_last_window(
         drop_last_window,
@@ -691,14 +698,20 @@ def _create_windows_from_events(
     events, events_id = mne.events_from_annotations(ds.raw, mapping, verbose=verbose)
     onsets = events[:, 0]
     ann = ds.raw.annotations
+    filtered_annotations = [
+        (i, annotation)
+        for i, annotation in enumerate(ann)
+        if annotation["description"] in events_id
+    ]
+    source_annotation_rows = np.array([i for i, _ in filtered_annotations], dtype=int)
     # Onsets are relative to the beginning of the recording
     filtered_durations = np.array(
-        [a["duration"] for a in ann if a["description"] in events_id]
+        [annotation["duration"] for _, annotation in filtered_annotations]
     )
 
     extras = None
     if hasattr(ann, "extras"):
-        extras = [a["extras"] for a in ann if a["description"] in events_id]
+        extras = [annotation["extras"] for _, annotation in filtered_annotations]
         if not any(extras):
             extras = None
 
@@ -816,6 +829,7 @@ def _create_windows_from_events(
                 events = events[checker_trials_size]
                 onsets = onsets[checker_trials_size]
                 stops = stops[checker_trials_size]
+                source_annotation_rows = source_annotation_rows[checker_trials_size]
                 if extras is not None:
                     extras = [e for i, e in enumerate(extras) if checker_trials_size[i]]
         description = events[:, -1]
@@ -823,6 +837,11 @@ def _create_windows_from_events(
         if not use_mne_epochs:
             onsets = onsets - ds.raw.first_samp
             stops = stops - ds.raw.first_samp
+        good_event_indices = np.flatnonzero(
+            window_size_samples
+            <= (stops + trial_stop_offset_samples)
+            - (onsets + trial_start_offset_samples)
+        )
         i_trials, i_window_in_trials, starts, stops = _compute_window_inds(
             onsets,
             stops,
@@ -833,6 +852,7 @@ def _create_windows_from_events(
             drop_last_window,
             accepted_bads_ratio,
         )
+        i_trials = [good_event_indices[i_trial] for i_trial in i_trials]
 
     if (on_overlapping_events != "ignore") and any(np.diff(starts) <= 0):
         msg = "Overlapping trials detected. You can ignore, warn, or raise an error, using the on_overlapping_events argument."
@@ -855,13 +875,16 @@ def _create_windows_from_events(
     metadata = pd.DataFrame(
         {
             "i_window_in_trial": i_window_in_trials,
+            "i_trial_in_dataset": source_annotation_rows[
+                np.asarray(i_trials, dtype=int)
+            ],
             "i_start_in_trial": starts,
             "i_stop_in_trial": stops,
             "target": description,
         }
     )
     if extras is not None:
-        extras_df = pd.DataFrame(extras)
+        extras_df = pd.DataFrame([dict(extra) for extra in extras])
         if forbidden_cols := set(metadata.columns).intersection(extras_df.columns):
             warnings.warn(
                 f"Dropping extra columns that conflict with windowing metadata: {forbidden_cols}"

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,6 +28,14 @@ Current 1.8.0 (GitHub)
 Enhancements
 ============
 
+- Preserve the recording-local row of each canonical MNE annotation as
+  ``i_trial_in_dataset`` in event-window metadata, keeping it aligned with
+  targets and annotation extras through event mapping, duration filtering,
+  and dropped short trials. Conflicting annotation extras are dropped with a
+  warning, while conflicting dataset descriptions are rejected during
+  metadata aggregation.
+  (:gh:`1130` by `Bruno Aristimunha`_)
+
 - Models with TorchScript-compatible forward paths can now be passed straight
   to :func:`torch.jit.script`, without first being rebuilt as a plain
   :class:`torch.nn.Module`.

--- a/test/unit_tests/datautil/test_serialization.py
+++ b/test/unit_tests/datautil/test_serialization.py
@@ -2,15 +2,17 @@
 #
 # License: BSD-3
 
+import json
 import os
 import platform
 import warnings
 
+import mne
 import numpy as np
 import pandas as pd
 import pytest
 
-from braindecode.datasets import BaseConcatDataset, MOABBDataset
+from braindecode.datasets import BaseConcatDataset, MOABBDataset, RawDataset
 from braindecode.datautil.serialization import (
     _check_save_dir_empty,
     load_concat_dataset,
@@ -143,6 +145,78 @@ def test_load_concat_windows_dataset(setup_concat_windows_dataset, tmpdir):
         concat_windows_dataset.description.astype(str),
         loaded_concat_windows_dataset.description.astype(str),
     )
+
+
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_source_metadata_roundtrip(tmp_path, use_mne_epochs):
+    raws = []
+    for _ in range(2):
+        raw = mne.io.RawArray(
+            np.zeros((1, 1100)),
+            mne.create_info(["Cz"], sfreq=100, ch_types="eeg"),
+            verbose=False,
+        )
+        raw.set_annotations(
+            mne.Annotations(
+                onset=[7, 1, 4],
+                duration=[2, 2, 2],
+                description=["B", "A", "OMIT"],
+                extras=[
+                    {"trial_uid": 30, "phase": "b"},
+                    {"trial_uid": 10, "phase": "a"},
+                    {"trial_uid": 20, "phase": "omit"},
+                ],
+            )
+        )
+        raws.append(raw)
+
+    windows = create_windows_from_events(
+        BaseConcatDataset(
+            [
+                RawDataset(raw, description={"recording": i})
+                for i, raw in enumerate(raws)
+            ]
+        ),
+        window_size_samples=100,
+        window_stride_samples=100,
+        on_last_window="drop",
+        mapping={"A": 7, "B": 9},
+        use_mne_epochs=use_mne_epochs,
+        drop_bad_windows=False,
+        preload=True,
+    )
+    expected = pd.DataFrame(
+        {
+            "i_window_in_trial": [0, 1, 0, 1],
+            "i_trial_in_dataset": [0, 0, 2, 2],
+            "i_start_in_trial": [100, 200, 700, 800],
+            "i_stop_in_trial": [200, 300, 800, 900],
+            "target": [7, 7, 9, 9],
+            "trial_uid": [10, 10, 30, 30],
+            "phase": ["a", "a", "b", "b"],
+        }
+    )
+    for ds in windows.datasets:
+        pd.testing.assert_frame_equal(
+            ds.metadata.reset_index(drop=True), expected, check_dtype=False
+        )
+        assert pd.api.types.is_integer_dtype(ds.metadata["i_trial_in_dataset"])
+
+    save_dir = tmp_path / "event-source-windows"
+    windows.save(save_dir, overwrite=False)
+    loaded = load_concat_dataset(save_dir, preload=False)
+
+    for before, after in zip(windows.datasets, loaded.datasets):
+        # MNE reindexes metadata rows to follow the Epochs selection, so only
+        # pandas row-index identity is deliberately excluded from this roundtrip.
+        pd.testing.assert_frame_equal(
+            after.metadata.reset_index(drop=True),
+            before.metadata.reset_index(drop=True),
+        )
+        assert pd.api.types.is_integer_dtype(after.metadata["i_trial_in_dataset"])
+        normalized_kwargs = json.loads(json.dumps(before.window_kwargs))
+        assert after.window_kwargs == normalized_kwargs
+        assert "i_trial_in_dataset" not in json.dumps(after.window_kwargs)
 
 
 def test_load_multiple_concat_raw_dataset(setup_concat_raw_dataset, tmpdir):

--- a/test/unit_tests/preprocessing/test_windowers.py
+++ b/test/unit_tests/preprocessing/test_windowers.py
@@ -37,6 +37,91 @@ from braindecode.preprocessing.windowers import (
 )
 from braindecode.util import create_mne_dummy_raw
 
+_EVENT_METADATA_COLUMNS = [
+    "i_window_in_trial",
+    "i_trial_in_dataset",
+    "i_start_in_trial",
+    "i_stop_in_trial",
+    "target",
+    "trial_uid",
+    "phase",
+]
+
+
+def _make_annotated_raw(
+    onsets,
+    durations,
+    descriptions,
+    trial_uids,
+    phases,
+    *,
+    first_samp=0,
+    source_values=None,
+):
+    n_times = int((max(onsets) + max(durations) + 2) * 100)
+    raw = mne.io.RawArray(
+        np.zeros((1, n_times)),
+        mne.create_info(["Cz"], sfreq=100, ch_types="eeg"),
+        first_samp=first_samp,
+        verbose=False,
+    )
+    extras = []
+    for i, (trial_uid, phase) in enumerate(zip(trial_uids, phases)):
+        extra = {"trial_uid": trial_uid, "phase": phase}
+        if source_values is not None:
+            extra["i_trial_in_dataset"] = source_values[i]
+        extras.append(extra)
+    raw.set_annotations(
+        mne.Annotations(
+            onset=onsets,
+            duration=durations,
+            description=descriptions,
+            extras=extras,
+        )
+    )
+    return raw
+
+
+def _event_windows(raws, *, use_mne_epochs, descriptions=None, **kwargs):
+    if descriptions is None:
+        descriptions = [None] * len(raws)
+    concat = BaseConcatDataset(
+        [
+            RawDataset(raw, description=description)
+            for raw, description in zip(raws, descriptions)
+        ]
+    )
+    return create_windows_from_events(
+        concat,
+        use_mne_epochs=use_mne_epochs,
+        drop_bad_windows=False,
+        **kwargs,
+    )
+
+
+def _expected_event_metadata(
+    *, window_numbers, source_rows, starts, stops, targets, trial_uids, phases
+):
+    return pd.DataFrame(
+        {
+            "i_window_in_trial": window_numbers,
+            "i_trial_in_dataset": source_rows,
+            "i_start_in_trial": starts,
+            "i_stop_in_trial": stops,
+            "target": targets,
+            "trial_uid": trial_uids,
+            "phase": phases,
+        },
+        columns=_EVENT_METADATA_COLUMNS,
+    )
+
+
+def _assert_event_metadata(actual, expected):
+    actual = actual.reset_index(drop=True)
+    pd.testing.assert_frame_equal(actual, expected, check_dtype=False)
+    assert list(actual.columns) == _EVENT_METADATA_COLUMNS
+    assert pd.api.types.is_integer_dtype(actual["i_trial_in_dataset"])
+
 
 def _get_raw(tmpdir_factory, description=None):
     _, fnames = create_mne_dummy_raw(
@@ -1522,6 +1607,285 @@ def test_dict_params_bad_trial_dropped_extras_not_misassigned():
     assert (t0_meta["trial_id"] == 30).all(), (
         f"Expected trial_id=30 for surviving T0 windows, got {t0_meta['trial_id'].tolist()}"
     )
+
+
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_source_index_mapping_gap_and_canonical_order(use_mne_epochs):
+    raws = [
+        _make_annotated_raw(
+            [7, 1, 4],
+            [2, 2, 2],
+            ["B", "A", "OMIT"],
+            [30, 10, 20],
+            ["b", "a", "omit"],
+        )
+        for _ in range(2)
+    ]
+    windows = _event_windows(
+        raws,
+        use_mne_epochs=use_mne_epochs,
+        window_size_samples=100,
+        window_stride_samples=100,
+        on_last_window="drop",
+        mapping={"A": 7, "B": 9},
+    )
+    expected = _expected_event_metadata(
+        window_numbers=[0, 1, 0, 1],
+        source_rows=[0, 0, 2, 2],
+        starts=[100, 200, 700, 800],
+        stops=[200, 300, 800, 900],
+        targets=[7, 7, 9, 9],
+        trial_uids=[10, 10, 30, 30],
+        phases=["a", "a", "b", "b"],
+    )
+    for ds in windows.datasets:
+        _assert_event_metadata(ds.metadata, expected)
+        if use_mne_epochs:
+            np.testing.assert_array_equal(ds.windows.events[:, 2], expected["target"])
+
+
+@pytest.mark.parametrize("drop_position", ["early", "middle"])
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_source_index_scalar_short_drop(drop_position, use_mne_epochs):
+    durations = [0.5, 2, 2] if drop_position == "early" else [2, 0.5, 2]
+    raw = _make_annotated_raw(
+        [1, 4, 7], durations, ["A", "B", "C"], [10, 20, 30], ["a", "b", "c"]
+    )
+    expected_values = {
+        "early": {
+            "source_rows": [1, 1, 2, 2],
+            "starts": [400, 500, 700, 800],
+            "targets": [8, 8, 9, 9],
+            "trial_uids": [20, 20, 30, 30],
+            "phases": ["b", "b", "c", "c"],
+            "dropped": 0,
+        },
+        "middle": {
+            "source_rows": [0, 0, 2, 2],
+            "starts": [100, 200, 700, 800],
+            "targets": [7, 7, 9, 9],
+            "trial_uids": [10, 10, 30, 30],
+            "phases": ["a", "a", "c", "c"],
+            "dropped": 1,
+        },
+    }[drop_position]
+    with pytest.warns(UserWarning, match=rf"Trials \[{expected_values['dropped']}\].*dropped"):
+        windows = _event_windows(
+            [raw],
+            use_mne_epochs=use_mne_epochs,
+            window_size_samples=100,
+            window_stride_samples=100,
+            on_last_window="drop",
+            mapping={"A": 7, "B": 8, "C": 9},
+            accepted_bads_ratio=1 / 3,
+            on_missing="ignore",
+        )
+    expected = _expected_event_metadata(
+        window_numbers=[0, 1, 0, 1],
+        source_rows=expected_values["source_rows"],
+        starts=expected_values["starts"],
+        stops=[start + 100 for start in expected_values["starts"]],
+        targets=expected_values["targets"],
+        trial_uids=expected_values["trial_uids"],
+        phases=expected_values["phases"],
+    )
+    actual = windows.datasets[0].metadata.reset_index(drop=True)
+    # These assertions precede source-column access so RED proves the old remap bug.
+    for column in (
+        "target",
+        "trial_uid",
+        "phase",
+        "i_start_in_trial",
+        "i_stop_in_trial",
+        "i_window_in_trial",
+    ):
+        np.testing.assert_array_equal(actual[column], expected[column])
+    _assert_event_metadata(actual, expected)
+    if use_mne_epochs:
+        np.testing.assert_array_equal(
+            windows.datasets[0].windows.events[:, 2], expected["target"]
+        )
+
+
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_source_index_per_event_short_drop(use_mne_epochs):
+    raw = _make_annotated_raw(
+        [1, 4, 7, 10],
+        [0.5, 2, 2, 2],
+        ["A", "B", "A", "B"],
+        [10, 20, 30, 40],
+        ["a0", "b0", "a1", "b1"],
+    )
+    with pytest.warns(UserWarning, match=r"Trials \[0\].*dropped"):
+        windows = _event_windows(
+            [raw],
+            use_mne_epochs=use_mne_epochs,
+            trial_start_offset_samples={"A": 0, "B": 0},
+            trial_stop_offset_samples={"A": 0, "B": 0},
+            window_size_samples=100,
+            window_stride_samples={"A": 100, "B": 100},
+            on_last_window="drop",
+            mapping={"A": 7, "B": 9},
+            accepted_bads_ratio=0.5,
+        )
+    expected = _expected_event_metadata(
+        window_numbers=[0, 1, 0, 1, 0, 1],
+        source_rows=[1, 1, 2, 2, 3, 3],
+        starts=[400, 500, 700, 800, 1000, 1100],
+        stops=[500, 600, 800, 900, 1100, 1200],
+        targets=[9, 9, 7, 7, 9, 9],
+        trial_uids=[20, 20, 30, 30, 40, 40],
+        phases=["b0", "b0", "a1", "a1", "b1", "b1"],
+    )
+    _assert_event_metadata(windows.datasets[0].metadata, expected)
+    if use_mne_epochs:
+        np.testing.assert_array_equal(
+            windows.datasets[0].windows.events[:, 2], expected["target"]
+        )
+
+
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_source_index_inferred_size_filter(use_mne_epochs):
+    raw = _make_annotated_raw(
+        [1, 4, 7], [2, 1, 2], ["A", "B", "C"], [10, 20, 30], ["a", "b", "c"]
+    )
+    with pytest.warns(UserWarning, match="different windows size 1"):
+        windows = _event_windows(
+            [raw],
+            use_mne_epochs=use_mne_epochs,
+            mapping={"A": 7, "B": 8, "C": 9},
+            on_missing="ignore",
+        )
+    expected = _expected_event_metadata(
+        window_numbers=[0, 0],
+        source_rows=[0, 2],
+        starts=[100, 700],
+        stops=[300, 900],
+        targets=[7, 9],
+        trial_uids=[10, 30],
+        phases=["a", "c"],
+    )
+    _assert_event_metadata(windows.datasets[0].metadata, expected)
+    if use_mne_epochs:
+        np.testing.assert_array_equal(
+            windows.datasets[0].windows.events[:, 2], expected["target"]
+        )
+
+
+def test_event_source_index_nonzero_first_samp():
+    direct_raw = _make_annotated_raw(
+        [1], [1], ["T0"], [10], ["a"], first_samp=1000
+    )
+    mne_raw = direct_raw.copy()
+    kwargs = dict(
+        window_size_samples=100,
+        window_stride_samples=100,
+        on_last_window="drop",
+        mapping={"T0": 7},
+    )
+    direct = _event_windows([direct_raw], use_mne_epochs=False, **kwargs)
+    epochs = _event_windows([mne_raw], use_mne_epochs=True, **kwargs)
+    direct_md = direct.datasets[0].metadata.reset_index(drop=True)
+    epochs_md = epochs.datasets[0].metadata.reset_index(drop=True)
+    np.testing.assert_array_equal(direct_md[["i_start_in_trial", "i_stop_in_trial"]], [[100, 200]])
+    np.testing.assert_array_equal(epochs_md[["i_start_in_trial", "i_stop_in_trial"]], [[1100, 1200]])
+    np.testing.assert_array_equal(epochs.datasets[0].windows.events[:, [0, 2]], [[1100, 7]])
+    normalized = epochs_md.copy()
+    normalized[["i_start_in_trial", "i_stop_in_trial"]] -= 1000
+    pd.testing.assert_frame_equal(direct_md, normalized)
+    assert pd.api.types.is_integer_dtype(direct_md["i_trial_in_dataset"])
+
+
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_source_index_reserved_extra(use_mne_epochs):
+    raw = _make_annotated_raw(
+        [1], [1], ["T0"], [10], ["a"], source_values=[999]
+    )
+    with pytest.warns(UserWarning, match="Dropping extra columns.*i_trial_in_dataset"):
+        windows = _event_windows(
+            [raw],
+            use_mne_epochs=use_mne_epochs,
+            window_size_samples=100,
+            window_stride_samples=100,
+            on_last_window="drop",
+            mapping={"T0": 7},
+        )
+    expected = _expected_event_metadata(
+        window_numbers=[0],
+        source_rows=[0],
+        starts=[100],
+        stops=[200],
+        targets=[7],
+        trial_uids=[10],
+        phases=["a"],
+    )
+    _assert_event_metadata(windows.datasets[0].metadata, expected)
+    assert 999 not in windows.datasets[0].metadata["i_trial_in_dataset"].to_list()
+
+
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_source_index_reserved_description(use_mne_epochs):
+    raw = _make_annotated_raw([1], [1], ["T0"], [10], ["a"])
+    windows = _event_windows(
+        [raw],
+        descriptions=[{"recording": 0, "i_trial_in_dataset": 999}],
+        use_mne_epochs=use_mne_epochs,
+        window_size_samples=100,
+        window_stride_samples=100,
+        on_last_window="drop",
+        mapping={"T0": 7},
+    )
+    stored_before = windows.datasets[0].metadata.copy(deep=True)
+    np.testing.assert_array_equal(stored_before["i_trial_in_dataset"], [0])
+    with pytest.raises(ValueError, match="reserved.*i_trial_in_dataset"):
+        windows.get_metadata()
+    pd.testing.assert_frame_equal(windows.datasets[0].metadata, stored_before)
+
+
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_source_index_is_internal_in_representations(use_mne_epochs):
+    raw = _make_annotated_raw([1], [1], ["T0"], [10], ["a"])
+    windows = _event_windows(
+        [raw],
+        use_mne_epochs=use_mne_epochs,
+        window_size_samples=100,
+        window_stride_samples=100,
+        on_last_window="drop",
+        mapping={"T0": 7},
+    )
+    assert "i_trial_in_dataset" in windows.datasets[0].metadata
+    for rendered in (
+        repr(windows.datasets[0]),
+        windows.datasets[0]._repr_html_(),
+        repr(windows),
+        windows._repr_html_(),
+    ):
+        assert "i_trial_in_dataset" not in rendered
+
+
+@pytest.mark.parametrize("parameter_style", ["scalar", "per_event"])
+@pytest.mark.parametrize("use_mne_epochs", [False, True])
+def test_event_all_short_preserves_post_1058_error(parameter_style, use_mne_epochs):
+    raw = _make_annotated_raw(
+        [1, 4], [0.2, 0.2], ["A", "B"], [10, 20], ["a", "b"]
+    )
+    kwargs = dict(
+        window_size_samples=100,
+        on_last_window="drop",
+        mapping={"A": 7, "B": 9},
+        accepted_bads_ratio=1.0,
+    )
+    if parameter_style == "scalar":
+        kwargs["window_stride_samples"] = 100
+    else:
+        kwargs.update(
+            trial_start_offset_samples={"A": 0, "B": 0},
+            trial_stop_offset_samples={"A": 0, "B": 0},
+            window_stride_samples={"A": 100, "B": 100},
+        )
+    with pytest.warns(UserWarning, match="are being dropped"):
+        with pytest.raises(IndexError, match="too many indices"):
+            _event_windows([raw], use_mne_epochs=use_mne_epochs, **kwargs)
 
 
 def _make_small_eeg_windows_dataset(lazy_loadable_dataset):


### PR DESCRIPTION
## Summary

This reduced replacement for #1051 preserves the source annotation row of
every event window on current `master`.

`create_windows_from_events` now writes `i_trial_in_dataset`: the zero-based
row of the source annotation in that recording's canonical
`raw.annotations` sequence at windower entry. The row identity is
recording-local and is captured before mapping omissions, inferred-duration
filtering, short-trial dropping, or expansion into multiple windows. Gaps and
repeated values are therefore meaningful.

One filtered-event coordinate now drives source row, target, retained
annotation extras, window bounds, and MNE event class. This fixes the
early/middle dropped-trial misalignment identified in the two unresolved #1051
review threads. Direct `EEGWindowsDataset` bounds remain raw-relative; MNE
`WindowsDataset` bounds/events remain absolute and include `raw.first_samp`.

## Reserved metadata name

`i_trial_in_dataset` is one reserved internal key:

- a same-named annotation extra is dropped with the existing warning, while
  the generated source row wins and other extras remain aligned;
- a same-named dataset-description field raises `ValueError` before metadata
  assignment, so stored window metadata is not overwritten; and
- dataset/concat representations treat the key as internal.

This is deliberately a single-key protection, not a generic metadata
collision, equality, or aggregation framework.

## Scope and exclusions

Exact head: `119b3c9cb744565a633f74dfed7e42659d21913f`  
Base: `f068a93168a8865841adc2fabf03ef9d90208115`  
Tree: `8bf71cf2f54621b2dd488cbfe23540d5e737e2ae`  
Binary diff SHA-256:
`afa71be7cea516d116919625f05f2d1dd91c86c2e016eb2e4ab6a0ff169f9114`

The PR changes exactly five paths: the dataset metadata guard, event windower,
their focused serialization/windowing tests, and the changelog. It does not
change `_compute_window_inds`, `on_last_window`, `set_target`, serializer
production code, existing annotation-free or all-short exception behavior,
generic metadata behavior, tutorials, datasets, or experiments.

## Verification

The pre-restack five-path candidate passed the focused suite (**238 passed, 2
skipped**), complete pytest (**3,231 passed, 224 skipped**), complete
pre-commit, every hosted platform job, and hosted docs. The restack only
integrates the already-qualified #1119 squash merge; on exact restacked head
`119b3c9c...`, all 23 tests added by this replacement and the five-path
pre-commit selection pass. `git diff --check` also passes.

Independent review found no P0-P3 and covered inferred, explicit, and callable
mappings; both window backends; nonzero
  `first_samp`; per-event offsets/strides; reserved collisions; pickle reloads;
  edge errors; and large event/window probes.

The local warning-as-error docs build generated the site but returned nonzero
only for pre-existing documentation/configuration warnings outside the five
changed lines. Hosted docs and the full hosted platform matrix on this exact
head remain merge gates.

## Provenance

This PR supersedes the broad, conflicting #1051 without rewriting its history.
GitHub Copilot authored the original source-index implementation and tests;
Bruno Aristimunha contributed the dropped-trial alignment, serialization test,
and later contract work. The old PR and branch remain intact until this
replacement is squash-merged and verified on `master`; only then should #1051
be closed as superseded.
