### PR TITLE
Refactor shared EMG model support components

### DIFF
--- a/braindecode/models/base.py
+++ b/braindecode/models/base.py
@@ -519,6 +519,31 @@ class EEGModuleMixin(_BaseHubMixin, metaclass=_BraindecodeDocstringMeta):
         resolve_type_kwargs(cls, config)
         return cls(**config)
 
+    def _set_n_outputs(self, n_outputs: int) -> None:
+        """Record a new ``n_outputs`` on the model and its saved configs.
+
+        Helper for :meth:`reset_head` implementations: validates the value,
+        then keeps the ``n_outputs`` property, the braindecode init kwargs
+        and the Hugging Face hub config in sync, so a re-serialized model
+        reports the head it actually has.
+
+        Parameters
+        ----------
+        n_outputs : int
+            New number of outputs. Must be positive.
+
+        .. versionadded:: 1.8
+        """
+        if n_outputs <= 0:
+            raise ValueError(f"n_outputs must be positive; got {n_outputs}.")
+        self._n_outputs = n_outputs
+        for config in (
+            getattr(self, "_braindecode_init_kwargs", None),
+            getattr(self, "_hub_mixin_config", None),
+        ):
+            if config is not None and "n_outputs" in config:
+                config["n_outputs"] = n_outputs
+
     def reset_head(self, n_outputs):
         """Replace the classification head for a new number of outputs.
 

--- a/braindecode/models/dance.py
+++ b/braindecode/models/dance.py
@@ -349,8 +349,7 @@ class DANCE(EEGModuleMixin, nn.Module, license="mit"):
 
     def reset_head(self, n_outputs: int) -> None:
         """Replace the dense head and the DETR class head for a new ``n_outputs``."""
-        if n_outputs <= 0:
-            raise ValueError(f"n_outputs must be positive; got {n_outputs}.")
+        self._set_n_outputs(n_outputs)
         old = self.final_layer
         self.final_layer = nn.Linear(old.in_features, n_outputs).to(
             device=old.weight.device, dtype=old.weight.dtype
@@ -359,10 +358,3 @@ class DANCE(EEGModuleMixin, nn.Module, license="mit"):
         self.decoder.class_head = nn.Linear(ch.in_features, n_outputs).to(
             device=ch.weight.device, dtype=ch.weight.dtype
         )
-        self._n_outputs = n_outputs
-        init_kwargs = getattr(self, "_braindecode_init_kwargs", None)
-        if init_kwargs is not None and "n_outputs" in init_kwargs:
-            init_kwargs["n_outputs"] = n_outputs
-        hub_config = getattr(self, "_hub_mixin_config", None)
-        if hub_config is not None and "n_outputs" in hub_config:
-            hub_config["n_outputs"] = n_outputs

--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -17,6 +17,7 @@ import torchaudio.transforms as ta_transforms
 from torch import nn
 
 from braindecode.models.base import EEGModuleMixin
+from braindecode.modules import TDSConv2dBlock, TDSConvEncoder
 
 
 class EMG2QwertyNet(EEGModuleMixin, nn.Module, license="cc-by-nc-sa-4.0"):
@@ -346,7 +347,7 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module, license="cc-by-nc-sa-4.0"):
                 activation=activation,
             ),
             nn.Flatten(start_dim=2),
-            _TDSConvEncoder(
+            TDSConvEncoder(
                 num_features=num_features,
                 block_channels=list(block_channels),
                 kernel_width=kernel_width,
@@ -358,7 +359,7 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module, license="cc-by-nc-sa-4.0"):
         self.final_layer = nn.Linear(num_features, self.n_outputs)
 
         self._n_conv_blocks = sum(
-            isinstance(m, _TDSConv2dBlock) for m in self.model[3].tds_conv_blocks
+            isinstance(m, TDSConv2dBlock) for m in self.model[3].tds_conv_blocks
         )
 
     def forward(
@@ -453,22 +454,11 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module, license="cc-by-nc-sa-4.0"):
         captured init config (``get_config()``) is also kept in sync so
         save/load round-trips rebuild the new head.
         """
-        if n_outputs <= 0:
-            raise ValueError(f"n_outputs must be positive; got {n_outputs}.")
+        self._set_n_outputs(n_outputs)
         old_head = self.final_layer
         self.final_layer = nn.Linear(old_head.in_features, n_outputs).to(
             device=old_head.weight.device, dtype=old_head.weight.dtype
         )
