### PR TITLE
Activation hooks

### DIFF
--- a/braindecode/visualization/__init__.py
+++ b/braindecode/visualization/__init__.py
@@ -2,6 +2,10 @@
 Functions for visualisations, especially of the ConvNets.
 """
 
+from .activations import (
+    capture_activations,
+    run_with_activation_substitution,
+)
 from .attribution import (
     deconvolution,
     deep_lift,
@@ -28,6 +32,7 @@ __all__ = [
     "SSIM_METRIC_NAMES",
     "amplitude_gradients",
     "amplitude_gradients_per_trial",
+    "capture_activations",
     "cascading_layer_reset",
     "compute_metrics",
     "compute_ssim_metrics",
@@ -41,5 +46,6 @@ __all__ = [
     "plot_confusion_matrix",
     "project_to_topomap",
     "random_target",
+    "run_with_activation_substitution",
     "saliency",
 ]

--- a/braindecode/visualization/activations.py
+++ b/braindecode/visualization/activations.py
@@ -1,0 +1,172 @@
+# Authors: Vandit Shah <shahvanditt@gmail.com>
+#
+# License: BSD (3-clause)
+
+"""Read and replace the intermediate activations of a trained model.
+
+Two primitives built on :meth:`torch.nn.Module.register_forward_hook`:
+:func:`capture_activations` records what a submodule emitted during a
+forward pass, and :func:`run_with_activation_substitution` replaces that
+output so the rest of the model runs on the substitute. Hooks are removed
+in a ``finally`` block, so a raising forward pass cannot leave them
+attached.
+
+Notes
+-----
+The hook lifecycle follows the ``register_forward_hook`` contract in the
+PyTorch documentation: a capture hook returns ``None`` and keeps the
+module's own output, while a hook that returns a value replaces it. These
+functions are written against that public API and are not derived from any
+third-party implementation.
+"""
+
+from collections.abc import Mapping
+from copy import deepcopy
+
+import torch
+from torch import nn
+
+
+def _detach_output(output):
+    """Detach every tensor in a possibly nested module output.
+
+    Blocks commonly return a tuple or dict rather than a bare tensor, so
+    the structure is walked rather than assumed.
+    """
+    if torch.is_tensor(output):
+        return output.detach()
+    if isinstance(output, tuple):
+        return tuple(_detach_output(item) for item in output)
+    if isinstance(output, list):
+        return [_detach_output(item) for item in output]
+    if isinstance(output, dict):
+        return {key: _detach_output(value) for key, value in output.items()}
+    return deepcopy(output)
+
+
+def _as_module_items(layers):
+    """Return ``(key, module)`` pairs from either a mapping or a sequence."""
+    if isinstance(layers, Mapping):
+        return list(layers.items())
+    return list(enumerate(layers))
+
+
+def capture_activations(model, x, layers, forward_fn=None, detach=True):
+    """Capture the outputs of one or more modules during a forward pass.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        The model to run.
+    x : torch.Tensor
+        Input passed to ``forward_fn``.
+    layers : torch.nn.Module or list of torch.nn.Module or dict
+        Modules whose outputs to capture. A single module is keyed ``0``, a
+        sequence is keyed by position, and a mapping keeps its own keys.
+    forward_fn : callable or None, default=None
+        Callable invoked as ``forward_fn(x)``. Defaults to ``model``. Use
+        this to reach a submodule's forward, for instance a backbone's
+        feature extractor rather than the full classifier.
+    detach : bool, default=True
+        Detach captured tensors from the autograd graph. Set to ``False``
+        only when gradients through the captured activations are needed.
+
+    Returns
+    -------
+    dict
+        One entry per requested module, keyed as described above. A module
+        returning a tuple or dict is stored with that structure intact.
+
+    See Also
+    --------
+    run_with_activation_substitution : Replace a layer's output instead.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from torch import nn
+    >>> from braindecode.visualization import capture_activations
+    >>> model = nn.Sequential(nn.Linear(4, 6), nn.ReLU(), nn.Linear(6, 2))
+    >>> captured = capture_activations(model, torch.randn(3, 4), [model[0]])
+    >>> captured[0].shape
+    torch.Size([3, 6])
+    """
+    forward_fn = model if forward_fn is None else forward_fn
+    if isinstance(layers, nn.Module):
+        items = [(0, layers)]
+    else:
+        items = _as_module_items(layers)
+    captured = {}
+    handles = []
+
+    def make_hook(key):
+        """Build a forward hook that stores its module's output under ``key``."""
+
+        def hook(_module, _inputs, output):
+            """Store this module's output, detaching it when asked."""
+            captured[key] = _detach_output(output) if detach else output
+
+        return hook
+
+    for key, module in items:
+        handles.append(module.register_forward_hook(make_hook(key)))
+
+    try:
+        forward_fn(x)
+    finally:
+        for handle in handles:
+            handle.remove()
+
+    return captured
+
+
+def run_with_activation_substitution(model, x, layer, substitute_fn, forward_fn=None):
+    """Run ``model`` with the output of ``layer`` replaced.
+
+    Comparing a metric before and after the substitution measures how much
+    the rest of the model depends on what was replaced.
+
+    Parameters
+    ----------
+    model : torch.nn.Module
+        The model to run.
+    x : torch.Tensor
+        Input passed to ``forward_fn``.
+    layer : torch.nn.Module
+        Module whose output is replaced.
+    substitute_fn : callable
+        Called with the layer's output; its return value is used instead.
+        It receives whatever the module emitted, so a module returning a
+        tuple must be handled as a tuple and returned as one.
+    forward_fn : callable or None, default=None
+        Callable invoked as ``forward_fn(x)``. Defaults to ``model``.
+
+    Returns
+    -------
+    Any
+        Whatever ``forward_fn`` returns, computed with the substitution in
+        place.
+
+    See Also
+    --------
+    capture_activations : Record a layer's output instead of replacing it.
+
+    Examples
+    --------
+    Zeroing a block measures how much the head relies on it:
+
+    >>> out = run_with_activation_substitution(
+    ...     model, torch.randn(3, 4), model[0], torch.zeros_like
+    ... )  # doctest: +SKIP
+    """
+    forward_fn = model if forward_fn is None else forward_fn
+
+    def hook(_module, _inputs, output):
+        """Return the substituted output in place of the module's own."""
+        return substitute_fn(output)
+
+    handle = layer.register_forward_hook(hook)
+    try:
+        return forward_fn(x)
+    finally:
+        handle.remove()

--- a/braindecode/visualization/activations.py
+++ b/braindecode/visualization/activations.py
@@ -77,9 +77,21 @@ def capture_activations(model, x, layers, forward_fn=None, detach=True):
         One entry per requested module, keyed as described above. A module
         returning a tuple or dict is stored with that structure intact.
 
