### PR TITLE
ci: make stable releases PR-driven

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -1,36 +1,10 @@
-name: Monthly stable release to PyPI
+name: Prepare monthly stable release PR
 
-# Cuts a stable braindecode release on the 1st of every month, alongside the
-# per-push ``.devN`` releases produced by ``.github/workflows/release.yml``.
-#
-# ``master`` is protected by a ruleset that requires all changes to go through
-# a pull request, and the GitHub Actions app cannot be granted a ruleset
-# bypass on this org-owned repo. So this workflow never pushes to ``master``.
-# Instead it:
-#   1. Finalizes the version in the runner's working tree (no master push).
-#   2. Pushes ONLY the annotated tag ``vX.Y.Z`` (tags are not covered by the
-#      branch ruleset) — this is the source-of-truth for the release.
-#   3. Builds + ``twine check`` + publishes the sdist/wheel to PyPI.
-#   4. Creates a GitHub Release on the tag.
-#   5. Opens a pull request that bumps ``version.py`` to the next ``dev0``
-#      cycle and dates the changelog heading, for a maintainer to merge.
-#
-# The tag is pushed BEFORE the PyPI publish: PyPI uploads are irrevocable, so
-# a tag-push failure must stop the run before any PyPI side effect. A publish
-# failure after a successful tag push is recoverable via ``twine upload`` from
-# the uploaded ``dist-*`` artifact.
-#
-# Requirements:
-#   - ``PYPI_API_TOKEN`` secret (shared with the dev-release workflow).
-#   - Note: the bump PR is opened with the default ``GITHUB_TOKEN``, so by
-#     GitHub policy its ``pull_request`` event does NOT trigger the PR CI
-#     workflows (tests, whats-new check). A maintainer can kick CI by pushing
-#     an empty commit to the PR branch (or just merge it — no status check is
-#     required by the ruleset).
+# Build and validate a stable release, then open a PR with the finalized
+# version and changelog. Merging that PR is the only stable-publish trigger.
 
 on:
   schedule:
-    # 09:00 UTC on the 1st of every month. Adjust freely; cron is in UTC.
     - cron: "0 9 1 * *"
   workflow_dispatch:
     inputs:
@@ -39,33 +13,24 @@ on:
         required: true
         type: choice
         default: minor
-        options:
-          - minor
-          - patch
-          - major
+        options: [minor, patch, major]
       dry_run:
-        description: "Build everything but do not publish, tag, or open the bump PR"
+        description: "Build everything but do not open a release PR"
         required: false
         type: boolean
         default: false
 
 permissions:
-  contents: write        # push the tag, create the GitHub Release
-  pull-requests: write   # open the version-bump PR
-  id-token: write        # reserved for future PyPI Trusted Publishing migration
+  contents: write
+  pull-requests: write
 
 jobs:
   release:
-    # Belt-and-suspenders so a fork running this on schedule does not try to
-    # publish to the official PyPI project.
     if: github.repository == 'braindecode/braindecode'
     runs-on: ubuntu-latest
-    # Share the lock with the dev-release workflow so the two cannot
-    # interleave a ``.devN`` publish in the middle of a stable cut.
     concurrency:
       group: pypi-publish
       cancel-in-progress: false
-
     env:
       BUMP: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.bump || 'minor' }}
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && 'true' || 'false' }}
@@ -81,7 +46,7 @@ jobs:
 
       - name: Configure Git identity
         run: |
-          git config user.name  "github-actions[bot]"
+          git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Set up Python
@@ -99,46 +64,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python scripts/monthly_release.py compute --bump "$BUMP" \
-            | tee -a "$GITHUB_OUTPUT"
+          python scripts/monthly_release.py compute --bump "$BUMP" | tee -a "$GITHUB_OUTPUT"
 
       - name: Skip if no commits since last tag
         id: changes
         shell: bash
         run: |
           set -euo pipefail
-          # Match only ``vMAJOR.MINOR.PATCH`` style tags so that scratch
-          # tags (``v9.9.9-test``) and pre-releases (``v2.0.0rc1``) cannot
-          # become the comparison base and corrupt the skip decision.
           LAST_TAG="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n1 || true)"
-          if [[ -z "$LAST_TAG" ]]; then
-            echo "no previous v* tag found; proceeding with first release"
+          if [[ -z "$LAST_TAG" ]] || [[ "$(git rev-list "${LAST_TAG}..HEAD" --count)" -gt 0 ]]; then
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          COMMITS_AHEAD="$(git rev-list "${LAST_TAG}..HEAD" --count)"
-          echo "${COMMITS_AHEAD} commits since ${LAST_TAG}"
-          if [[ "${COMMITS_AHEAD}" -eq 0 ]]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
           else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Finalize release in tree
         if: steps.changes.outputs.skip != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          # ``finalize`` does not take ``--bump``: the release version is