-        self._n_outputs = n_outputs
-        # Keep the init-kwargs snapshot used by ``get_config()`` aligned with
-        # the live head, so ``EMG2QwertyNet.from_config(m.get_config())``
-        # rebuilds the head with the new vocab size.
-        init_kwargs = getattr(self, "_braindecode_init_kwargs", None)
-        if init_kwargs is not None and "n_outputs" in init_kwargs:
-            init_kwargs["n_outputs"] = n_outputs
-        hub_config = getattr(self, "_hub_mixin_config", None)
-        if hub_config is not None and "n_outputs" in hub_config:
-            hub_config["n_outputs"] = n_outputs
 
     def compute_output_lengths(self, input_lengths: torch.Tensor) -> torch.Tensor:
         """Map per-sample input lengths to CTC emission lengths.
@@ -800,116 +790,3 @@ class _MultiBandRotationInvariantMLP(nn.Module):
         for band_idx, mlp in enumerate(self.mlps):
             band_outputs.append(mlp(per_band_inputs[band_idx]))
         return torch.stack(band_outputs, dim=self.stack_dim)
-
-
-class _TDSConv2dBlock(nn.Module):
-    r"""Time-Depth-Separable 2-D conv block ([hannun2019tds]_).
-
-    1×``kernel_width`` conv + activation + residual + LayerNorm. No
-    temporal padding: strips ``kernel_width - 1`` frames per block.
-    """
-
-    def __init__(
-        self,
-        channels: int,
-        width: int,
-        kernel_width: int,
-        activation: type[nn.Module] = nn.ReLU,
-    ) -> None:
-        super().__init__()
-        self.channels = channels
-        self.width = width
-        self.conv2d = nn.Conv2d(
-            in_channels=channels,
-            out_channels=channels,
-            kernel_size=(1, kernel_width),
-        )
-        self.activation = activation()
-        self.layer_norm = nn.LayerNorm(channels * width)
-
-    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-        n_in_frames, batch_size, n_features = inputs.shape
-        folded = inputs.movedim(0, -1).reshape(
-            batch_size, self.channels, self.width, n_in_frames
-        )
-        conv_out = self.activation(self.conv2d(folded))
-        conv_out = conv_out.reshape(batch_size, n_features, -1).movedim(-1, 0)
-        n_out_frames = conv_out.shape[0]
-        # Output frame i aligns with input frame i+(kernel_width-1), so
-        # the residual is the LAST n_out_frames input frames.
-        residual_added = conv_out + inputs[-n_out_frames:]
-        return self.layer_norm(residual_added)
-
-
-class _TDSFullyConnectedBlock(nn.Module):
-    r"""Two-layer FFN with residual skip, LayerNorm, and optional dropout."""
-
-    def __init__(
-        self,
-        num_features: int,
-        activation: type[nn.Module] = nn.ReLU,
-        drop_prob: float = 0.0,
-    ) -> None:
-        super().__init__()
-        layers: list[nn.Module] = [
-            nn.Linear(num_features, num_features),
-            activation(),
-        ]
-        if drop_prob > 0:
-            layers.append(nn.Dropout(drop_prob))
-        layers.append(nn.Linear(num_features, num_features))
-        if drop_prob > 0:
-            layers.append(nn.Dropout(drop_prob))
-        self.fc_block = nn.Sequential(*layers)
-        self.layer_norm = nn.LayerNorm(num_features)
-
-    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-        return self.layer_norm(self.fc_block(inputs) + inputs)
-
-
-class _TDSConvEncoder(nn.Module):
-    r"""``_TDSConv2dBlock`` + ``_TDSFullyConnectedBlock`` stack.
-
-    With ``K = len(block_channels)`` blocks and no temporal padding, the
-    encoder strips ``K * (kernel_width - 1)`` frames in total. Each ``ch``
-    must evenly divide ``num_features`` so the conv block can fold features
-    as ``(channels=ch, width=num_features // ch)``.
-    """
-
-    def __init__(
-        self,
-        num_features: int,
-        block_channels: Sequence[int] = (24, 24, 24, 24),
-        kernel_width: int = 32,
-        activation: type[nn.Module] = nn.ReLU,
-        drop_prob: float = 0.0,
-    ) -> None:
-        super().__init__()
-        if not block_channels:
-            raise ValueError("block_channels must be non-empty.")
-        blocks: list[nn.Module] = []
-        for n_block_channels in block_channels:
-            if num_features % n_block_channels != 0:
-                raise ValueError(
-                    f"block_channels entry {n_block_channels} does not evenly "
-                    f"divide num_features={num_features}."
-                )
-            blocks.extend(
-                [
-                    _TDSConv2dBlock(
-                        n_block_channels,
-                        num_features // n_block_channels,
-                        kernel_width,
-                        activation=activation,
-                    ),
-                    _TDSFullyConnectedBlock(
-                        num_features,
-                        activation=activation,
-                        drop_prob=drop_prob,
-                    ),
-                ]
-            )
-        self.tds_conv_blocks = nn.Sequential(*blocks)
-
-    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
-        return self.tds_conv_blocks(inputs)

--- a/braindecode/models/emg2qwerty.py
+++ b/braindecode/models/emg2qwerty.py
@@ -17,7 +17,7 @@ import torchaudio.transforms as ta_transforms
 from torch import nn
 
 from braindecode.models.base import EEGModuleMixin
-from braindecode.modules import TDSConv2dBlock, TDSConvEncoder
+from braindecode.modules import TDSConvEncoder
 
 
 class EMG2QwertyNet(EEGModuleMixin, nn.Module, license="cc-by-nc-sa-4.0"):
@@ -358,9 +358,7 @@ class EMG2QwertyNet(EEGModuleMixin, nn.Module, license="cc-by-nc-sa-4.0"):
 
         self.final_layer = nn.Linear(num_features, self.n_outputs)
 
-        self._n_conv_blocks = sum(
-            isinstance(m, TDSConv2dBlock) for m in self.model[3].tds_conv_blocks
-        )
+        self._n_conv_blocks = len(block_channels)
 
     def forward(
         self, x: torch.Tensor, return_features: bool = False

--- a/braindecode/modules/__init__.py
+++ b/braindecode/modules/__init__.py
@@ -24,9 +24,7 @@ from .blocks import (
     FeedForwardBlock,
     InceptionBlock,
     PatchTokenizer,
-    TDSConv2dBlock,
     TDSConvEncoder,
-    TDSFullyConnectedBlock,
 )
 from .convolution import (
     AvgPool2dWithConv,
@@ -86,9 +84,7 @@ __all__ = [
     "FeedForwardBlock",
     "InceptionBlock",
     "PatchTokenizer",
-    "TDSConv2dBlock",
     "TDSConvEncoder",
-    "TDSFullyConnectedBlock",
     "AvgPool2dWithConv",
     "CausalConv1d",
     "CombinedConv",

--- a/braindecode/modules/__init__.py
+++ b/braindecode/modules/__init__.py
@@ -1,4 +1,10 @@
-from .activation import GatedLinearUnit, LogActivation, SafeLog, Square
+from .activation import (
+    GatedLinearUnit,
+    LogActivation,
+    SafeLog,
+    SmoothMaximumUnit,
+    Square,
+)
 from .attention import (
     CAT,
     CBAM,
@@ -14,7 +20,15 @@ from .attention import (
     MultiHeadAttention,
     SqueezeAndExcitation,
 )
-from .blocks import MLP, FeedForwardBlock, InceptionBlock, PatchTokenizer
+from .blocks import (
+    MLP,
+    FeedForwardBlock,
+    InceptionBlock,
+    PatchTokenizer,
+    TDSConv2dBlock,
+    TDSConvEncoder,
+    TDSFullyConnectedBlock,
+)
 from .convolution import (
     AvgPool2dWithConv,
     CausalConv1d,
@@ -54,6 +68,7 @@ __all__ = [
     "GatedLinearUnit",
     "LogActivation",
     "SafeLog",
+    "SmoothMaximumUnit",
     "Square",
     "CAT",
     "CBAM",
@@ -73,6 +88,9 @@ __all__ = [
     "FeedForwardBlock",
     "InceptionBlock",
     "PatchTokenizer",
+    "TDSConv2dBlock",
+    "TDSConvEncoder",
+    "TDSFullyConnectedBlock",
     "AvgPool2dWithConv",
     "CausalConv1d",
     "CombinedConv",

--- a/braindecode/modules/__init__.py
+++ b/braindecode/modules/__init__.py
@@ -2,7 +2,6 @@ from .activation import (
     GatedLinearUnit,
     LogActivation,
     SafeLog,
-    SmoothMaximumUnit,
     Square,
 )
 from .attention import (
@@ -68,7 +67,6 @@ __all__ = [
     "GatedLinearUnit",
     "LogActivation",
     "SafeLog",
-    "SmoothMaximumUnit",
     "Square",
     "CAT",
     "CBAM",

--- a/braindecode/modules/activation.py
+++ b/braindecode/modules/activation.py
@@ -138,29 +138,3 @@ class GatedLinearUnit(nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         value, gate = x.chunk(2, dim=-1)
         return value * self.activation(gate)
-
-
-class SmoothMaximumUnit(nn.Module):
-    r"""Smooth Maximum Unit (SMU) activation.
-
-    This is the learnable smooth activation used by SensingDynamics. ``alpha``
-    controls the negative slope and ``mu`` controls the smoothness of the
-    transition.
-
-    Parameters
-    ----------
-    alpha : float, default=0.01
-        Negative-slope coefficient.
-    mu : float, default=2.5
-        Initial value of the learnable smoothness parameter.
-    """
-
-    def __init__(self, alpha: float = 0.01, mu: float = 2.5) -> None:
-        super().__init__()
-        self.alpha = float(alpha)
-        self.mu = nn.Parameter(torch.tensor(float(mu)))
-
-    def forward(self, x: Tensor) -> Tensor:
-        positive = (1.0 + self.alpha) * x
-        smooth = (1.0 - self.alpha) * x * torch.erf(self.mu * (1.0 - self.alpha) * x)
-        return 0.5 * (positive + smooth)

--- a/braindecode/modules/activation.py
+++ b/braindecode/modules/activation.py
@@ -138,3 +138,29 @@ class GatedLinearUnit(nn.Module):
     def forward(self, x: Tensor) -> Tensor:
         value, gate = x.chunk(2, dim=-1)
         return value * self.activation(gate)
+
+
+class SmoothMaximumUnit(nn.Module):
+    r"""Smooth Maximum Unit (SMU) activation.
+
+    This is the learnable smooth activation used by SensingDynamics. ``alpha``
+    controls the negative slope and ``mu`` controls the smoothness of the
+    transition.
+
+    Parameters
+    ----------
+    alpha : float, default=0.01
+        Negative-slope coefficient.
+    mu : float, default=2.5
+        Initial value of the learnable smoothness parameter.
+    """
+
+    def __init__(self, alpha: float = 0.01, mu: float = 2.5) -> None:
+        super().__init__()
+        self.alpha = float(alpha)
+        self.mu = nn.Parameter(torch.tensor(float(mu)))
+
+    def forward(self, x: Tensor) -> Tensor:
+        positive = (1.0 + self.alpha) * x
+        smooth = (1.0 - self.alpha) * x * torch.erf(self.mu * (1.0 - self.alpha) * x)
+        return 0.5 * (positive + smooth)

--- a/braindecode/modules/blocks.py
+++ b/braindecode/modules/blocks.py
@@ -319,7 +319,7 @@ class FeedForwardBlock(nn.Sequential):
         )
 
 
-class TDSConv2dBlock(nn.Module):
+class _TDSConv2dBlock(nn.Module):
     r"""Time-depth-separable convolutional block.
 
     The feature dimension is factorized as ``channels * width`` and processed
@@ -405,7 +405,7 @@ class TDSConv2dBlock(nn.Module):
         return output
 
 
-class TDSFullyConnectedBlock(nn.Module):
+class _TDSFullyConnectedBlock(nn.Module):
     r"""Residual position-wise feed-forward TDS block.
 
     Parameters
@@ -508,14 +508,14 @@ class TDSConvEncoder(nn.Module):
                 )
             blocks.extend(
                 [
-                    TDSConv2dBlock(
+                    _TDSConv2dBlock(
                         channels=n_block_channels,
                         width=num_features // n_block_channels,
                         kernel_width=kernel_width,
                         activation=activation,
                         time_first=time_first,
                     ),
-                    TDSFullyConnectedBlock(
+                    _TDSFullyConnectedBlock(
                         num_features=num_features,
                         activation=activation,
                         drop_prob=drop_prob,

--- a/braindecode/modules/blocks.py
+++ b/braindecode/modules/blocks.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
 from warnings import warn
 
 import torch
+from einops.layers.torch import Rearrange
 from torch import nn
 
 
@@ -315,3 +317,214 @@ class FeedForwardBlock(nn.Sequential):
             nn.Dropout(drop_p),
             nn.Linear(expansion * emb_size, emb_size),
         )
+
+
+class TDSConv2dBlock(nn.Module):
+    r"""Time-depth-separable convolutional block.
+
+    The feature dimension is factorized as ``channels * width`` and processed
+    by a valid ``(1, kernel_width)`` convolution. The result is combined with
+    the aligned tail of the input before layer normalization.
+
+    Parameters
+    ----------
+    channels : int
+        Number of convolution channels in the feature factorization.
+    width : int
+        Width of each convolution channel. The input feature dimension must be
+        ``channels * width``.
+    kernel_width : int
+        Size of the valid temporal convolution kernel.
+    activation : type[nn.Module], default=nn.ReLU
+        Activation constructor applied after the convolution.
+    time_first : bool, default=True
+        If ``True``, inputs and outputs use ``(time, batch, features)``. If
+        ``False``, they use ``(batch, features, time)``.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        width: int,
+        kernel_width: int,
+        activation: type[nn.Module] = nn.ReLU,
+        time_first: bool = True,
+    ) -> None:
+        super().__init__()
+        self.channels = channels
+        self.width = width
+        self.time_first = time_first
+        self.conv2d = nn.Conv2d(
+            in_channels=channels,
+            out_channels=channels,
+            kernel_size=(1, kernel_width),
+        )
+        self.activation = activation()
+        self.layer_norm = nn.LayerNorm(channels * width)
+        if time_first:
+            self.fold_features = Rearrange(
+                "time batch (channels width) -> batch channels width time",
+                channels=channels,
+                width=width,
+            )
+            self.unfold_features = Rearrange(
+                "batch channels width time -> time batch (channels width)"
+            )
+        else:
+            self.fold_features = Rearrange(
+                "batch (channels width) time -> batch channels width time",
+                channels=channels,
+                width=width,
+            )
+            self.unfold_features = Rearrange(
+                "batch channels width time -> batch (channels width) time"
+            )
+        self.features_to_sequence = Rearrange(
+            "batch features time -> batch time features"
+        )
+        self.sequence_to_features = Rearrange(
+            "batch time features -> batch features time"
+        )
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        folded = self.fold_features(inputs)
+        convolved = self.conv2d(folded)
+        activated = self.activation(convolved)
+        conv_out = self.unfold_features(activated)
+        n_out_frames = activated.shape[-1]
+
+        if self.time_first:
+            residual_added = conv_out + inputs[-n_out_frames:]
+            output = self.layer_norm(residual_added)
+            return output
+
+        residual_added = conv_out + inputs[..., -n_out_frames:]
+        sequence = self.features_to_sequence(residual_added)
+        normalized = self.layer_norm(sequence)
+        output = self.sequence_to_features(normalized)
+        return output
+
+
+class TDSFullyConnectedBlock(nn.Module):
+    r"""Residual position-wise feed-forward TDS block.
+
+    Parameters
+    ----------
+    num_features : int
+        Size of the feature dimension.
+    activation : type[nn.Module], default=nn.ReLU
+        Activation constructor used between the two linear layers.
+    drop_prob : float, default=0.0
+        Dropout probability after the activation and second linear layer.
+    time_first : bool, default=True
+        If ``True``, inputs and outputs use ``(time, batch, features)``. If
+        ``False``, they use ``(batch, features, time)``.
+    """
+
+    def __init__(
+        self,
+        num_features: int,
+        activation: type[nn.Module] = nn.ReLU,
+        drop_prob: float = 0.0,
+        time_first: bool = True,
+    ) -> None:
+        super().__init__()
+        self.time_first = time_first
+        layers: list[nn.Module] = [
+            nn.Linear(num_features, num_features),
+            activation(),
+        ]
+        if drop_prob > 0:
+            layers.append(nn.Dropout(drop_prob))
+        layers.append(nn.Linear(num_features, num_features))
+        if drop_prob > 0:
+            layers.append(nn.Dropout(drop_prob))
+        self.fc_block = nn.Sequential(*layers)
+        self.layer_norm = nn.LayerNorm(num_features)
+        self.features_to_sequence = Rearrange(
+            "batch features time -> batch time features"
+        )
+        self.sequence_to_features = Rearrange(
+            "batch time features -> batch features time"
+        )
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        if self.time_first:
+            transformed = self.fc_block(inputs)
+            residual_added = transformed + inputs
+            output = self.layer_norm(residual_added)
+            return output
+
+        sequence = self.features_to_sequence(inputs)
+        transformed = self.fc_block(sequence)
+        residual_added = transformed + sequence
+        normalized = self.layer_norm(residual_added)
+        output = self.sequence_to_features(normalized)
+        return output
+
+
+class TDSConvEncoder(nn.Module):
+    r"""Stack time-depth-separable convolution and feed-forward blocks.
+
+    With ``K = len(block_channels)`` blocks and valid convolutions, the encoder
+    removes ``K * (kernel_width - 1)`` frames. Every entry in
+    ``block_channels`` must evenly divide ``num_features``.
+
+    Parameters
+    ----------
+    num_features : int
+        Size of the input and output feature dimension.
+    block_channels : sequence of int, default=(24, 24, 24, 24)
+        Convolution channel count for each TDS block.
+    kernel_width : int, default=32
+        Size of each valid temporal convolution kernel.
+    activation : type[nn.Module], default=nn.ReLU
+        Activation constructor used in every block.
+    drop_prob : float, default=0.0
+        Dropout probability in the feed-forward blocks.
+    time_first : bool, default=True
+        If ``True``, inputs and outputs use ``(time, batch, features)``. If
+        ``False``, they use ``(batch, features, time)``.
+    """
+
+    def __init__(
+        self,
+        num_features: int,
+        block_channels: Sequence[int] = (24, 24, 24, 24),
+        kernel_width: int = 32,
+        activation: type[nn.Module] = nn.ReLU,
+        drop_prob: float = 0.0,
+        time_first: bool = True,
+    ) -> None:
+        super().__init__()
+        if not block_channels:
+            raise ValueError("block_channels must be non-empty.")
+        blocks: list[nn.Module] = []
+        for n_block_channels in block_channels:
+            if num_features % n_block_channels != 0:
+                raise ValueError(
+                    f"block_channels entry {n_block_channels} does not evenly "
+                    f"divide num_features={num_features}."
+                )
+            blocks.extend(
+                [
+                    TDSConv2dBlock(
+                        channels=n_block_channels,
+                        width=num_features // n_block_channels,
+                        kernel_width=kernel_width,
+                        activation=activation,
+                        time_first=time_first,
+                    ),
+                    TDSFullyConnectedBlock(
+                        num_features=num_features,
+                        activation=activation,
+                        drop_prob=drop_prob,
+                        time_first=time_first,
+                    ),
+                ]
+            )
+        self.tds_conv_blocks = nn.Sequential(*blocks)
+
+    def forward(self, inputs: torch.Tensor) -> torch.Tensor:
+        output = self.tds_conv_blocks(inputs)
+        return output

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,6 +28,12 @@ Current 1.8.0 (GitHub)
 Enhancements
 ============
 