+    Raises
+    ------
+    RuntimeError
+        If a requested module was never called during the forward pass.
+        Returning a short dictionary instead would push the failure to
+        whichever line first indexes the missing key, long after the cause.
+
     See Also
     --------
     run_with_activation_substitution : Replace a layer's output instead.
+
+    Notes
+    -----
+    A module called more than once in a single forward pass, as with weight
+    sharing or a loop over a shared block, keeps only its last output.
 
     Examples
     --------
@@ -117,6 +129,14 @@ def capture_activations(model, x, layers, forward_fn=None, detach=True):
         for handle in handles:
             handle.remove()
 
+    missing = [key for key, _ in items if key not in captured]
+    if missing:
+        raise RuntimeError(
+            f"these modules were never called during the forward pass: {missing}. "
+            "Check that they belong to the model reached by forward_fn and that "
+            "the input takes the branch containing them."
+        )
+
     return captured
 
 
@@ -147,6 +167,15 @@ def run_with_activation_substitution(model, x, layer, substitute_fn, forward_fn=
         Whatever ``forward_fn`` returns, computed with the substitution in
         place.
 
+    Raises
+    ------
+    TypeError
+        If ``substitute_fn`` returns ``None``. A forward hook returning
+        ``None`` leaves the module's own output in place, so a
+        ``substitute_fn`` missing its ``return`` would otherwise run to
+        completion and report an unchanged metric as though the
+        substitution had happened.
+
     See Also
     --------
     capture_activations : Record a layer's output instead of replacing it.
@@ -163,7 +192,13 @@ def run_with_activation_substitution(model, x, layer, substitute_fn, forward_fn=
 
     def hook(_module, _inputs, output):
         """Return the substituted output in place of the module's own."""
-        return substitute_fn(output)
+        replacement = substitute_fn(output)
+        if replacement is None:
+            raise TypeError(
+                "substitute_fn returned None, which torch reads as "
+                "'keep the original output'. Return the replacement instead."
+            )
+        return replacement
 
     handle = layer.register_forward_hook(hook)
     try:

--- a/braindecode/visualization/activations.py
+++ b/braindecode/visualization/activations.py
@@ -2,206 +2,76 @@
 #
 # License: BSD (3-clause)
 
-"""Read and replace the intermediate activations of a trained model.
+"""Read and replace intermediate module outputs with temporary hooks."""
 
-Two primitives built on :meth:`torch.nn.Module.register_forward_hook`:
-:func:`capture_activations` records what a submodule emitted during a
-forward pass, and :func:`run_with_activation_substitution` replaces that
-output so the rest of the model runs on the substitute. Hooks are removed
-in a ``finally`` block, so a raising forward pass cannot leave them
-attached.
-
-Notes
------
-The hook lifecycle follows the ``register_forward_hook`` contract in the
-PyTorch documentation: a capture hook returns ``None`` and keeps the
-module's own output, while a hook that returns a value replaces it. These
-functions are written against that public API and are not derived from any
-third-party implementation.
-"""
-
-from collections.abc import Mapping
-from copy import deepcopy
-
-import torch
 from torch import nn
 
 
-def _detach_output(output):
-    """Detach every tensor in a possibly nested module output.
+def capture_activations(model: nn.Module, x, layer: nn.Module):
+    """Return the output emitted by ``layer`` during ``model(x)``.
 
-    Blocks commonly return a tuple or dict rather than a bare tensor, so
-    the structure is walked rather than assumed.
-    """
-    if torch.is_tensor(output):
-        return output.detach()
-    if isinstance(output, tuple):
-        return tuple(_detach_output(item) for item in output)
-    if isinstance(output, list):
-        return [_detach_output(item) for item in output]
-    if isinstance(output, dict):
-        return {key: _detach_output(value) for key, value in output.items()}
-    return deepcopy(output)
-
-
-def _as_module_items(layers):
-    """Return ``(key, module)`` pairs from either a mapping or a sequence."""
-    if isinstance(layers, Mapping):
-        return list(layers.items())
-    return list(enumerate(layers))
-
-
-def capture_activations(model, x, layers, forward_fn=None, detach=True):
-    """Capture the outputs of one or more modules during a forward pass.
+    Nested outputs are returned unchanged. If a layer runs more than once,
+    only its last output is kept.
 
     Parameters
     ----------
     model : torch.nn.Module
-        The model to run.
+        Model to run.
     x : torch.Tensor
-        Input passed to ``forward_fn``.
-    layers : torch.nn.Module or list of torch.nn.Module or dict
-        Modules whose outputs to capture. A single module is keyed ``0``, a
-        sequence is keyed by position, and a mapping keeps its own keys.
-    forward_fn : callable or None, default=None
-        Callable invoked as ``forward_fn(x)``. Defaults to ``model``. Use
-        this to reach a submodule's forward, for instance a backbone's
-        feature extractor rather than the full classifier.
-    detach : bool, default=True
-        Detach captured tensors from the autograd graph. Set to ``False``
-        only when gradients through the captured activations are needed.
-
-    Returns
-    -------
-    dict
-        One entry per requested module, keyed as described above. A module
-        returning a tuple or dict is stored with that structure intact.
+        Model input.
+    layer : torch.nn.Module
+        Submodule whose output is captured.
 
     Raises
     ------
     RuntimeError
-        If a requested module was never called during the forward pass.
-        Returning a short dictionary instead would push the failure to
-        whichever line first indexes the missing key, long after the cause.
-
-    See Also
-    --------
-    run_with_activation_substitution : Replace a layer's output instead.
-
-    Notes
-    -----
-    A module called more than once in a single forward pass, as with weight
-    sharing or a loop over a shared block, keeps only its last output.
-
-    Examples
-    --------
-    >>> import torch
-    >>> from torch import nn
-    >>> from braindecode.visualization import capture_activations
-    >>> model = nn.Sequential(nn.Linear(4, 6), nn.ReLU(), nn.Linear(6, 2))
-    >>> captured = capture_activations(model, torch.randn(3, 4), [model[0]])
-    >>> captured[0].shape
-    torch.Size([3, 6])
+        If ``layer`` is not called by the forward pass.
     """
-    forward_fn = model if forward_fn is None else forward_fn
-    if isinstance(layers, nn.Module):
-        items = [(0, layers)]
-    else:
-        items = _as_module_items(layers)
-    captured = {}
-    handles = []
+    captured: list[object] = []
 
-    def make_hook(key):
-        """Build a forward hook that stores its module's output under ``key``."""
+    def hook(_module, _inputs, output):
+        captured[:] = [output]
 
-        def hook(_module, _inputs, output):
-            """Store this module's output, detaching it when asked."""
-            captured[key] = _detach_output(output) if detach else output
-
-        return hook
-
-    for key, module in items:
-        handles.append(module.register_forward_hook(make_hook(key)))
-
-    try:
-        forward_fn(x)
-    finally:
-        for handle in handles:
-            handle.remove()
-
-    missing = [key for key, _ in items if key not in captured]
-    if missing:
-        raise RuntimeError(
-            f"these modules were never called during the forward pass: {missing}. "
-            "Check that they belong to the model reached by forward_fn and that "
-            "the input takes the branch containing them."
-        )
-
-    return captured
+    with layer.register_forward_hook(hook):
+        model(x)
+    if not captured:
+        raise RuntimeError("layer was not called during the forward pass")
+    return captured[0]
 
 
-def run_with_activation_substitution(model, x, layer, substitute_fn, forward_fn=None):
-    """Run ``model`` with the output of ``layer`` replaced.
-
-    Comparing a metric before and after the substitution measures how much
-    the rest of the model depends on what was replaced.
+def run_with_activation_substitution(
+    model: nn.Module, x, layer: nn.Module, substitute_fn
+):
+    """Run ``model(x)`` after replacing ``layer``'s output.
 
     Parameters
     ----------
     model : torch.nn.Module
-        The model to run.
+        Model to run.
     x : torch.Tensor
-        Input passed to ``forward_fn``.
+        Model input.
     layer : torch.nn.Module
-        Module whose output is replaced.
+        Submodule whose output is replaced.
     substitute_fn : callable
-        Called with the layer's output; its return value is used instead.
-        It receives whatever the module emitted, so a module returning a
-        tuple must be handled as a tuple and returned as one.
-    forward_fn : callable or None, default=None
-        Callable invoked as ``forward_fn(x)``. Defaults to ``model``.
+        Called with the layer output and must return its replacement.
 
     Returns
     -------
     Any
-        Whatever ``forward_fn`` returns, computed with the substitution in
-        place.
+        The model output after substitution.
 
     Raises
     ------
     TypeError
-        If ``substitute_fn`` returns ``None``. A forward hook returning
-        ``None`` leaves the module's own output in place, so a
-        ``substitute_fn`` missing its ``return`` would otherwise run to
-        completion and report an unchanged metric as though the
-        substitution had happened.
-
-    See Also
-    --------
-    capture_activations : Record a layer's output instead of replacing it.
-
-    Examples
-    --------
-    Zeroing a block measures how much the head relies on it:
-
-    >>> out = run_with_activation_substitution(
-    ...     model, torch.randn(3, 4), model[0], torch.zeros_like
-    ... )  # doctest: +SKIP
+        If ``substitute_fn`` returns ``None``, which PyTorch interprets as
+        keeping the original output.
     """
-    forward_fn = model if forward_fn is None else forward_fn
 
     def hook(_module, _inputs, output):
-        """Return the substituted output in place of the module's own."""
         replacement = substitute_fn(output)
         if replacement is None:
-            raise TypeError(
-                "substitute_fn returned None, which torch reads as "
-                "'keep the original output'. Return the replacement instead."
-            )
+            raise TypeError("substitute_fn must return a replacement")
         return replacement
 
-    handle = layer.register_forward_hook(hook)
-    try:
-        return forward_fn(x)
-    finally:
-        handle.remove()
+    with layer.register_forward_hook(hook):
+        return model(x)

--- a/braindecode/visualization/attribution.py
+++ b/braindecode/visualization/attribution.py
@@ -1,4 +1,4 @@
-# Authors: Vandit Shah <shahvanditt@gmail.com>
+# Authors: Vandit Shah <shahvandit@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/braindecode/visualization/attribution.py
+++ b/braindecode/visualization/attribution.py
@@ -1,4 +1,4 @@
-# Authors: Vandit Shah <shahvandit@gmail.com>
+# Authors: Vandit Shah <shahvanditt@gmail.com>
 #
 # License: BSD (3-clause)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -904,12 +904,8 @@ reimplementation of skimage's structural similarity (no extra dependency). Pass
 Activations
 ===========
 
-Read or replace what a submodule emits during a forward pass, via
-:meth:`torch.nn.Module.register_forward_hook`. :func:`capture_activations` records the
-output of one or more named modules; :func:`run_with_activation_substitution` swaps a
-module's output for something else so everything downstream runs on the substitute,
-which is how a layer is ablated or a stand-in representation is tested. Hooks are
-removed in a ``finally`` block, so a raising forward pass cannot leave them attached.
+Read or replace a submodule's output during a forward pass. The temporary hooks are
+removed even when the forward pass raises.
 
 .. autosummary::
     :toctree: generated/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -901,6 +901,22 @@ reimplementation of skimage's structural similarity (no extra dependency). Pass
      METRIC_NAMES
      SSIM_METRIC_NAMES
 
+Activations
+===========
+
+Read or replace what a submodule emits during a forward pass, via
+:meth:`torch.nn.Module.register_forward_hook`. :func:`capture_activations` records the
+output of one or more named modules; :func:`run_with_activation_substitution` swaps a
+module's output for something else so everything downstream runs on the substitute,
+which is how a layer is ablated or a stand-in representation is tested. Hooks are
+removed in a ``finally`` block, so a raising forward pass cannot leave them attached.
+
+.. autosummary::
+    :toctree: generated/
+
+     capture_activations
+     run_with_activation_substitution
+
 Topography
 ==========
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -35,10 +35,9 @@ Enhancements
   (:gh:`1133` by `Bruno Aristimunha`_)
 
 - Add :func:`braindecode.visualization.capture_activations` and
-  :func:`braindecode.visualization.run_with_activation_substitution`, forward-hook
-  primitives for recording a submodule's output during a forward pass and for
-  replacing it so the rest of the model runs on the substitute
-  (:gh:`1131` by `Vandit Shah`_)
+  :func:`braindecode.visualization.run_with_activation_substitution` to read or
+  replace a submodule's output during a forward pass
+  (:gh:`1138` by `Vandit Shah`_)
 
 - Preserve the recording-local row of each canonical MNE annotation as
   ``i_trial_in_dataset`` in event-window metadata, keeping it aligned with

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -34,6 +34,12 @@ Enhancements
   synchronized hand-pose panel when a ``*_desc-pose.json`` sidecar is present
   (:gh:`1133` by `Bruno Aristimunha`_)
 
+- Add :func:`braindecode.visualization.capture_activations` and
+  :func:`braindecode.visualization.run_with_activation_substitution`, forward-hook
+  primitives for recording a submodule's output during a forward pass and for
+  replacing it so the rest of the model runs on the substitute
+  (:gh:`1131` by `Vandit Shah`_)
+
 - Preserve the recording-local row of each canonical MNE annotation as
   ``i_trial_in_dataset`` in event-window metadata, keeping it aligned with
   targets and annotation extras through event mapping, duration filtering,

--- a/test/unit_tests/visualization/test_activations.py
+++ b/test/unit_tests/visualization/test_activations.py
@@ -2,140 +2,156 @@ import pytest
 import torch
 from torch import nn
 
+from braindecode.models import ShallowFBCSPNet
 from braindecode.visualization import (
     capture_activations,
     run_with_activation_substitution,
 )
 
+from .conftest import SEED
 
-class ToyNet(nn.Module):
-    def __init__(self):
+N_CHANS = 18
+N_TIMES = 600
+N_OUTPUTS = 2
+BATCH = 4
+
+
+@pytest.fixture(scope="module")
+def model():
+    m = ShallowFBCSPNet(
+        n_chans=N_CHANS,
+        n_outputs=N_OUTPUTS,
+        n_times=N_TIMES,
+        final_conv_length="auto",
+    )
+    m.eval()
+    return m
+
+
+@pytest.fixture(scope="module")
+def X():
+    torch.manual_seed(SEED)
+    return torch.randn(BATCH, N_CHANS, N_TIMES)
+
+
+class _ToyNet(nn.Module):
+    """Small enough that the substituted output can be derived by hand."""
+
+    def __init__(self, block=None):
         super().__init__()
-        self.block = nn.Linear(4, 6)
+        torch.manual_seed(SEED)
+        self.block = nn.Linear(4, 6) if block is None else block
         self.head = nn.Linear(6, 2)
 
     def forward(self, x):
-        x = self.block(x)
-        return self.head(x)
+        out = self.block(x)
+        hidden = out if torch.is_tensor(out) else _hidden_of(out)
+        return self.head(hidden)
 
 
-class ExplodingNet(nn.Module):
+class _MultiOutBlock(nn.Module):
+    """A block returning a container, as transformer blocks commonly do."""
+
+    def __init__(self, kind):
+        super().__init__()
+        self.linear = nn.Linear(4, 6)
+        self.kind = kind
+
+    def forward(self, x):
+        hidden = self.linear(x)
+        aux = hidden.mean(dim=-1)
+        if self.kind == "tuple":
+            return hidden, aux
+        return {"hidden": hidden, "aux": aux}
+
+
+def _hidden_of(out):
+    return out[0] if isinstance(out, tuple) else out["hidden"]
+
+
+class _ExplodingNet(nn.Module):
     def __init__(self):
         super().__init__()
         self.block = nn.Linear(4, 4)
 
     def forward(self, x):
-        x = self.block(x)
+        self.block(x)
         raise RuntimeError("boom")
 
 
-class TupleBlock(nn.Module):
-    """A block returning ``(hidden, aux)``, as transformer blocks often do."""
+@pytest.mark.parametrize("as_layers", [lambda b: b, lambda b: [b], lambda b: {"b": b}])
+def test_captured_activation_substitutes_back_unchanged(model, X, as_layers):
+    """Round-trip on a real model.
 
-    def __init__(self):
-        super().__init__()
-        self.linear = nn.Linear(4, 6)
+    Feeding a captured activation straight back in must be a no-op. This
+    fails if capture returns anything other than the genuine layer output,
+    and it fails if the substitution hook does not actually reach the rest
+    of the network -- so it pins both functions against one another without
+    needing to know the model's internals.
+    """
+    layer = model.conv_nonlin_exp
+    captured = capture_activations(model, X, as_layers(layer))
+    (activation,) = captured.values()
 
-    def forward(self, x):
-        hidden = self.linear(x)
-        return hidden, hidden.mean(dim=-1)
-
-
-class TupleNet(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.block = TupleBlock()
-        self.head = nn.Linear(6, 2)
-
-    def forward(self, x):
-        hidden, _aux = self.block(x)
-        return self.head(hidden)
-
-
-def test_capture_activations_returns_one_entry_and_cleans_hooks():
-    model = ToyNet().eval()
-    captured = capture_activations(model, torch.randn(3, 4), {"block": model.block})
-    assert set(captured) == {"block"}
-    assert captured["block"].shape == (3, 6)
-    assert len(model.block._forward_hooks) == 0
-
-
-def test_capture_activations_keys_by_position_for_a_sequence():
-    model = ToyNet().eval()
-    captured = capture_activations(model, torch.randn(3, 4), [model.block, model.head])
-    assert set(captured) == {0, 1}
-    assert captured[1].shape == (3, 2)
-
-
-def test_capture_activations_cleans_up_on_exception():
-    model = ExplodingNet().eval()
-    with pytest.raises(RuntimeError, match="boom"):
-        capture_activations(model, torch.randn(2, 4), [model.block])
-    assert len(model.block._forward_hooks) == 0
-
-
-def test_capture_activations_preserves_nested_output_structure():
-    model = TupleNet().eval()
-    captured = capture_activations(model, torch.randn(3, 4), {"block": model.block})
-    hidden, aux = captured["block"]
-    assert isinstance(captured["block"], tuple)
-    assert hidden.shape == (3, 6)
-    assert aux.shape == (3,)
-    assert not hidden.requires_grad  # detach walks into the tuple
-
-
-def test_capture_activations_can_keep_the_graph():
-    model = ToyNet().eval()
-    captured = capture_activations(
-        model, torch.randn(3, 4), [model.block], detach=False
-    )
-    assert captured[0].requires_grad
-
-
-def test_activation_substitution_identity_and_change():
-    model = ToyNet().eval()
-    x = torch.randn(4, 4)
-
-    baseline = model(x)
-    identity = run_with_activation_substitution(model, x, model.block, lambda out: out)
-    torch.testing.assert_close(identity, baseline)
-    assert len(model.block._forward_hooks) == 0
-
-    shifted = run_with_activation_substitution(
-        model, x, model.block, lambda out: out + 1.0
-    )
-    assert not torch.allclose(shifted, baseline)
-    assert len(model.block._forward_hooks) == 0
-
-
-def test_activation_substitution_on_a_tuple_returning_block():
-    model = TupleNet().eval()
-    x = torch.randn(4, 4)
-
-    baseline = model(x)
-    zeroed = run_with_activation_substitution(
-        model, x, model.block, lambda out: (torch.zeros_like(out[0]), out[1])
-    )
-    assert zeroed.shape == baseline.shape
-    assert not torch.allclose(zeroed, baseline)
-    # With the hidden state zeroed the head sees only its own bias.
-    torch.testing.assert_close(zeroed, model.head.bias.expand_as(zeroed))
-    assert len(model.block._forward_hooks) == 0
-
-
-def test_activation_substitution_cleans_up_on_exception():
-    model = ExplodingNet().eval()
-    with pytest.raises(RuntimeError, match="boom"):
-        run_with_activation_substitution(
-            model, torch.randn(2, 4), model.block, lambda out: out
+    with torch.no_grad():
+        baseline = model(X)
+        restored = run_with_activation_substitution(
+            model, X, layer, lambda _out: activation
         )
-    assert len(model.block._forward_hooks) == 0
+    torch.testing.assert_close(restored, baseline)
 
 
-def test_forward_fn_reaches_a_submodule():
-    model = ToyNet().eval()
-    x = torch.randn(3, 4)
+def test_substituted_output_matches_hand_computation():
+    """Zeroing a block leaves the head with nothing but its own bias."""
+    model = _ToyNet().eval()
+    with torch.no_grad():
+        out = run_with_activation_substitution(
+            model, torch.randn(BATCH, 4), model.block, torch.zeros_like
+        )
+    torch.testing.assert_close(out, model.head.bias.expand_as(out))
+
+
+@pytest.mark.parametrize("kind", ["tuple", "dict"])
+def test_capture_preserves_nested_output_structure(kind):
+    block = _MultiOutBlock(kind)
+    model = _ToyNet(block=block).eval()
+    x = torch.randn(BATCH, 4)
+
+    captured = capture_activations(model, x, {"block": model.block})["block"]
+
+    torch.testing.assert_close(_hidden_of(captured), block.linear(x))
+    assert not _hidden_of(captured).requires_grad  # detach walks the container
+
+
+def test_capture_without_detach_keeps_the_graph():
+    model = _ToyNet().eval()
     captured = capture_activations(
-        model, x, [model.block], forward_fn=lambda inp: model.block(inp)
+        model, torch.randn(BATCH, 4), [model.block], detach=False
     )
-    torch.testing.assert_close(captured[0], model.block(x))
+    captured[0].sum().backward()
+    assert model.block.weight.grad is not None
+
+
+@pytest.mark.parametrize(
+    "run",
+    [
+        lambda m, x: capture_activations(m, x, [m.block]),
+        lambda m, x: run_with_activation_substitution(m, x, m.block, lambda o: o),
+    ],
+)
+def test_hooks_are_removed_when_the_forward_raises(run):
+    model = _ExplodingNet().eval()
+    with pytest.raises(RuntimeError, match="boom"):
+        run(model, torch.randn(2, 4))
+    assert not model.block._forward_hooks
+
+
+def test_hooks_are_removed_when_the_substitute_raises():
+    model = _ToyNet().eval()
+
+    def boom(_out):
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run_with_activation_substitution(model, torch.randn(2, 4), model.block, boom)
+    assert not model.block._forward_hooks

--- a/test/unit_tests/visualization/test_activations.py
+++ b/test/unit_tests/visualization/test_activations.py
@@ -2,200 +2,75 @@ import pytest
 import torch
 from torch import nn
 
-from braindecode.models import EEGConformer, ShallowFBCSPNet
 from braindecode.visualization import (
     capture_activations,
     run_with_activation_substitution,
 )
 
-from .conftest import SEED
 
-N_CHANS = 18
-N_TIMES = 600
-N_OUTPUTS = 2
-BATCH = 4
+class _Block(nn.Module):
+    def forward(self, x):
+        return x * 2, {"mean": x.mean()}
 
 
-def _shallow():
-    """A convolutional stack, hooked at a top-level child."""
-    m = ShallowFBCSPNet(
-        n_chans=N_CHANS,
-        n_outputs=N_OUTPUTS,
-        n_times=N_TIMES,
-        final_conv_length="auto",
+class _Model(nn.Module):
+    def __init__(self, explode=False):
+        super().__init__()
+        self.block = _Block()
+        self.explode = explode
+
+    def forward(self, x):
+        hidden, _ = self.block(x)
+        if self.explode:
+            raise RuntimeError("boom")
+        return hidden + 1
+
+
+def test_capture_and_substitute_nested_output():
+    model = _Model()
+    x = torch.randn(2, 3)
+    captured = capture_activations(model, x, model.block)
+
+    torch.testing.assert_close(captured[0], x * 2)
+    assert isinstance(captured[1], dict)
+    baseline = model(x)
+    restored = run_with_activation_substitution(
+        model, x, model.block, lambda _output: captured
     )
-    return m.eval(), "conv_nonlin_exp"
-
-
-def _conformer():
-    """A transformer, hooked at a residual block three levels down.
-
-    The harder of the two: the hooked module is not a direct child, and a
-    second residual block plus the head still run downstream of it, so a
-    substitution that fails to propagate has more places to show up.
-    """
-    m = EEGConformer(n_chans=N_CHANS, n_outputs=N_OUTPUTS, n_times=N_TIMES)
-    return m.eval(), "transformer.0.0"
-
-
-@pytest.fixture(scope="module", params=[_shallow, _conformer], ids=["cnn", "residual"])
-def model_and_layer(request):
-    model, name = request.param()
-    return model, dict(model.named_modules())[name]
-
-
-def _randn(*shape, seed=SEED):
-    """Seeded input drawn from a local generator.
-
-    A bare ``torch.manual_seed`` would reseed the process-global RNG and
-    silently change the draws of every test that runs afterwards.
-    """
-    return torch.randn(*shape, generator=torch.Generator().manual_seed(seed))
-
-
-@pytest.fixture(scope="module")
-def X():
-    return _randn(BATCH, N_CHANS, N_TIMES)
-
-
-class _ToyNet(nn.Module):
-    """Small enough that the substituted output can be derived by hand."""
-
-    def __init__(self, block=None):
-        super().__init__()
-        self.block = nn.Linear(4, 6) if block is None else block
-        self.head = nn.Linear(6, 2)
-
-    def forward(self, x):
-        out = self.block(x)
-        hidden = out if torch.is_tensor(out) else _hidden_of(out)
-        return self.head(hidden)
-
-
-class _MultiOutBlock(nn.Module):
-    """A block returning a container, as transformer blocks commonly do."""
-
-    def __init__(self, kind):
-        super().__init__()
-        self.linear = nn.Linear(4, 6)
-        self.kind = kind
-
-    def forward(self, x):
-        hidden = self.linear(x)
-        aux = hidden.mean(dim=-1)
-        if self.kind == "tuple":
-            return hidden, aux
-        return {"hidden": hidden, "aux": aux}
-
-
-def _hidden_of(out):
-    return out[0] if isinstance(out, tuple) else out["hidden"]
-
-
-class _ExplodingNet(nn.Module):
-    def __init__(self):
-        super().__init__()
-        self.block = nn.Linear(4, 4)
-
-    def forward(self, x):
-        self.block(x)
-        raise RuntimeError("boom")
-
-
-@pytest.mark.parametrize("how", ["module", "list", "dict"])
-def test_captured_activation_substitutes_back_unchanged(model_and_layer, X, how):
-    """Round-trip on a real model.
-
-    Feeding a captured activation straight back in must be a no-op, which
-    fails if capture returns anything other than the genuine layer output.
-    A hook returning ``None`` also leaves the output untouched, so the
-    round-trip alone cannot tell a working substitution from one that never
-    fires; perturbing the activation pins that down.
-    """
-    model, layer = model_and_layer
-    layers = {"module": layer, "list": [layer], "dict": {"b": layer}}[how]
-    captured = capture_activations(model, X, layers)
-    (activation,) = captured.values()
-
-    with torch.no_grad():
-        baseline = model(X)
-        restored = run_with_activation_substitution(
-            model, X, layer, lambda _out: activation
-        )
-        perturbed = run_with_activation_substitution(
-            model, X, layer, lambda _out: activation + 1.0
-        )
+    changed = run_with_activation_substitution(
+        model, x, model.block, lambda output: (output[0] + 1, output[1])
+    )
     torch.testing.assert_close(restored, baseline)
-    assert not torch.allclose(perturbed, baseline)
-
-
-def test_substituted_output_matches_hand_computation():
-    """Zeroing a block leaves the head with nothing but its own bias."""
-    model = _ToyNet().eval()
-    with torch.no_grad():
-        out = run_with_activation_substitution(
-            model, _randn(BATCH, 4), model.block, torch.zeros_like
-        )
-    torch.testing.assert_close(out, model.head.bias.expand_as(out))
-
-
-@pytest.mark.parametrize("kind", ["tuple", "dict"])
-def test_capture_preserves_nested_output_structure(kind):
-    block = _MultiOutBlock(kind)
-    model = _ToyNet(block=block).eval()
-    x = _randn(BATCH, 4)
-
-    captured = capture_activations(model, x, {"block": model.block})["block"]
-
-    torch.testing.assert_close(_hidden_of(captured), block.linear(x))
-    assert not _hidden_of(captured).requires_grad  # detach walks the container
-
-
-def test_capture_without_detach_keeps_the_graph():
-    model = _ToyNet().eval()
-    captured = capture_activations(model, _randn(BATCH, 4), [model.block], detach=False)
-    captured[0].sum().backward()
-    assert model.block.weight.grad is not None
+    assert not torch.equal(changed, baseline)
+    assert not model.block._forward_hooks
 
 
 @pytest.mark.parametrize(
     "run",
     [
-        lambda m, x: capture_activations(m, x, [m.block]),
-        lambda m, x: run_with_activation_substitution(m, x, m.block, lambda o: o),
+        lambda model, x: capture_activations(model, x, model.block),
+        lambda model, x: run_with_activation_substitution(
+            model, x, model.block, lambda output: output
+        ),
     ],
 )
-def test_hooks_are_removed_when_the_forward_raises(run):
-    model = _ExplodingNet().eval()
+def test_hooks_are_removed_when_forward_raises(run):
+    model = _Model(explode=True)
     with pytest.raises(RuntimeError, match="boom"):
-        run(model, _randn(2, 4))
+        run(model, torch.randn(2, 3))
     assert not model.block._forward_hooks
 
 
-def test_hooks_are_removed_when_the_substitute_raises():
-    model = _ToyNet().eval()
-
-    def boom(_out):
-        raise RuntimeError("boom")
-
-    with pytest.raises(RuntimeError, match="boom"):
-        run_with_activation_substitution(model, _randn(2, 4), model.block, boom)
-    assert not model.block._forward_hooks
+def test_capture_rejects_an_uncalled_layer():
+    model = _Model()
+    with pytest.raises(RuntimeError, match="not called"):
+        capture_activations(model, torch.randn(2, 3), nn.Identity())
 
 
-def test_capture_raises_when_a_requested_layer_never_runs():
-    """A short dict would defer the failure to whoever indexes the key."""
-    model = _ToyNet().eval()
-    unused = nn.Linear(4, 4)
-    with pytest.raises(RuntimeError, match="never called"):
-        capture_activations(model, _randn(BATCH, 4), {"unused": unused})
-
-
-def test_substitution_rejects_a_substitute_fn_that_returns_none():
-    """Torch reads a None hook return as 'keep the original output', so a
-    missing return would silently disable the substitution."""
-    model = _ToyNet().eval()
-    with pytest.raises(TypeError, match="returned None"):
+def test_substitution_rejects_none():
+    model = _Model()
+    with pytest.raises(TypeError, match="must return"):
         run_with_activation_substitution(
-            model, _randn(BATCH, 4), model.block, lambda out: None
+            model, torch.randn(2, 3), model.block, lambda _output: None
         )
+    assert not model.block._forward_hooks

--- a/test/unit_tests/visualization/test_activations.py
+++ b/test/unit_tests/visualization/test_activations.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 from torch import nn
 
-from braindecode.models import ShallowFBCSPNet
+from braindecode.models import EEGConformer, ShallowFBCSPNet
 from braindecode.visualization import (
     capture_activations,
     run_with_activation_substitution,
@@ -16,22 +16,46 @@ N_OUTPUTS = 2
 BATCH = 4
 
 
-@pytest.fixture(scope="module")
-def model():
+def _shallow():
+    """A convolutional stack, hooked at a top-level child."""
     m = ShallowFBCSPNet(
         n_chans=N_CHANS,
         n_outputs=N_OUTPUTS,
         n_times=N_TIMES,
         final_conv_length="auto",
     )
-    m.eval()
-    return m
+    return m.eval(), "conv_nonlin_exp"
+
+
+def _conformer():
+    """A transformer, hooked at a residual block three levels down.
+
+    The harder of the two: the hooked module is not a direct child, and a
+    second residual block plus the head still run downstream of it, so a
+    substitution that fails to propagate has more places to show up.
+    """
+    m = EEGConformer(n_chans=N_CHANS, n_outputs=N_OUTPUTS, n_times=N_TIMES)
+    return m.eval(), "transformer.0.0"
+
+
+@pytest.fixture(scope="module", params=[_shallow, _conformer], ids=["cnn", "residual"])
+def model_and_layer(request):
+    model, name = request.param()
+    return model, dict(model.named_modules())[name]
+
+
+def _randn(*shape, seed=SEED):
+    """Seeded input drawn from a local generator.
+
+    A bare ``torch.manual_seed`` would reseed the process-global RNG and
+    silently change the draws of every test that runs afterwards.
+    """
+    return torch.randn(*shape, generator=torch.Generator().manual_seed(seed))
 
 
 @pytest.fixture(scope="module")
 def X():
-    torch.manual_seed(SEED)
-    return torch.randn(BATCH, N_CHANS, N_TIMES)
+    return _randn(BATCH, N_CHANS, N_TIMES)
 
 
 class _ToyNet(nn.Module):
@@ -39,7 +63,6 @@ class _ToyNet(nn.Module):
 
     def __init__(self, block=None):
         super().__init__()
-        torch.manual_seed(SEED)
         self.block = nn.Linear(4, 6) if block is None else block
         self.head = nn.Linear(6, 2)
 
@@ -79,18 +102,19 @@ class _ExplodingNet(nn.Module):
         raise RuntimeError("boom")
 
 
-@pytest.mark.parametrize("as_layers", [lambda b: b, lambda b: [b], lambda b: {"b": b}])
-def test_captured_activation_substitutes_back_unchanged(model, X, as_layers):
+@pytest.mark.parametrize("how", ["module", "list", "dict"])
+def test_captured_activation_substitutes_back_unchanged(model_and_layer, X, how):
     """Round-trip on a real model.
 
-    Feeding a captured activation straight back in must be a no-op. This
-    fails if capture returns anything other than the genuine layer output,
-    and it fails if the substitution hook does not actually reach the rest
-    of the network -- so it pins both functions against one another without
-    needing to know the model's internals.
+    Feeding a captured activation straight back in must be a no-op, which
+    fails if capture returns anything other than the genuine layer output.
+    A hook returning ``None`` also leaves the output untouched, so the
+    round-trip alone cannot tell a working substitution from one that never
+    fires; perturbing the activation pins that down.
     """
-    layer = model.conv_nonlin_exp
-    captured = capture_activations(model, X, as_layers(layer))
+    model, layer = model_and_layer
+    layers = {"module": layer, "list": [layer], "dict": {"b": layer}}[how]
+    captured = capture_activations(model, X, layers)
     (activation,) = captured.values()
 
     with torch.no_grad():
@@ -98,7 +122,11 @@ def test_captured_activation_substitutes_back_unchanged(model, X, as_layers):
         restored = run_with_activation_substitution(
             model, X, layer, lambda _out: activation
         )
+        perturbed = run_with_activation_substitution(
+            model, X, layer, lambda _out: activation + 1.0
+        )
     torch.testing.assert_close(restored, baseline)
+    assert not torch.allclose(perturbed, baseline)
 
 
 def test_substituted_output_matches_hand_computation():
@@ -106,7 +134,7 @@ def test_substituted_output_matches_hand_computation():
     model = _ToyNet().eval()
     with torch.no_grad():
         out = run_with_activation_substitution(
-            model, torch.randn(BATCH, 4), model.block, torch.zeros_like
+            model, _randn(BATCH, 4), model.block, torch.zeros_like
         )
     torch.testing.assert_close(out, model.head.bias.expand_as(out))
 
@@ -115,7 +143,7 @@ def test_substituted_output_matches_hand_computation():
 def test_capture_preserves_nested_output_structure(kind):
     block = _MultiOutBlock(kind)
     model = _ToyNet(block=block).eval()
-    x = torch.randn(BATCH, 4)
+    x = _randn(BATCH, 4)
 
     captured = capture_activations(model, x, {"block": model.block})["block"]
 
@@ -125,9 +153,7 @@ def test_capture_preserves_nested_output_structure(kind):
 
 def test_capture_without_detach_keeps_the_graph():
     model = _ToyNet().eval()
-    captured = capture_activations(
-        model, torch.randn(BATCH, 4), [model.block], detach=False
-    )
+    captured = capture_activations(model, _randn(BATCH, 4), [model.block], detach=False)
     captured[0].sum().backward()
     assert model.block.weight.grad is not None
 
@@ -142,7 +168,7 @@ def test_capture_without_detach_keeps_the_graph():
 def test_hooks_are_removed_when_the_forward_raises(run):
     model = _ExplodingNet().eval()
     with pytest.raises(RuntimeError, match="boom"):
-        run(model, torch.randn(2, 4))
+        run(model, _randn(2, 4))
     assert not model.block._forward_hooks
 
 
@@ -153,5 +179,23 @@ def test_hooks_are_removed_when_the_substitute_raises():
         raise RuntimeError("boom")
 
     with pytest.raises(RuntimeError, match="boom"):
-        run_with_activation_substitution(model, torch.randn(2, 4), model.block, boom)
+        run_with_activation_substitution(model, _randn(2, 4), model.block, boom)
     assert not model.block._forward_hooks
+
+
+def test_capture_raises_when_a_requested_layer_never_runs():
+    """A short dict would defer the failure to whoever indexes the key."""
+    model = _ToyNet().eval()
+    unused = nn.Linear(4, 4)
+    with pytest.raises(RuntimeError, match="never called"):
+        capture_activations(model, _randn(BATCH, 4), {"unused": unused})
+
+
+def test_substitution_rejects_a_substitute_fn_that_returns_none():
+    """Torch reads a None hook return as 'keep the original output', so a
+    missing return would silently disable the substitution."""
+    model = _ToyNet().eval()
+    with pytest.raises(TypeError, match="returned None"):
+        run_with_activation_substitution(
+            model, _randn(BATCH, 4), model.block, lambda out: None
+        )

--- a/test/unit_tests/visualization/test_activations.py
+++ b/test/unit_tests/visualization/test_activations.py
@@ -1,0 +1,141 @@
+import pytest
+import torch
+from torch import nn
+
+from braindecode.visualization import (
+    capture_activations,
+    run_with_activation_substitution,
+)
+
+
+class ToyNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = nn.Linear(4, 6)
+        self.head = nn.Linear(6, 2)
+
+    def forward(self, x):
+        x = self.block(x)
+        return self.head(x)
+
+
+class ExplodingNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = nn.Linear(4, 4)
+
+    def forward(self, x):
+        x = self.block(x)
+        raise RuntimeError("boom")
+
+
+class TupleBlock(nn.Module):
+    """A block returning ``(hidden, aux)``, as transformer blocks often do."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 6)
+
+    def forward(self, x):
+        hidden = self.linear(x)
+        return hidden, hidden.mean(dim=-1)
+
+
+class TupleNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = TupleBlock()
+        self.head = nn.Linear(6, 2)
+
+    def forward(self, x):
+        hidden, _aux = self.block(x)
+        return self.head(hidden)
+
+
+def test_capture_activations_returns_one_entry_and_cleans_hooks():
+    model = ToyNet().eval()
+    captured = capture_activations(model, torch.randn(3, 4), {"block": model.block})
+    assert set(captured) == {"block"}
+    assert captured["block"].shape == (3, 6)
+    assert len(model.block._forward_hooks) == 0
+
+
+def test_capture_activations_keys_by_position_for_a_sequence():
+    model = ToyNet().eval()
+    captured = capture_activations(model, torch.randn(3, 4), [model.block, model.head])
+    assert set(captured) == {0, 1}
+    assert captured[1].shape == (3, 2)
+
+
+def test_capture_activations_cleans_up_on_exception():
+    model = ExplodingNet().eval()
+    with pytest.raises(RuntimeError, match="boom"):
+        capture_activations(model, torch.randn(2, 4), [model.block])
+    assert len(model.block._forward_hooks) == 0
+
+
+def test_capture_activations_preserves_nested_output_structure():
+    model = TupleNet().eval()
+    captured = capture_activations(model, torch.randn(3, 4), {"block": model.block})
+    hidden, aux = captured["block"]
+    assert isinstance(captured["block"], tuple)
+    assert hidden.shape == (3, 6)
+    assert aux.shape == (3,)
+    assert not hidden.requires_grad  # detach walks into the tuple
+
+
+def test_capture_activations_can_keep_the_graph():
+    model = ToyNet().eval()
+    captured = capture_activations(
+        model, torch.randn(3, 4), [model.block], detach=False
+    )
+    assert captured[0].requires_grad
+
+
+def test_activation_substitution_identity_and_change():
+    model = ToyNet().eval()
+    x = torch.randn(4, 4)
+
+    baseline = model(x)
+    identity = run_with_activation_substitution(model, x, model.block, lambda out: out)
+    torch.testing.assert_close(identity, baseline)
+    assert len(model.block._forward_hooks) == 0
+
+    shifted = run_with_activation_substitution(
+        model, x, model.block, lambda out: out + 1.0
+    )
+    assert not torch.allclose(shifted, baseline)
+    assert len(model.block._forward_hooks) == 0
+
+
+def test_activation_substitution_on_a_tuple_returning_block():
+    model = TupleNet().eval()
+    x = torch.randn(4, 4)
+
+    baseline = model(x)
+    zeroed = run_with_activation_substitution(
+        model, x, model.block, lambda out: (torch.zeros_like(out[0]), out[1])
+    )
+    assert zeroed.shape == baseline.shape
+    assert not torch.allclose(zeroed, baseline)
+    # With the hidden state zeroed the head sees only its own bias.
+    torch.testing.assert_close(zeroed, model.head.bias.expand_as(zeroed))
+    assert len(model.block._forward_hooks) == 0
+
+
+def test_activation_substitution_cleans_up_on_exception():
+    model = ExplodingNet().eval()
+    with pytest.raises(RuntimeError, match="boom"):
+        run_with_activation_substitution(
+            model, torch.randn(2, 4), model.block, lambda out: out
+        )
+    assert len(model.block._forward_hooks) == 0
+
+
+def test_forward_fn_reaches_a_submodule():
+    model = ToyNet().eval()
+    x = torch.randn(3, 4)
+    captured = capture_activations(
+        model, x, [model.block], forward_fn=lambda inp: model.block(inp)
+    )
+    torch.testing.assert_close(captured[0], model.block(x))


### PR DESCRIPTION
Adds two forward-hook primitives to `braindecode.visualization`:

- **`capture_activations(model, x, layers, ...)`** — records what one or more submodules emitted during a forward pass. A single module, a list, or a dict of modules is accepted; tuple and dict outputs keep their structure.
- **`run_with_activation_substitution(model, x, layer, substitute_fn, ...)`** — replaces a module's output so everything downstream runs on the substitute. This is how a layer is ablated, or a stand-in representation tested.

Hooks are registered immediately before the forward pass and removed in a `finally` block, so a raising forward pass cannot leave them attached to the model.

Braindecode currently has no helper for reading or replacing an intermediate representation — `attribution.py` delegates its hook handling to captum, and the models expose only final-layer features via `return_features=True`. These two functions fill that gap and depend on nothing beyond torch.

### Scope

This is the first of the split @bruAristimunha asked for in https://github.com/braindecode/braindecode/pull/1120. It contains **only** the hook primitives, their tests, and a changelog entry, no SAE, no dataset, no training loop, and no paper claim. The remaining pieces stay in that draft and are not proposed here.

On the lineage question raised there: both functions were written against the public `register_forward_hook` contract in the PyTorch documentation and are not derived from any third-party implementation. The companion code for arXiv:2605.13930 captures activations through a stateful `ActivationExtractor` class with a manually invoked `remove_hooks()`; these are plain functions with `try`/`finally` cleanup and were not modelled on it.

### Two silent failure modes are rejected rather than tolerated

Both were reachable in the first draft of this module and both would produce plausible-looking output:

- `substitute_fn` returning `None` raises `TypeError`. Torch treats a `None` hook return as "keep the original output", so forgetting the `return` gave a full run with no substitution and an unchanged metric.
- `capture_activations` raises `RuntimeError` if a requested module never ran, and names it.


A module called more than once in a single pass keeps only its last output; that is documented rather than rejected.

### Tests

`test/unit_tests/visualization/test_activations.py`, 6 tests / 15 cases, ~9 s.

The main test is a round trip on a real model: capture a layer's activation, feed that exact value back in through the substitution hook, and require the model output to be unchanged. It then substitutes a perturbed activation and requires the output to change — the round trip alone cannot distinguish a working substitution from a hook that never fires, since both leave the output untouched.

It runs against two topologies:

| id | model | hooked module |
|---|---|---|
| `cnn` | `ShallowFBCSPNet` | `conv_nonlin_exp`, a top-level child |
| `residual` | `EEGConformer` | `transformer.0.0`, a residual block three levels deep, with a second residual block and the head still downstream |

Both are bit-exact on the round trip.

Also covered: tuple and dict outputs keep their structure and are detached through the container; `detach=False` leaves the graph intact and a gradient flows; hooks are removed when the forward raises **and** when `substitute_fn` itself raises; and the two rejections above.

Test inputs are drawn from a local `torch.Generator` rather than `torch.manual_seed`, so they do not reseed the process-global RNG for tests that run afterwards.

### Unrelated one-line fix

The last commit corrects my author email in `braindecode/visualization/attribution.py` (`shahvandit@` → `shahvanditt@`).
