### PR TITLE
Improve LUNA, ZUNA, and USleep accelerator portability

### DIFF
--- a/braindecode/models/luna.py
+++ b/braindecode/models/luna.py
@@ -545,6 +545,22 @@ class _RotarySelfAttentionBlock(nn.Module):
         self.proj = nn.Linear(dim, dim)
         self.proj_drop = nn.Dropout(proj_drop)
 
+    def _rotate_queries_or_keys(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Apply full-head RoPE without concatenating empty boundary views."""
+        seq_dim = self.rotary_emb.default_seq_dim
+        seq_len = tensor.shape[seq_dim]
+        seq = self.rotary_emb.get_seq_pos(
+            seq_len, device=tensor.device, dtype=tensor.dtype, offset=0
+        )
+        freqs = self.rotary_emb(seq, seq_len=seq_len, offset=0)
+        if seq_dim == -3:
+            freqs = rearrange(freqs, "n d -> n 1 d")
+
+        pairs = tensor.reshape(*tensor.shape[:-1], -1, 2)
+        rotated = torch.stack((-pairs[..., 1], pairs[..., 0]), dim=-1).flatten(-2)
+        transformed = tensor * freqs.cos() + rotated * freqs.sin()
+        return transformed.to(tensor.dtype)
+
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         B, N, C = x.shape
         qkv = (
@@ -553,8 +569,8 @@ class _RotarySelfAttentionBlock(nn.Module):
             .permute(2, 0, 3, 1, 4)
         )  # (K, B, H, N, D)
         q, k, v = qkv[0], qkv[1], qkv[2]
-        q = self.rotary_emb.rotate_queries_or_keys(q)
-        k = self.rotary_emb.rotate_queries_or_keys(k)
+        q = self._rotate_queries_or_keys(q)
+        k = self._rotate_queries_or_keys(k)
         # Calculate attention scores
         attn_weights = (q @ k.transpose(-2, -1)) * self.scale  # (B, H, N, N)
 

--- a/braindecode/models/luna.py
+++ b/braindecode/models/luna.py
@@ -20,7 +20,6 @@ import torch.fft as fft
 import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
-from rotary_embedding_torch import RotaryEmbedding
 
 from braindecode.models.base import EEGModuleMixin
 from braindecode.models.util import extract_channel_locations_from_chs_info
@@ -535,7 +534,7 @@ class _RotarySelfAttentionBlock(nn.Module):
         self.dim = dim
         self.num_heads = num_heads
         head_dim = dim // num_heads
-        self.rotary_emb = RotaryEmbedding(dim=head_dim, learned_freq=False)
+        self.rotary_emb = _RotaryEmbedding(head_dim)
 
         self.scale = qk_scale or head_dim**-0.5
 
@@ -547,14 +546,9 @@ class _RotarySelfAttentionBlock(nn.Module):
 
     def _rotate_queries_or_keys(self, tensor: torch.Tensor) -> torch.Tensor:
         """Apply full-head RoPE without concatenating empty boundary views."""
-        seq_dim = self.rotary_emb.default_seq_dim
-        seq_len = tensor.shape[seq_dim]
-        seq = self.rotary_emb.get_seq_pos(
-            seq_len, device=tensor.device, dtype=tensor.dtype, offset=0
-        )
-        freqs = self.rotary_emb(seq, seq_len=seq_len, offset=0)
-        if seq_dim == -3:
-            freqs = rearrange(freqs, "n d -> n 1 d")
+        seq_len = tensor.shape[-2]
+        positions = torch.arange(seq_len, device=tensor.device, dtype=tensor.dtype)
+        freqs = self.rotary_emb(positions)
 
         pairs = tensor.reshape(*tensor.shape[:-1], -1, 2)
         rotated = torch.stack((-pairs[..., 1], pairs[..., 0]), dim=-1).flatten(-2)
@@ -584,6 +578,21 @@ class _RotarySelfAttentionBlock(nn.Module):
         attn = attn_weights @ v  # (B, H, N, D)
         attn = rearrange(attn, "B H N D -> B N (H D)")
         return self.proj_drop(self.proj(attn))
+
+
+class _RotaryEmbedding(nn.Module):
+    """Minimal language RoPE frequency generator used by LUNA."""
+
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        frequencies = 1.0 / (
+            theta ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
+        )
+        self.freqs = nn.Parameter(frequencies, requires_grad=False)
+
+    def forward(self, positions: torch.Tensor) -> torch.Tensor:
+        angles = positions.to(self.freqs.dtype).unsqueeze(-1) * self.freqs
+        return angles.repeat_interleave(2, dim=-1)
 
 
 class _FeedForwardBlock(nn.Module):

--- a/braindecode/models/usleep.py
+++ b/braindecode/models/usleep.py
@@ -431,11 +431,7 @@ class _DecoderBlock(nn.Module):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Crops two tensors to their lowest-common-dimension along an axis."""
         dim_cropped = min(x1.shape[axis], x2.shape[axis])
-
-        x1_cropped = torch.index_select(
-            x1, dim=axis, index=torch.arange(dim_cropped).to(device=x1.device)
+        return (
+            x1.narrow(axis, 0, dim_cropped),
+            x2.narrow(axis, 0, dim_cropped),
         )
-        x2_cropped = torch.index_select(
-            x2, dim=axis, index=torch.arange(dim_cropped).to(device=x1.device)
-        )
-        return x1_cropped, x2_cropped

--- a/braindecode/models/zuna.py
+++ b/braindecode/models/zuna.py
@@ -11,7 +11,6 @@ from typing import Optional
 import torch
 from einops import rearrange
 from einops.layers.torch import Rearrange
-from rotary_embedding_torch import RotaryEmbedding
 from torch import nn
 from torch.nn import functional
 
@@ -275,18 +274,11 @@ class ZUNA(EEGModuleMixin, nn.Module):
             (channel_position_indices, coarse_time_indices.unsqueeze(1)), dim=1
         )
 
-        rotary_embedding = RotaryEmbedding(
-            # rotary_embedding_torch cannot construct dim=2 directly because
-            # of its theta-rescaling formula; dim=4 followed by slicing is
-            # equivalent for the single-frequency dim=2 case.
-            dim=max(rotary_axis_dim, 4),
+        rotary_frequency_table = _build_rotary_frequency_table(
+            torch.arange(max_seqlen, dtype=torch.float32),
+            axis_dim=rotary_axis_dim,
             theta=rope_theta,
-            cache_if_possible=False,
         )
-        with torch.no_grad():
-            rotary_frequency_table = rotary_embedding(
-                torch.arange(max_seqlen, dtype=torch.float32)
-            )[:, :rotary_axis_dim]
         token_rotary_frequencies = rearrange(
             rotary_frequency_table[token_position_indices],
             "token coordinate rotary_frequency -> token (coordinate rotary_frequency)",
@@ -342,6 +334,28 @@ class ZUNA(EEGModuleMixin, nn.Module):
             Rearrange("batch channel latent -> batch (channel latent)"),
             nn.Linear(self.num_channels * self.latent_dim, n_outputs),
         )
+
+
+def _build_rotary_frequency_table(
+    positions: torch.Tensor, *, axis_dim: int, theta: float
+) -> torch.Tensor:
+    """Build ZUNA's per-axis rotary frequencies with native PyTorch."""
+    embedding_dim = max(axis_dim, 4)
+    inverse_frequencies = 1.0 / (
+        theta
+        ** (
+            torch.arange(
+                0,
+                embedding_dim,
+                2,
+                device=positions.device,
+                dtype=torch.float32,
+            )
+            / embedding_dim
+        )
+    )
+    angles = positions.to(torch.float32).unsqueeze(-1) * inverse_frequencies
+    return angles.repeat_interleave(2, dim=-1)[:, :axis_dim]
 
 
 class _RotaryPositionEmbedding(nn.Module):

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -67,10 +67,21 @@ API and behavior changes
 Requirements
 ============
 
-- None yet
+- Remove the ``rotary_embedding_torch`` dependency. The rotary frequency
+  generation used by :class:`braindecode.models.LUNA` and
+  :class:`braindecode.models.ZUNA` is now implemented directly with PyTorch.
+  (:gh:`1136` by `Bruno Aristimunha`_)
 
 Bug fixes
 ==========
+
+- Make :class:`braindecode.models.LUNA` rotary attention portable to
+  accelerators that reject concatenations containing empty tensor views, while
+  preserving its pretrained-checkpoint parameter keys and numerical behavior.
+  Also crop mismatched :class:`braindecode.models.USleep` decoder tensors with
+  views instead of allocating index tensors, avoiding unsupported accelerator
+  lowering without changing the selected samples. (:gh:`1136` by `Bruno
+  Aristimunha`_)
 
 - Fix the docstrings of :class:`braindecode.models.ATCNet`,
   :class:`braindecode.models.AttnSleep`, :class:`braindecode.models.CTNet`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
     'wfdb>=4.3.1',  # requests comes transitively via mne→pooch and wfdb
     'linear_attention_transformer',
     'docstring_inheritance',        # we get einops from here
-    'rotary_embedding_torch',
     'pydantic>=2.0',
 ]
 

--- a/test/unit_tests/models/test_foundation_models.py
+++ b/test/unit_tests/models/test_foundation_models.py
@@ -12,6 +12,9 @@ import pooch
 import pytest
 import torch
 
+import braindecode.models.luna as luna_module
+import braindecode.models.zuna as zuna_module
+
 try:
     from huggingface_hub import hf_hub_download
     from safetensors.torch import load_file
@@ -24,6 +27,15 @@ from braindecode.models import LUNA, REVE, CBraMod, CodeBrain, Labram
 from braindecode.models.labram import LABRAM_CHANNEL_ORDER
 from braindecode.models.luna import _RotarySelfAttentionBlock
 from braindecode.models.reve import RevePositionBank
+
+_ORIGINAL_TORCH_CAT = torch.cat
+
+
+def _reject_empty_tensors(tensors, *args, **kwargs):
+    dim = kwargs.get("dim", args[0] if args else 0)
+    if any(tensor.shape[dim] == 0 for tensor in tensors):
+        raise RuntimeError("backend does not support empty tensor concatenation")
+    return _ORIGINAL_TORCH_CAT(tensors, *args, **kwargs)
 
 
 @pytest.fixture
@@ -676,14 +688,6 @@ def test_luna_base_gradient_flow(luna_base_model):
 
 def test_luna_full_rotary_attention_avoids_empty_concatenation(monkeypatch):
     """Full-head RoPE does not concatenate zero-width tensor views."""
-    original_cat = torch.cat
-
-    def _reject_empty_tensors(tensors, *args, **kwargs):
-        dim = kwargs.get("dim", args[0] if args else 0)
-        if any(tensor.shape[dim] == 0 for tensor in tensors):
-            raise RuntimeError("backend does not support empty tensor concatenation")
-        return original_cat(tensors, *args, **kwargs)
-
     monkeypatch.setattr(torch, "cat", _reject_empty_tensors)
     attention = _RotarySelfAttentionBlock(dim=32, num_heads=4)
     signal = torch.randn(2, 10, 32, requires_grad=True)
@@ -693,6 +697,32 @@ def test_luna_full_rotary_attention_avoids_empty_concatenation(monkeypatch):
 
     assert output.shape == signal.shape
     assert signal.grad is not None
+
+
+def test_luna_rotary_embedding_is_native_and_checkpoint_compatible():
+    """LUNA uses Braindecode-native RoPE without changing checkpoint keys."""
+    attention = _RotarySelfAttentionBlock(dim=32, num_heads=4)
+
+    assert type(attention.rotary_emb).__module__ == luna_module.__name__
+    assert "rotary_emb.freqs" in attention.state_dict()
+    expected = 1.0 / (10000 ** (torch.arange(0, 8, 2).float() / 8))
+    torch.testing.assert_close(attention.rotary_emb.freqs, expected)
+
+
+@pytest.mark.parametrize("axis_dim", [2, 4, 8])
+def test_zuna_builds_rotary_frequency_table_natively(axis_dim):
+    """ZUNA's native table matches rotary-embedding-torch semantics."""
+    positions = torch.arange(5, dtype=torch.float32)
+    table = zuna_module._build_rotary_frequency_table(
+        positions, axis_dim=axis_dim, theta=10000.0
+    )
+
+    embedding_dim = max(axis_dim, 4)
+    inverse_frequencies = 1.0 / (
+        10000.0 ** (torch.arange(0, embedding_dim, 2).float() / embedding_dim)
+    )
+    expected = torch.outer(positions, inverse_frequencies).repeat_interleave(2, dim=1)
+    torch.testing.assert_close(table, expected[:, :axis_dim])
 
 
 # ==============================================================================

--- a/test/unit_tests/models/test_foundation_models.py
+++ b/test/unit_tests/models/test_foundation_models.py
@@ -22,6 +22,7 @@ except ImportError:
 
 from braindecode.models import LUNA, REVE, CBraMod, CodeBrain, Labram
 from braindecode.models.labram import LABRAM_CHANNEL_ORDER
+from braindecode.models.luna import _RotarySelfAttentionBlock
 from braindecode.models.reve import RevePositionBank
 
 
@@ -671,6 +672,27 @@ def test_luna_base_gradient_flow(luna_base_model):
     assert any(p.grad is not None for p in luna_base_model.blocks[0].parameters())
     # Check gradient in final classification head
     assert luna_base_model.final_layer.decoder_ffn.fc1.weight.grad is not None
+
+
+def test_luna_full_rotary_attention_avoids_empty_concatenation(monkeypatch):
+    """Full-head RoPE does not concatenate zero-width tensor views."""
+    original_cat = torch.cat
+
+    def _reject_empty_tensors(tensors, *args, **kwargs):
+        dim = kwargs.get("dim", args[0] if args else 0)
+        if any(tensor.shape[dim] == 0 for tensor in tensors):
+            raise RuntimeError("backend does not support empty tensor concatenation")
+        return original_cat(tensors, *args, **kwargs)
+
+    monkeypatch.setattr(torch, "cat", _reject_empty_tensors)
+    attention = _RotarySelfAttentionBlock(dim=32, num_heads=4)
+    signal = torch.randn(2, 10, 32, requires_grad=True)
+
+    output = attention(signal)
+    output.sum().backward()
+
+    assert output.shape == signal.shape
+    assert signal.grad is not None
 
 
 # ==============================================================================

--- a/test/unit_tests/models/test_models.py
+++ b/test/unit_tests/models/test_models.py
@@ -74,6 +74,7 @@ from braindecode.models.eegpt import (
     _rotate_half,
 )
 from braindecode.models.labram import LABRAM_CHANNEL_ORDER
+from braindecode.models.usleep import _DecoderBlock
 from braindecode.models.util import (
     _get_possible_signal_params,
     _get_signal_params,
@@ -886,6 +887,27 @@ def test_usleep(n_chans, sfreq, n_classes, input_size_s):
     assert y_pred3.shape == (n_examples, n_classes, seq_length)
     np.testing.assert_allclose(
         y_pred1.detach().cpu().numpy(), y_pred2.detach().cpu().numpy()
+    )
+
+
+def test_usleep_decoder_crop_returns_prefix_views():
+    """Decoder alignment avoids allocating device-specific index tensors."""
+    longer = torch.arange(30).reshape(2, 3, 5)
+    shorter = torch.arange(24).reshape(2, 3, 4)
+
+    cropped_longer, cropped_shorter = _DecoderBlock._crop_tensors_to_match(
+        longer, shorter
+    )
+
+    torch.testing.assert_close(cropped_longer, longer[..., :4])
+    torch.testing.assert_close(cropped_shorter, shorter)
+    assert (
+        cropped_longer.untyped_storage().data_ptr()
+        == longer.untyped_storage().data_ptr()
+    )
+    assert (
+        cropped_shorter.untyped_storage().data_ptr()
+        == shorter.untyped_storage().data_ptr()
     )
 
 


### PR DESCRIPTION
## Summary

- replace `rotary_embedding_torch` with small native PyTorch frequency generators for LUNA and ZUNA
- avoid zero-width tensor concatenation in the LUNA full-head rotary path while preserving checkpoint keys and numerical behavior
- use narrow views for USleep decoder alignment instead of allocating index tensors
- document the dependency removal and portability fixes in `docs/whats_new.rst`

## LUNA root cause

LUNA applies RoPE to the complete attention head width. The external rotary helper consequently concatenates an empty left view, the transformed full-width tensor, and an empty right view. This valid no-op concatenation fails on Intel Gaudi with SynapseAI 1.21.4 as `synStatus 30` Sections validation failure. Because HPU execution is asynchronous, the exception was reported at the subsequent DropPath Bernoulli call.

A controlled Gaudi probe established that standalone Bernoulli passes in BF16 and FP32, while the zero-width concatenation fails in both. Returning the transformed tensor directly passes forward and backward.

## Dependency removal

LUNA now uses a minimal native PyTorch module that retains the existing `rotary_emb.freqs` state-dict key. ZUNA builds its fixed multi-axis rotary table directly with PyTorch. Both implementations match the removed dependency frequency semantics, including the special two-dimensional ZUNA axis case.

## Validation

- 23 LUNA tests passed; 5 network-dependent tests skipped
- 9 LUNA, ZUNA, and USleep config / Hugging Face round-trip tests passed; 1 skipped
- 30 non-compile integration and export checks passed; 5 skipped
- 3 model registration checks passed
- dependency-blocked fresh import succeeded for LUNA and ZUNA
- native frequency tables exactly matched the removed dependency for dimensions 2, 4, 8, and 16
- LUNA rotary outputs and input gradients exactly matched in FP32 and FP64
- critical Ruff checks and `git diff --check` passed

The combined local `torch.compile` check stalled in the existing slow compile path after the preceding integration tests passed and was stopped after nearly four minutes; no compile failure was emitted.