+- Add reusable temporal-distributed separable convolution blocks and the
+  smooth maximum unit activation to :mod:`braindecode.modules`, and centralize
+  output-head replacement for models using
+  :class:`braindecode.models.base.EEGModuleMixin` (:gh:`1145` by `Bruno
+  Aristimunha`_)
+
 - Add :meth:`braindecode.datasets.BaseConcatDataset.plot` (every dataset, ``BIDSDataset`` included): show a recording in the
   `eegdash-viewer <https://github.com/eegdash/eegdash-viewer>`_ inside a
   Jupyter cell — serverless (bytes inlined, viewer from CDN), with the

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -28,9 +28,8 @@ Current 1.8.0 (GitHub)
 Enhancements
 ============
 
-- Add reusable temporal-distributed separable convolution blocks and the
-  smooth maximum unit activation to :mod:`braindecode.modules`, and centralize
-  output-head replacement for models using
+- Add a reusable temporal-distributed separable convolution encoder to
+  :mod:`braindecode.modules`, and centralize output-head replacement for models using
   :class:`braindecode.models.base.EEGModuleMixin` (:gh:`1145` by `Bruno
   Aristimunha`_)
 

--- a/test/unit_tests/models/test_modules.py
+++ b/test/unit_tests/models/test_modules.py
@@ -33,9 +33,7 @@ from braindecode.modules import (
     MaxNormLinear,
     SafeLog,
     SqueezeAndExcitation,
-    TDSConv2dBlock,
     TDSConvEncoder,
-    TDSFullyConnectedBlock,
     TimeDistributed,
 )
 
