### PR TITLE
FIX correct the AttnSleep model summary

### DIFF
--- a/braindecode/models/summary.csv
+++ b/braindecode/models/summary.csv
@@ -31,7 +31,7 @@ SincShallowNet,Motor Imagery,Prediction,250,"n_chans, n_outputs, n_times, sfreq"
 ShallowFBCSPNet,General,Prediction,250,"n_chans, n_outputs, n_times",46084,"ShallowFBCSPNet(n_chans=22,  n_outputs=4,  n_times=1000, sfreq=250)","Convolution",EEG
 SleepStagerBlanco2020,Sleep Staging,Prediction,100,"n_chans, n_outputs, n_times",2845,"SleepStagerBlanco2020(n_chans=2, n_outputs=5, n_times=3000, sfreq=100)","Convolution",EEG
 SleepStagerChambon2018,Sleep Staging,Prediction,128,"n_chans, n_outputs, n_times, sfreq",5835,"SleepStagerChambon2018(n_chans=2, n_outputs=5, n_times=3840, sfreq=128)","Convolution",EEG
-AttnSleep,Sleep Staging,Prediction,100,"n_chans, n_outputs, n_times, sfreq",719925,"AttnSleep(n_chans=2, n_outputs=5, n_times=3000, sfreq=100)","Convolution, Attention/Transformer",EEG
+AttnSleep,Sleep Staging,Prediction,100,"n_chans, n_outputs, n_times, sfreq",522805,"AttnSleep(n_chans=1, n_outputs=5, n_times=3000, sfreq=100)","Convolution, Attention/Transformer",EEG
 SPARCNet,Epilepsy,Prediction,200,"n_chans, n_outputs, n_times",1141921,"SPARCNet(n_chans=16, n_outputs=6, n_times=2000, sfreq=200)","Convolution",EEG
 SyncNet,"Emotion Recognition, Alcoholism",Prediction,256,"n_chans, n_outputs, n_times",554,"SyncNet(n_chans=62, n_outputs=3, n_times=5120, sfreq=256)","Interpretability",EEG
 TSception,Emotion Recognition,Prediction,256,"n_chans, n_outputs, n_times, sfreq",2187206,"TSception(n_chans=62, n_outputs=3, n_times=5120, sfreq=256)","Convolution",EEG


### PR DESCRIPTION
This corrects the AttnSleep entry in the model summary after #1119. The architecture accepts one input channel, and the documented constructor has 522,805 trainable parameters.

The change is limited to one row in summary.csv; model code and defaults are unchanged.

Validation:
- 9 focused AttnSleep tests
- 126 model categorization/modality tests (2 skipped)
- 143 enforced model-contract tests (5 skipped)
- independent exact-head review: approved