### PR TITLE
Fix DropPath sampling on Gaudi lazy mode

### DIFF
--- a/braindecode/functional/functions.py
+++ b/braindecode/functional/functions.py
@@ -40,7 +40,7 @@ def drop_path(
     x : torch.Tensor
         input tensor
     drop_prob : float, optional
-        survival rate (i.e. probability of being kept), by default 0.0
+        probability of dropping a path, by default 0.0
     training : bool, optional
         whether the model is in training mode, by default False
     scale_by_keep : bool, optional
@@ -68,9 +68,10 @@ def drop_path(
     shape = (x.shape[0],) + (1,) * (
         x.ndim - 1
     )  # work with diff dim tensors, not just 2D ConvNets
-    random_tensor = x.new_empty(shape).bernoulli_(keep_prob)
+    probabilities = torch.full(shape, keep_prob, dtype=torch.float32, device=x.device)
+    random_tensor = torch.bernoulli(probabilities).to(dtype=x.dtype)
     if keep_prob > 0.0 and scale_by_keep:
-        random_tensor.div_(keep_prob)
+        random_tensor = random_tensor / keep_prob
     return x * random_tensor
 
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -81,6 +81,14 @@ Requirements
 Bug fixes
 ==========
 
+- Sample stochastic-depth masks with out-of-place
+  :func:`torch.bernoulli` instead of in-place ``Tensor.bernoulli_``. This keeps
+  the same per-sample Bernoulli mask and scaling while avoiding lazy
+  recipe-cache offset failures on Gaudi accelerators. The
+  :func:`braindecode.functional.drop_path` documentation now also correctly
+  describes ``drop_prob`` as the probability of dropping a path. By `Bruno
+  Aristimunha`_.
+
 - Make :class:`braindecode.models.LUNA` rotary attention portable to
   accelerators that reject concatenations containing empty tensor views, while
   preserving its pretrained-checkpoint parameter keys and numerical behavior.

--- a/test/unit_tests/models/test_modules.py
+++ b/test/unit_tests/models/test_modules.py
@@ -2,6 +2,7 @@
 #          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
+from unittest.mock import patch
 from warnings import catch_warnings, simplefilter
 
 import numpy as np
@@ -359,19 +360,56 @@ def test_drop_path_with_dropout_shape():
     )
 
 
+def test_drop_path_does_not_require_inplace_bernoulli():
+    x = torch.ones(64, 3)
+
+    with patch.object(
+        torch.Tensor,
+        "bernoulli_",
+        side_effect=AssertionError("drop_path must not use in-place Bernoulli"),
+    ):
+        output = drop_path(x, drop_prob=0.5, training=True)
+
+    assert output.shape == x.shape
+    assert set(output.unique().tolist()).issubset({0.0, 2.0})
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64, torch.bfloat16])
+def test_drop_path_preserves_tensor_contract_and_seed(dtype):
+    x = torch.ones(64, 3, 4, dtype=dtype)
+
+    torch.manual_seed(42)
+    first = drop_path(x, drop_prob=0.5, training=True)
+    torch.manual_seed(42)
+    second = drop_path(x, drop_prob=0.5, training=True)
+
+    assert torch.equal(first, second)
+    assert first.shape == x.shape
+    assert first.dtype == x.dtype
+    assert first.device == x.device
+    assert torch.equal(first, first[:, :1, :1].expand_as(first))
+    assert set(first.unique().tolist()).issubset({0.0, 2.0})
+
+
+@pytest.mark.parametrize("drop_prob", [-0.1, 1.1, float("nan")])
+def test_drop_path_rejects_invalid_probability(drop_prob):
+    with pytest.raises(RuntimeError):
+        drop_path(torch.ones(2, 3), drop_prob=drop_prob, training=True)
+
+
 def test_drop_path_scale_by_keep():
-    torch.manual_seed(0)
-    x = torch.rand(1, 10)  # Single-dimension tensor for simplicity
+    x = torch.ones(64, 10)
     drop_prob = 0.2
+
+    torch.manual_seed(0)
     scaled_output = drop_path(x, drop_prob=drop_prob, training=True, scale_by_keep=True)
+    torch.manual_seed(0)
     unscaled_output = drop_path(
         x, drop_prob=drop_prob, training=True, scale_by_keep=False
     )
-    # This test relies on statistical expectation and may need multiple runs or adjustments
-    scale_factor = 1 / (1 - drop_prob)
-    assert torch.allclose(
-        scaled_output.mean(), unscaled_output.mean() * scale_factor, atol=0.1
-    ), "Scaled output does not match expected scaling."
+
+    keep_prob = 1 - drop_prob
+    assert torch.equal(scaled_output, unscaled_output / keep_prob)
 
 
 def test_drop_path_different_dimensions():
@@ -610,9 +648,7 @@ def test_filter_bank_layer_matches_mne_iir(l_freq, h_freq, phase, ftype):
             axis=-1,
         )
     else:
-        filtered_scipy = _filfilt_in_torch_sytle(
-            b=filts["b"], a=filts["a"], x_np=x_np
-        )
+        filtered_scipy = _filfilt_in_torch_sytle(b=filts["b"], a=filts["a"], x_np=x_np)
     # Compare the outputs
     np.testing.assert_array_almost_equal(
         filtered_signal_torch.numpy().flatten(),


### PR DESCRIPTION
## Summary

- sample DropPath masks with the out-of-place tensor-probability `torch.bernoulli` path
- preserve per-sample broadcasting, dtype, scaling, seeded determinism, and invalid-probability validation
- fix the `drop_prob` docstring and document the accelerator portability change

## Why

Gaudi 1.21 lazy recipe reuse can reject the in-place scalar `Tensor.bernoulli_` path with a tensor storage-offset mismatch. The bridge has a distinct, tested out-of-place tensor-probability Bernoulli path.

## Validation

- 14 focused DropPath tests
- 71 model/integration tests across DropPath, LUNA, EEGDINO, and TCFormer (9 skipped)
- Voyager Gaudi 1.21.4: 100 synchronized Bernoulli iterations and 5 BF16 LUNA forward/backward/AdamW steps in lazy mode; finite losses and gradients; exit 0