@@ -43,16 +41,6 @@ from braindecode.modules import (
 @pytest.mark.parametrize(
     "module_factory",
     [
-        lambda time_first: TDSConv2dBlock(
-            channels=3,
-            width=4,
-            kernel_width=3,
-            time_first=time_first,
-        ),
-        lambda time_first: TDSFullyConnectedBlock(
-            num_features=12,
-            time_first=time_first,
-        ),
         lambda time_first: TDSConvEncoder(
             num_features=12,
             block_channels=(3, 4),

--- a/test/unit_tests/models/test_modules.py
+++ b/test/unit_tests/models/test_modules.py
@@ -8,6 +8,7 @@ from warnings import catch_warnings, simplefilter
 import numpy as np
 import pytest
 import torch
+from einops import rearrange
 from mne.filter import create_filter
 from mne.time_frequency import psd_array_welch
 from scipy.signal import fftconvolve as fftconvolve_scipy
@@ -32,8 +33,60 @@ from braindecode.modules import (
     MaxNormLinear,
     SafeLog,
     SqueezeAndExcitation,
+    TDSConv2dBlock,
+    TDSConvEncoder,
+    TDSFullyConnectedBlock,
     TimeDistributed,
 )
+
+
+@pytest.mark.parametrize(
+    "module_factory",
+    [
+        lambda time_first: TDSConv2dBlock(
+            channels=3,
+            width=4,
+            kernel_width=3,
+            time_first=time_first,
+        ),
+        lambda time_first: TDSFullyConnectedBlock(
+            num_features=12,
+            time_first=time_first,
+        ),
+        lambda time_first: TDSConvEncoder(
+            num_features=12,
+            block_channels=(3, 4),
+            kernel_width=3,
+            time_first=time_first,
+        ),
+    ],
+)
+def test_tds_blocks_layouts_and_torchscript(module_factory):
+    """Both supported layouts are numerically equivalent and scriptable."""
+    torch.manual_seed(0)
+    time_first = module_factory(True).eval()
+    batch_first = module_factory(False).eval()
+    batch_first.load_state_dict(time_first.state_dict())
+
+    time_first_inputs = torch.randn(11, 2, 12)
+    batch_first_inputs = rearrange(
+        time_first_inputs, "time batch features -> batch features time"
+    )
+
+    time_first_output = time_first(time_first_inputs)
+    expected = rearrange(
+        time_first_output, "time batch features -> batch features time"
+    )
+    actual = batch_first(batch_first_inputs)
+
+    assert torch.allclose(actual, expected)
+    assert torch.allclose(
+        torch.jit.script(time_first)(time_first_inputs), time_first_output
+    )
+    assert torch.allclose(
+        torch.jit.script(batch_first)(batch_first_inputs),
+        actual,
+    )
 
 
 def old_maxnorm(


### PR DESCRIPTION
## Summary

Extract the reusable support pieces needed by the sEMG pose baselines into a focused prerequisite PR:

- centralize output-head replacement in `EEGModuleMixin`
- expose one scriptable TDS encoder reused by EMG2Qwerty and VEMG2Pose
- migrate Dance and EMG2Qwerty to the shared implementations
- add focused module tests

This is the support layer for #1132. Keeping it separate lets #1132 contain the three pose models and their model-specific integration only.

## Verification

- `python -m pytest test/unit_tests/models/test_modules.py -q` (206 passed)
- `python -m pytest test/unit_tests/models/test_models.py -k emg2qwerty -q` (8 passed)
- `python -m pytest test/unit_tests/models/test_models.py -k dance -q` (2 passed)
- pre-commit on all changed files