-          # derived from the current dev seed and is independent of bump kind.
-          python scripts/monthly_release.py finalize
-          git add braindecode/version.py docs/whats_new.rst
-          git commit -m "release: ${{ steps.ver.outputs.release_tag }}"
-          # Annotated tag on the finalized commit. The commit lives only at the
-          # tag (it is never pushed to master); the version-bump PR carries the
-          # equivalent changelog/version housekeeping onto master separately.
-          git tag -a "${{ steps.ver.outputs.release_tag }}" \
-            -m "braindecode ${{ steps.ver.outputs.release_version }}"
+        run: python scripts/monthly_release.py finalize
 
       - name: Build sdist and wheel
         if: steps.changes.outputs.skip != 'true'
@@ -154,63 +96,33 @@ jobs:
           path: dist/
           if-no-files-found: error
 
-      # Push the tag BEFORE PyPI publish (see header). Tags are not covered by
-      # the branch ruleset, so this succeeds with the default GITHUB_TOKEN.
-      - name: Push release tag
+      - name: Open stable release pull request
         if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          git push origin "refs/tags/${{ steps.ver.outputs.release_tag }}"
-
-      - name: Publish to PyPI
-        if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-
-      - name: Create GitHub Release
-        if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ steps.ver.outputs.release_tag }}
-          name: braindecode ${{ steps.ver.outputs.release_version }}
-          generate_release_notes: true
-          files: dist/*
-
-      # master is PR-protected, so the version bump cannot be pushed directly.
-      # Open it as a PR branched fresh from master: date the just-released
-      # changelog heading (finalize) and seed the next dev cycle (next-dev).
-      - name: Open version-bump pull request
-        if: steps.changes.outputs.skip != 'true' && env.DRY_RUN != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          BRANCH="chore/bump-after-${{ steps.ver.outputs.release_tag }}"
-          git checkout -B "$BRANCH" origin/master
+          BRANCH="release/${{ steps.ver.outputs.release_tag }}"
+          if git ls-remote --exit-code --heads origin "$BRANCH"; then
+            echo "release branch $BRANCH already exists"
+            exit 0
+          fi
+          git checkout -b "$BRANCH" origin/master
           python scripts/monthly_release.py finalize
-          python scripts/monthly_release.py next-dev --bump "$BUMP"
           git add braindecode/version.py docs/whats_new.rst
-          git commit -m "chore: bump version to ${{ steps.ver.outputs.next_dev_version }} after ${{ steps.ver.outputs.release_tag }}"
-          git push -u origin "$BRANCH" --force-with-lease
-          # Body via a quoted heredoc so backticks stay literal and newlines
-          # render. The double-brace placeholders are substituted by Actions
-          # before bash runs (do not write an empty expression here -- Actions
-          # parses expressions even inside shell comments and heredocs).
+          git commit -m "release: ${{ steps.ver.outputs.release_tag }}"
+          git push -u origin "$BRANCH"
           cat > /tmp/pr_body.md <<'BODY'
-          Automated post-release housekeeping for ${{ steps.ver.outputs.release_tag }} (published to PyPI).
+          Validated stable release for ${{ steps.ver.outputs.release_tag }}.
 
-          - Date the `Current ${{ steps.ver.outputs.release_version }} (GitHub)` changelog heading.
-          - Seed the next development cycle: `version.py` -> `${{ steps.ver.outputs.next_dev_version }}` plus a fresh `Current ${{ steps.ver.outputs.next_dev_base }} (GitHub)` section.
-
-          Note: opened by GITHUB_TOKEN, so PR CI does not auto-run. Push an empty commit to trigger it, or merge directly (no status check is required by the ruleset).
+          - Finalize `version.py` as `${{ steps.ver.outputs.release_version }}`.
+          - Date the matching changelog heading.
+          - Merging this PR tags, publishes, and creates the GitHub Release.
           BODY
           gh pr create \
             --base master \
             --head "$BRANCH" \
-            --title "chore: bump version to ${{ steps.ver.outputs.next_dev_version }} after ${{ steps.ver.outputs.release_tag }}" \
-            --body-file /tmp/pr_body.md \
-            || echo "gh pr create failed (a PR for $BRANCH may already exist); branch is pushed regardless."
+            --title "release: ${{ steps.ver.outputs.release_tag }}" \
+            --body-file /tmp/pr_body.md
 
       - name: Summarize run
         if: always()
@@ -222,10 +134,9 @@ jobs:
             echo "| Field | Value |"
             echo "| ----- | ----- |"
             echo "| Current dev | \`${{ steps.ver.outputs.current_version || 'n/a' }}\` |"
-            echo "| Released    | \`${{ steps.ver.outputs.release_version || 'n/a' }}\` |"
-            echo "| Tag         | \`${{ steps.ver.outputs.release_tag || 'n/a' }}\` |"
-            echo "| Next dev    | \`${{ steps.ver.outputs.next_dev_version || 'n/a' }}\` |"
-            echo "| Bump        | \`${BUMP}\` |"
-            echo "| Dry run     | \`${DRY_RUN}\` |"
-            echo "| Skipped     | \`${{ steps.changes.outputs.skip || 'n/a' }}\` |"
+            echo "| Release | \`${{ steps.ver.outputs.release_version || 'n/a' }}\` |"
+            echo "| Tag | \`${{ steps.ver.outputs.release_tag || 'n/a' }}\` |"
+            echo "| Next dev | \`${{ steps.ver.outputs.next_dev_version || 'n/a' }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
+            echo "| Skipped | \`${{ steps.changes.outputs.skip || 'n/a' }}\` |"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,43 @@
-name: Publish to PyPI on main updates
+name: Publish packages on main updates
 
 on:
   push:
     branches: [master]
 
 jobs:
-  publish:
+  classify:
     runs-on: ubuntu-latest
-    # Skip the per-commit ``.devN`` publish when the head commit is the stable
-    # release commit produced by ``.github/workflows/monthly-release.yml``.
-    # At that commit, ``braindecode/version.py`` is ``X.Y.Z`` (no ``.dev``),
-    # and running this job would otherwise push ``X.Y.Z.devN`` to PyPI right
-    # after the stable ``X.Y.Z``. The companion ``chore: bump version`` commit
-    # is intentionally NOT excluded — it kicks off the next dev cycle.
-    if: "${{ !startsWith(github.event.head_commit.message, 'release: v') }}"
+    permissions:
+      contents: read
+    outputs:
+      stable: ${{ steps.version.outputs.stable }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: pip install packaging
+      - name: Classify package version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          from packaging.version import Version
+          from scripts.monthly_release import read_version
+
+          version = Version(read_version("braindecode/version.py"))
+          if version.is_prerelease or version.is_postrelease or version.local:
+              raise SystemExit(f"unsupported release version: {version}")
+          print(f"version={version}")
+          print(f"stable={'false' if version.is_devrelease else 'true'}")
+          PY
+
+  publish-dev:
+    needs: classify
+    if: needs.classify.outputs.stable != 'true'
+    runs-on: ubuntu-latest
     concurrency:
       group: pypi-publish
       cancel-in-progress: false
@@ -21,55 +45,40 @@ jobs:
       contents: read
     env:
       PYPI_USERNAME: __token__
-
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install build deps
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
           pip install build packaging
 
-      # Figure out if this push is a merged PR or a direct push
-      - name: Derive version suffix (PR number if merged, else short SHA)
+      - name: Derive version suffix
         id: ver
         shell: bash
         run: |
           set -euo pipefail
           COMMIT_MSG="$(git log -1 --pretty=%B)"
           if [[ "$COMMIT_MSG" =~ Merge\ pull\ request\ \#([0-9]+) ]]; then
-            echo "suffix=pr${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
             echo "pr_number=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-            echo "Detected merged PR #${BASH_REMATCH[1]}"
           else
-            SHORT_SHA="$(git rev-parse --short HEAD)"
-            echo "suffix=sha${SHORT_SHA}" >> "$GITHUB_OUTPUT"
-            echo "Detected direct push (no PR); using ${SHORT_SHA}"
+            echo "suffix=sha$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
           fi
 
-      # Use your script, passing PR number when present, otherwise a SHA-based suffix
-      - name: Bump version
+      - name: Seed the dev package version
         shell: bash
         run: |
           set -euo pipefail
           if [[ -n "${{ steps.ver.outputs.pr_number || '' }}" ]]; then
-            python scripts/release_script.py \
-              --init-file braindecode/version.py \
-              --pr "${{ steps.ver.outputs.pr_number }}"
+            python scripts/release_script.py --pr "${{ steps.ver.outputs.pr_number }}"
           else
-            # Fallback path must be supported by your script; if not, change the script
-            # to accept --pr and append a compliant .devN/.postN label.
-            python scripts/release_script.py \
-              --init-file braindecode/version.py \
-              --suffix "${{ steps.ver.outputs.suffix }}"
+            python scripts/release_script.py --suffix "${{ steps.ver.outputs.suffix }}"
           fi
 
       - name: Build sdist and wheel
@@ -79,3 +88,85 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-stable:
+    needs: classify
+    if: needs.classify.outputs.stable == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pypi-publish
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build packaging twine
+
+      - name: Build and validate stable package
+        run: |
+          python -m build
+          python -m twine check --strict dist/*
+
+      - name: Push stable release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="v${{ needs.classify.outputs.version }}"
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG"; then
+            echo "ERROR: $TAG already exists" >&2
+            exit 1
+          fi
+          git tag -a "$TAG" -m "braindecode ${{ needs.classify.outputs.version }}"
+          git push origin "refs/tags/$TAG"
+
+      - name: Publish stable package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.classify.outputs.version }}
+          name: braindecode ${{ needs.classify.outputs.version }}
+          generate_release_notes: true
+          files: dist/*
+
+      - name: Open next-development pull request
+        shell: bash
+        run: |
+          set -euo pipefail
+          BRANCH="chore/bump-after-v${{ needs.classify.outputs.version }}"
+          if git ls-remote --exit-code --heads origin "$BRANCH"; then
+            echo "next-development branch $BRANCH already exists"
+            exit 0
+          fi
+          git checkout -b "$BRANCH" origin/master
+          python scripts/monthly_release.py next-dev --bump minor
+          git add braindecode/version.py docs/whats_new.rst
+          git commit -m "chore: bump version to ${{ needs.classify.outputs.version }} after release"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --base master \
+            --head "$BRANCH" \
+            --title "chore: bump version after v${{ needs.classify.outputs.version }}" \
+            --body "Automated post-release development-version bump."

--- a/docs/superpowers/specs/2026-08-31-pr-driven-release-design.md
+++ b/docs/superpowers/specs/2026-08-31-pr-driven-release-design.md
@@ -1,0 +1,44 @@
+# PR-driven stable releases
+
+## Goal
+
+Make each stable release reviewable as a pull request before any tag, PyPI
+upload, or GitHub Release is created.
+
+## Flow
+
+1. The scheduled or manually dispatched monthly workflow computes the release
+   from the current development version, finalizes the version and changelog on
+   a `release/vX.Y.Z` branch, builds the distribution, runs `twine check`, and
+   opens a release PR.  It never publishes.
+2. Merging a release PR with commit subject `release: vX.Y.Z` triggers the
+   stable-publish path on `master`.  That path verifies the tag is absent,
+   builds and validates the exact merged source, pushes the annotated tag
+   before uploading to PyPI, then creates the GitHub Release.
+3. After a successful stable publish, that same workflow opens the existing
+   next-development PR.  It runs `next-dev` only because the merged release PR
+   already dated the changelog.
+4. All other pushes to `master` retain the existing `.devN` PyPI publishing
+   path.
+
+## Scope
+
+Only `.github/workflows/monthly-release.yml` and
+`.github/workflows/release.yml` change.  `scripts/monthly_release.py` already
+provides the required `compute`, `finalize`, and `next-dev` operations.
+
+## Safety properties
+
+- The release tag is pushed before the irreversible PyPI upload.
+- A release PR merge is the only stable-publish trigger.
+- The scheduled workflow has no publishing permissions or publish step.
+- The existing `pypi-publish` concurrency group continues to serialize dev and
+  stable publication.
+
+## Verification
+
+- Parse both workflow YAML files.
+- Run the monthly workflow with `dry_run=true` to verify finalization, build,
+  and strict package validation without creating a branch or PR.
+- Review the generated release PR, merge it, and confirm the stable-publish
+  workflow creates the tag, PyPI release, GitHub Release, and next-dev PR.

--- a/test/test_release_workflows.py
+++ b/test/test_release_workflows.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_stable_release_is_pr_driven():
+    monthly = (ROOT / ".github/workflows/monthly-release.yml").read_text()
+    publish = (ROOT / ".github/workflows/release.yml").read_text()
+
+    assert "gh pr create" in monthly
+    assert "gh-action-pypi-publish" not in monthly
+    assert "is_devrelease" in publish
+    assert "Open next-development pull request" in publish


### PR DESCRIPTION
Stable releases are built and reviewed as pull requests. Merging a release PR tags and publishes the exact merged artifact, creates the GitHub Release, and opens the next-development PR.

Verification:
- `pytest test/test_release_workflows.py -q`
- `actionlint .github/workflows/monthly-release.yml .github/workflows/release.yml`
- YAML parse with Ruby stdlib
- `1.8.0dev0 -> 1.8.0 -> 1.9.0dev0` release-script transition