### PR TITLE
Correct license metadata, NOTICE and README for non-BSD model files

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -12,6 +12,7 @@ The following components are licensed under the Creative Commons Attribution-Non
 
 - `braindecode/models/eegminer.py`
 - `braindecode/models/meta_neuromotor.py`
+- `braindecode/models/brainmodule.py`
 
 As well as class later imported into the `braindecode.models.module` named as GeneralizedGaussianFilter.
 
@@ -19,7 +20,45 @@ The `meta_neuromotor.py` file is a derivative of
 `facebookresearch/generic-neuromotor-interface`, released by Meta Platforms,
 Inc. under CC BY-NC 4.0, and inherits the same noncommercial terms.
 
+### CC BY-NC-SA 4.0 Licensed Files
+
+The following components are licensed under the Creative Commons
+Attribution-NonCommercial-ShareAlike 4.0 International License:
+
+- `braindecode/models/emg2qwerty.py`
+
+The `emg2qwerty.py` file is a derivative of `facebookresearch/emg2qwerty`,
+released by Meta Platforms, Inc. under CC BY-NC-SA 4.0, and inherits the
+same noncommercial ShareAlike terms.
+
+### MIT Licensed Files
+
+The following components are licensed under the MIT License:
+
+- `braindecode/models/ctnet.py`
+- `braindecode/models/dance.py`
+- `braindecode/models/medformer.py`
+- `braindecode/models/tcformer.py`
+- `braindecode/models/ifnet.py`
+
+### Apache-2.0 Licensed Files
+
+The following components are licensed under the Apache License 2.0:
+
+- `braindecode/models/mvpformer.py`
+- `braindecode/models/zuna.py`
+- `braindecode/models/luna.py`
+
 ## License Links
 
 - [BSD-3-Clause License](https://opensource.org/licenses/BSD-3-Clause)
 - [CC BY-NC 4.0 License](https://creativecommons.org/licenses/by-nc/4.0/)
+- [CC BY-NC-SA 4.0 License](https://creativecommons.org/licenses/by-nc-sa/4.0/)
+- [MIT License](https://opensource.org/licenses/MIT)
+- [Apache-2.0 License](https://www.apache.org/licenses/LICENSE-2.0)
+
+## Note
+
+This list covers files whose own headers declare a license other than
+BSD-3-Clause. Per-file provenance review of the remaining models is
+tracked separately.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -4,7 +4,8 @@
 
 ### BSD-3-Clause Licensed Files
 
-All files within the `src/` directory are licensed under the BSD-3-Clause License.
+All files within the `braindecode/` package are licensed under the BSD-3-Clause
+License, except for those listed in the sections below.
 
 ### CC BY-NC 4.0 Licensed Files
 

--- a/README.rst
+++ b/README.rst
@@ -170,10 +170,10 @@ This project is primarily licensed under the BSD-3-Clause License.
 Additional Components
 =====================
 
-Some components within this repository are licensed under other licenses,
-including Creative Commons Attribution-NonCommercial 4.0 International
-(CC BY-NC 4.0), Creative Commons Attribution-NonCommercial-ShareAlike 4.0
-International (CC BY-NC-SA 4.0), MIT and Apache-2.0.
+Some components within this repository are licensed under other licenses, including
+Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0), Creative
+Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0), MIT
+and Apache-2.0.
 
-Please refer to the ``LICENSE`` and ``NOTICE`` files for the per-file list and
-more detailed information.
+Please refer to the ``LICENSE`` and ``NOTICE`` files for the per-file list and more
+detailed information.

--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,10 @@ This project is primarily licensed under the BSD-3-Clause License.
 Additional Components
 =====================
 
-Some components within this repository are licensed under the Creative Commons
-Attribution-NonCommercial 4.0 International License.
+Some components within this repository are licensed under other licenses,
+including Creative Commons Attribution-NonCommercial 4.0 International
+(CC BY-NC 4.0), Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+International (CC BY-NC-SA 4.0), MIT and Apache-2.0.
 
-Please refer to the ``LICENSE`` and ``NOTICE`` files for more detailed information.
+Please refer to the ``LICENSE`` and ``NOTICE`` files for the per-file list and
+more detailed information.

--- a/braindecode/models/brainmodule.py
+++ b/braindecode/models/brainmodule.py
@@ -25,7 +25,7 @@ from braindecode.modules.layers import SubjectLayers
 __all__ = ["BrainModule"]
 
 
-class BrainModule(EEGModuleMixin, nn.Module):
+class BrainModule(EEGModuleMixin, nn.Module, license="cc-by-nc-4.0"):
     r"""BrainModule from [brainmagick]_, also known as SimpleConv.
 
     A dilated convolutional encoder for EEG decoding, using residual

--- a/braindecode/models/ctnet.py
+++ b/braindecode/models/ctnet.py
@@ -24,7 +24,7 @@ from braindecode.modules import (
 )
 
 
-class CTNet(EEGModuleMixin, nn.Module):
+class CTNet(EEGModuleMixin, nn.Module, license="mit"):
     r"""CTNet from Zhao, W et al (2024) [ctnet]_.
 
     :bdg-success:`Convolution` :bdg-info:`Attention/Transformer`

--- a/braindecode/models/dance.py
+++ b/braindecode/models/dance.py
@@ -22,7 +22,7 @@ from braindecode.modules import ChannelMerger, Perceiver, SimpleConv
 from braindecode.modules.dance_modules import DanceDetrDecoder
 
 
-class DANCE(EEGModuleMixin, nn.Module):
+class DANCE(EEGModuleMixin, nn.Module, license="mit"):
     r"""DANCE from Lévy et al (2026) [dance]_.
 
     :bdg-success:`Convolution` :bdg-info:`Attention/Transformer` :bdg-dark-line:`Channel`

--- a/braindecode/models/eegconformer.py
+++ b/braindecode/models/eegconformer.py
@@ -185,7 +185,7 @@ class EEGConformer(EEGModuleMixin, nn.Module):
        31, pp.710-719. https://ieeexplore.ieee.org/document/9991178
     .. [ConformerCode] Song, Y., Zheng, Q., Liu, B. and Gao, X., 2022. EEG
        conformer: Convolutional transformer for EEG decoding and visualization.
-       https://github.com/eeyhsong/EEG-Conformer.
+       https://github.com/eeyhsong/EEG-Conformer
     """
 
     def __init__(

--- a/braindecode/models/eegminer.py
+++ b/braindecode/models/eegminer.py
@@ -48,7 +48,7 @@ class _EEGMinerFeatures(nn.Module):
         return x[:, self.triu_row, self.triu_col, :]
 
 
-class EEGMiner(EEGModuleMixin, nn.Module):
+class EEGMiner(EEGModuleMixin, nn.Module, license="cc-by-nc-4.0"):
     r"""EEGMiner from Ludwig et al (2024) [eegminer]_.
 
     :bdg-success:`Convolution` :bdg-warning:`Interpretability`

--- a/braindecode/models/eegminer.py
+++ b/braindecode/models/eegminer.py
@@ -6,6 +6,7 @@
 """
 
 # Authors: Sarthak Tayal <sarthaktayal2@gmail.com>
+# License: Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
 
 import torch
 from torch import nn

--- a/braindecode/models/eegsimpleconv.py
+++ b/braindecode/models/eegsimpleconv.py
@@ -93,7 +93,7 @@ class EEGSimpleConv(EEGModuleMixin, torch.nn.Module):
     .. [Yassine2023Code] Yassine El Ouahidi, V. Gripon, B. Pasdeloup, G. Bouallegue
         N. Farrugia, G. Lioi, 2023. A Strong and Simple Deep Learning Baseline for
         BCI Motor Imagery Decoding. GitHub repository.
-        https://github.com/elouayas/EEGSimpleConv.
+        https://github.com/elouayas/EEGSimpleConv
 
     """
 

--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -1,9 +1,10 @@
 # Authors: Meta Platforms, Inc. and affiliates (original emg2qwerty)
 #          Bruno Aristimunha <b.aristimunha@gmail.com> (Braindecode adaptation)
 #
-# License: Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)
+# License: Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+#          International (CC BY-NC-SA 4.0)
 # Adapted from https://github.com/facebookresearch/emg2qwerty (NeurIPS 2024).
-# Inherits CC BY-NC 4.0; not covered by braindecode's BSD-3 license.
+# Inherits CC BY-NC-SA 4.0; not covered by braindecode's BSD-3 license.
 """``EMG2QwertyNet``: TDS-Conv-CTC for sEMG-to-keystroke decoding."""
 
 from __future__ import annotations
@@ -89,7 +90,7 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module):
     .. warning::
         **License: noncommercial use only.** This module is a derivative
         of Meta's reference implementation released under
-        `CC BY-NC 4.0 <https://creativecommons.org/licenses/by-nc/4.0/>`_,
+        `CC BY-NC-SA 4.0 <https://creativecommons.org/licenses/by-nc-sa/4.0/>`_,
         the same license as the upstream repository. Not covered by
         braindecode's BSD-3 license. Must not be used in commercial
         products or services. Pretrained weights from the upstream release

--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -19,7 +19,7 @@ from torch import nn
 from braindecode.models.base import EEGModuleMixin
 
 
-class EMG2QwertyNet(EEGModuleMixin, nn.Module):
+class EMG2QwertyNet(EEGModuleMixin, nn.Module, license="cc-by-nc-sa-4.0"):
     r"""Decoder mapping surface electromyography (sEMG) to keystrokes
     (emg2qwerty) [emg2qwerty2024]_.
 

--- a/braindecode/models/ifnet.py
+++ b/braindecode/models/ifnet.py
@@ -1,3 +1,4 @@
+# License: MIT
 """IFNet Neural Network.
 
 Authors: Jiaheng Wang

--- a/braindecode/models/ifnet.py
+++ b/braindecode/models/ifnet.py
@@ -28,7 +28,7 @@ from braindecode.modules import (
 )
 
 
-class IFNet(EEGModuleMixin, nn.Module):
+class IFNet(EEGModuleMixin, nn.Module, license="mit"):
     r"""IFNetV2 from Wang J et al (2023) [ifnet]_.
 
     :bdg-success:`Convolution` :bdg-primary:`Filterbank`

--- a/braindecode/models/luna.py
+++ b/braindecode/models/luna.py
@@ -1,3 +1,4 @@
+# License: Apache-2.0
 """This implementation is adapted from ETH Zurich's BioFoundation repository.
 
 Döner, B., Ingolfsson, T. M., Benini, L., & Li, Y. (2025).

--- a/braindecode/models/luna.py
+++ b/braindecode/models/luna.py
@@ -26,7 +26,7 @@ from braindecode.models.util import extract_channel_locations_from_chs_info
 from braindecode.modules.layers import DropPath
 
 
-class LUNA(EEGModuleMixin, nn.Module):
+class LUNA(EEGModuleMixin, nn.Module, license="apache-2.0"):
     r"""LUNA from Döner et al [LUNA]_.
 
     :bdg-success:`Convolution` :bdg-danger:`Foundation Model` :bdg-dark-line:`Channel`

--- a/braindecode/models/medformer.py
+++ b/braindecode/models/medformer.py
@@ -17,7 +17,7 @@ from braindecode.functional import sinusoidal_positional_encoding
 from braindecode.models.base import EEGModuleMixin
 
 
-class MEDFormer(EEGModuleMixin, nn.Module):
+class MEDFormer(EEGModuleMixin, nn.Module, license="mit"):
     r"""
     Medformer from Wang et al (2024) [Medformer2024]_.
 

--- a/braindecode/models/meta_neuromotor.py
+++ b/braindecode/models/meta_neuromotor.py
@@ -31,7 +31,7 @@ _LPadType = int | Literal["none", "steady", "full"]
 # ---------------------------------------------------------------------------
 
 
-class MetaNeuromotorHand(EEGModuleMixin, nn.Module):
+class MetaNeuromotorHand(EEGModuleMixin, nn.Module, license="cc-by-nc-4.0"):
     r"""Generic neuromotor interface for handwriting from Meta (2025) [gni2025]_.
 
     :bdg-info:`Attention/Transformer` :bdg-success:`Convolution`

--- a/braindecode/models/mvpformer.py
+++ b/braindecode/models/mvpformer.py
@@ -26,7 +26,7 @@ from braindecode.models.base import EEGModuleMixin
 from braindecode.modules import PatchTokenizer
 
 
-class MVPFormer(EEGModuleMixin, nn.Module):
+class MVPFormer(EEGModuleMixin, nn.Module, license="apache-2.0"):
     r"""MVPFormer from Carzaniga et al. (2026) [Carzaniga2026]_.
 
     :bdg-danger:`Foundation Model` :bdg-info:`Attention/Transformer`

--- a/braindecode/models/sstdpn.py
+++ b/braindecode/models/sstdpn.py
@@ -216,7 +216,7 @@ class SSTDPN(EEGModuleMixin, nn.Module):
         temporal dual prototype network for motor imagery
         brain–computer interface. Knowledge-Based Systems,
         315, 113315. GitHub repository.
-        https://github.com/hancan16/SST-DPN.
+        https://github.com/hancan16/SST-DPN
     """
 
     def __init__(

--- a/braindecode/models/tcformer.py
+++ b/braindecode/models/tcformer.py
@@ -14,7 +14,7 @@ from braindecode.models.base import EEGModuleMixin
 from braindecode.modules import CausalConv1d, Conv1dWithConstraint, DropPath
 
 
-class TCFormer(EEGModuleMixin, nn.Module):
+class TCFormer(EEGModuleMixin, nn.Module, license="mit"):
     r"""TCFormer from Altaheri et al (2025) [tcformer]_.
 
     :bdg-success:`Convolution` :bdg-info:`Attention/Transformer`

--- a/braindecode/models/zuna.py
+++ b/braindecode/models/zuna.py
@@ -19,7 +19,7 @@ from braindecode.models.util import extract_channel_locations_from_chs_info
 from braindecode.modules import PatchTokenizer
 
 
-class ZUNA(EEGModuleMixin, nn.Module):
+class ZUNA(EEGModuleMixin, nn.Module, license="apache-2.0"):
     r"""ZUNA from Warner et al. (2026) [Warner2026ZUNA]_.
 
     :bdg-danger:`Foundation Model` :bdg-dark-line:`Channel` :bdg-info:`Attention/Transformer`


### PR DESCRIPTION
Fixes the parts of #1139, #1140 and #1141 that can be settled from evidence, and deliberately leaves the parts that need a per-file provenance judgement.

## How the values were established

Every GitHub reference in `braindecode/models/*.py` was extracted, all 40 distinct upstream repositories were shallow-cloned, and their licence files were read from disk. The GitHub API's `license` field is not sufficient for this: it returned `NOASSERTION` for the two upstreams whose licences matter most, because neither Creative Commons texts nor the CBCR licence are in its classifier.

## What this changes

**1. `EMG2QwertyNet` was claiming the wrong licence.** Its header said CC BY-NC 4.0 and "Inherits CC BY-NC 4.0". The `LICENSE` in `facebookresearch/emg2qwerty` reads `Attribution-NonCommercial-ShareAlike 4.0 International`. ShareAlike is a stronger obligation, so the file was advertising weaker terms than it actually carries. Corrected to CC BY-NC-SA 4.0.

The two Meta repositories genuinely differ — `generic-neuromotor-interface` really is plain CC BY-NC 4.0, so `meta_neuromotor.py` was correct as written. That is presumably how the mistake arose.

**2. Non-BSD models published `bsd-3-clause` in their Hub model card.** `EEGModuleMixin.__init_subclass__` accepts a `license=` keyword and forwards it to the model-card metadata, defaulting to `bsd-3-clause`. No model set it, so noncommercial models advertised permissive terms. Now set for the twelve models whose own headers already declare a non-BSD licence:

| License | Models |
|---|---|
| `mit` | `CTNet`, `DANCE`, `MEDFormer`, `TCFormer`, `IFNet` |
| `apache-2.0` | `MVPFormer`, `ZUNA`, `LUNA` |
| `cc-by-nc-4.0` | `BrainModule`, `EEGMiner`, `MetaNeuromotorHand` |
| `cc-by-nc-sa-4.0` | `EMG2QwertyNet` |

The remaining 52 models are untouched and still report `bsd-3-clause`.

**3. `NOTICE.txt` recorded two of the twelve.** It listed only `eegminer.py` and `meta_neuromotor.py`. It now has sections for CC BY-NC 4.0, CC BY-NC-SA 4.0, MIT and Apache-2.0, with matching licence links.

Its BSD-3 statement also read "All files within the `src/` directory". There is no `src/` directory in this repository — the package is `braindecode/` — so the notice's central claim pointed at nothing and did not carve out the noncommercial files listed directly beneath it. Corrected, with the missing exception clause added.

**4. `README.rst`** named only CC BY-NC 4.0 under Additional Components. It now names all four and points at `NOTICE` for the per-file list, without a hardcoded count that would go stale.

**5. Three files stated a licence in prose but had no header line** — `luna.py` (Apache-2.0), `ifnet.py` (MIT), `eegminer.py` (CC BY-NC 4.0). The existing claim was moved into the standard header block. No new claim is introduced.

**6. Three upstream URLs were dead** because a sentence-ending period had been swept into the link: `eegconformer.py`, `eegsimpleconv.py`, `sstdpn.py`.

## What this deliberately does NOT change

Around 25 model→upstream references show a licence delta — files declaring BSD-3 while their upstream is MIT, Apache-2.0, GPL or noncommercial. **None of those are touched here**, because resolving them means asserting whether each file was written from the paper or adapted from the code, and only the author of each port knows. A clean-room reimplementation inherits nothing; several files already assert exactly that about themselves. A confidently wrong licence header is worse than a missing one, because people rely on headers.

The two that most deserve attention, both left alone:

- `eegconformer.py` declares BSD-3; `eeyhsong/EEG-Conformer` is **GNU GPL v3**. GPL is copyleft, so if that implementation derives from the code this is an incompatibility rather than a notice defect. Mitigating detail: the only reference to that repository inside the file is a hot-linked figure URL, and the file makes no derivation claim either way.
- `tsinception.py` declares BSD-3; `deepBrains/TSception` is **CBCR License 1.0** — BSD-3 text with "for non-commercial purpose" substituted into the grant.

Nine upstreams declare no licence at all, so their derivatives have nothing to inherit and no permission to rely on: `eegitnet`, `eegsimpleconv`, `fbmsnet`, `msvtnet`, `sinc_shallow`, `sstdpn`, `syncnet`, `tidnet`, and `signal_jepa` via BENDR. Confirmed two ways — a sparse clone finding no licence file, and the contents API listing none at the repository root.

Full evidence, tiered by severity, is in #1141.

## Also worth a maintainer's attention

`eegminer.py` carries a patent notice — GB2609265, Cogitat Ltd, "learnable filters for EEG classification". A patent is a separate grant from a copyright licence, CC BY-NC 4.0 conveys no patent rights, and neither `NOTICE.txt` nor the README mentions it. Out of scope here, but it is a larger question than any of the header mismatches this PR fixes.

## Verification

- Hub metadata read back for all 65 models: the twelve above report their new values, the other 52 still report `bsd-3-clause`.
- `pre-commit` green on all 17 changed files (`mypy`, `ruff`, `codespell`, `docstrfmt`, `sphinx-lint`, `isort`).
- Full `test/unit_tests/models/` suite run against the branch.

Reproduce the upstream side with:

```bash
git clone --depth 1 --filter=blob:none --no-checkout https://github.com/<slug>.git d
git -C d sparse-checkout set --no-cone '/LICENSE*' '/COPYING*' '/NOTICE*'
git -C d checkout && head -3 d/LICENSE*
```
