### PR TITLE
Fix license metadata without Hub dependency

### DIFF
--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -80,7 +80,7 @@ class _BraindecodeDocstringMeta(NumpyDocstringInheritanceInitMeta):
     unwrapped function and correctly inherits ``cls.__doc__``.
     """
 
-    def __init__(cls, class_name, class_bases, class_dict):
+    def __init__(cls, class_name, class_bases, class_dict, **kwargs):
         super().__init__(class_name, class_bases, class_dict)
         # Only wrap subclass __init__s, not EEGModuleMixin itself.
         # Wrapping the mixin would cause super().__init__() calls to
@@ -214,6 +214,8 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
     __jit_unused_properties__ = ["chs_info"]
 
     def __init_subclass__(cls, **kwargs):
+        license = kwargs.pop("license", "bsd-3-clause")
+
         # TorchScript only honours ``__jit_ignored_attributes__`` for
         # properties defined directly on the concrete class: it collects them
         # with ``vars(type(module))``, which skips inherited ones. Rebinding
@@ -253,8 +255,6 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
         )
         repo_url = kwargs.pop("repo_url", "https://braindecode.org")
         library_name = kwargs.pop("library_name", "braindecode")
-        license = kwargs.pop("license", "bsd-3-clause")
-
         # Register a coder so that type[nn.Module] parameters
         # (e.g. activation=nn.ELU) are serialized as importable
         # strings in config.json and decoded back on load.

--- a/test/unit_tests/models/test_base.py
+++ b/test/unit_tests/models/test_base.py
@@ -4,6 +4,8 @@
 
 
 import json
+import subprocess
+import sys
 from operator import attrgetter
 from unittest.mock import patch
 
@@ -113,6 +115,35 @@ def test_init_subclass_propagates_extended_jit_ignored_property():
         is DummyModuleWithExtraIgnoredProperty.__dict__["runtime_only"]
     )
     torch.testing.assert_close(scripted(input_tensor), module(input_tensor))
+
+
+def test_init_subclass_with_license_without_hf_hub():
+    """A model license can be declared without the optional Hub dependency."""
+    code = """
+import sys
+
+sys.modules["huggingface_hub"] = None
+
+from braindecode.models import base
+
+assert not base.HAS_HF_HUB
+
+class LicensedTestModel(
+    base.EEGModuleMixin,
+    license="cc-by-nc-sa-4.0",
+):
+    pass
+
+assert issubclass(LicensedTestModel, base.EEGModuleMixin)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 @pytest.fixture(scope="function")

--- a/test/unit_tests/models/test_base.py
+++ b/test/unit_tests/models/test_base.py
@@ -125,11 +125,13 @@ import sys
 sys.modules["huggingface_hub"] = None
 
 from braindecode.models import base
+from torch import nn
 
 assert not base.HAS_HF_HUB
 
 class LicensedTestModel(
     base.EEGModuleMixin,
+    nn.Module,
     license="cc-by-nc-sa-4.0",
 ):
     pass

--- a/test/unit_tests/models/test_huggingface.py
+++ b/test/unit_tests/models/test_huggingface.py
@@ -11,8 +11,6 @@ Hugging Face Hub when the optional huggingface_hub dependency is installed.
 """
 
 import json
-import subprocess
-import sys
 
 import numpy as np
 import pytest
@@ -356,32 +354,3 @@ def test_init_subclass_without_hf_hub():
         assert TestModel is not None
     finally:
         base.HAS_HF_HUB = original_has_hf_hub
-
-
-def test_init_subclass_with_license_without_hf_hub():
-    """A model license can be declared without the optional Hub dependency."""
-    code = """
-import sys
-
-sys.modules["huggingface_hub"] = None
-
-from braindecode.models import base
-
-assert not base.HAS_HF_HUB
-
-class LicensedTestModel(
-    base.EEGModuleMixin,
-    license="cc-by-nc-sa-4.0",
-):
-    pass
-
-assert issubclass(LicensedTestModel, base.EEGModuleMixin)
-"""
-
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-    )
-
-    assert result.returncode == 0, result.stderr

--- a/test/unit_tests/models/test_huggingface.py
+++ b/test/unit_tests/models/test_huggingface.py
@@ -11,6 +11,8 @@ Hugging Face Hub when the optional huggingface_hub dependency is installed.
 """
 
 import json
+import subprocess
+import sys
 
 import numpy as np
 import pytest
@@ -354,3 +356,32 @@ def test_init_subclass_without_hf_hub():
         assert TestModel is not None
     finally:
         base.HAS_HF_HUB = original_has_hf_hub
+
+
+def test_init_subclass_with_license_without_hf_hub():
+    """A model license can be declared without the optional Hub dependency."""
+    code = """
+import sys
+
+sys.modules["huggingface_hub"] = None
+
+from braindecode.models import base
+
+assert not base.HAS_HF_HUB
+
+class LicensedTestModel(
+    base.EEGModuleMixin,
+    license="cc-by-nc-sa-4.0",
+):
+    pass
+
+assert issubclass(LicensedTestModel, base.EEGModuleMixin)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
This extracts the only generic prerequisite from #1132 / #1129 into a two-file change.

- Consume the model license keyword before the no-Hub fallback metaclass receives subclass keywords.
- Add a subprocess regression test that imports Braindecode with huggingface_hub unavailable and declares a licensed model.
- Keep all pose models, registrations, NOTICE changes, and noncommercial code out of scope.

Validation:
- focused regression: 1 passed
- model base and Hub suites: 226 passed, 20 skipped
- changed-file pre-commit hooks: passed
- independent review: approve