### PR TITLE
Add a Top-K sparse autoencoder over model activations

### DIFF
--- a/braindecode/visualization/__init__.py
+++ b/braindecode/visualization/__init__.py
@@ -24,12 +24,14 @@ from .metrics import (
     compute_metrics,
     compute_ssim_metrics,
 )
+from .sae import SparseAutoencoder
 from .sanity import cascading_layer_reset, random_target
 from .topology import project_to_topomap
 
 __all__ = [
     "METRIC_NAMES",
     "SSIM_METRIC_NAMES",
+    "SparseAutoencoder",
     "amplitude_gradients",
     "amplitude_gradients_per_trial",
     "capture_activations",

--- a/braindecode/visualization/sae.py
+++ b/braindecode/visualization/sae.py
@@ -1,0 +1,207 @@
+# Authors: Vandit Shah <shahvanditt@gmail.com>
+#
+# License: BSD (3-clause)
+
+"""Top-K sparse autoencoder over model activations."""
+
+from numbers import Integral
+
+import torch
+from torch import nn
+
+
+class SparseAutoencoder(nn.Module):
+    """Top-K sparse autoencoder over activation vectors.
+
+    Re-expresses an activation as a sparse combination of
+    ``n_inputs * expansion`` learned directions. Only the ``k`` largest
+    encoder outputs are kept and the rest are zeroed [1]_, so sparsity is
+    structural rather than traded against reconstruction error through an
+    L1 coefficient.
+
+    The encoder is rectified and its weights are untied from the decoder,
+    whose columns are held at unit norm [2]_. Without the unit-norm
+    constraint the reconstruction can be improved by shrinking the code and
+    growing the decoder, which leaves feature magnitudes uninterpretable.
+    The rectifier is applied before the mask, so ``k`` bounds the number of
+    active features rather than fixing it.
+
+    Following [2]_ the input and output biases are tied: the decoder bias is
+    subtracted before encoding and added back on decode, so the module
+    computes ``ReLU(W_enc (x - b_dec) + b_enc)`` and ``W_dec z + b_dec``.
+
+    Parameters
+    ----------
+    n_inputs : int
+        Width of the activation vectors, i.e. the embedding dimension of the
+        layer being decomposed.
+    expansion : int, default=8
+        Dictionary size relative to ``n_inputs``. The autoencoder learns
+        ``n_inputs * expansion`` features.
+    k : int or None, default=None
+        Number of features kept per input. Defaults to ``8 * expansion``,
+        which holds the active fraction constant as the dictionary grows,
+        capped at ``n_inputs * expansion`` so the default is always valid.
+
+    Raises
+    ------
+    ValueError
+        If ``n_inputs``, ``expansion`` or ``k`` is not a positive integer, or
+        if ``k`` exceeds ``n_inputs * expansion``.
+
+    Notes
+    -----
+    ``activation_mean`` and ``activation_std`` are registered buffers, so the
+    standardisation used at fit time survives a ``state_dict`` round trip.
+    They default to zero and one until
+    :meth:`set_activation_normalization` is called.
+
+    References
+    ----------
+    .. [1] Makhzani, A., & Frey, B. (2014). k-Sparse Autoencoders.
+       International Conference on Learning Representations (ICLR).
+       Online: https://arxiv.org/abs/1312.5663
+    .. [2] Bricken, T., Templeton, A., Batson, J., et al. (2023). Towards
+       Monosemanticity: Decomposing Language Models With Dictionary
+       Learning. Transformer Circuits Thread.
+       Online: https://transformer-circuits.pub/2023/monosemantic-features
+    """
+
+    def __init__(self, n_inputs, expansion=8, k=None):
+        super().__init__()
+        for name, value in (("n_inputs", n_inputs), ("expansion", expansion)):
+            if isinstance(value, bool) or not isinstance(value, Integral) or value < 1:
+                raise ValueError(f"{name} must be a positive integer, got {value!r}")
+        self.n_inputs = int(n_inputs)
+        self.expansion = int(expansion)
+        self.n_features = self.n_inputs * self.expansion
+        k = min(self.n_features, 8 * self.expansion) if k is None else k
+        if (
+            isinstance(k, bool)
+            or not isinstance(k, Integral)
+            or not 1 <= k <= self.n_features
+        ):
+            raise ValueError(
+                f"k must be an integer in [1, {self.n_features}], got {k!r}"
+            )
+        self.k = int(k)
+        self.encoder = nn.Linear(self.n_inputs, self.n_features)
+        self.decoder = nn.Linear(self.n_features, self.n_inputs)
+        self.register_buffer("activation_mean", torch.zeros(self.n_inputs))
+        self.register_buffer("activation_std", torch.ones(self.n_inputs))
+        self.normalize_decoder_()
+
+    def encode(self, x):
+        """Encode standardised activations into a sparse feature code.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Standardised activations of shape ``(..., n_inputs)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Feature code of shape ``(..., n_features)`` with at most ``k``
+            non-zero entries per activation. Fewer than ``k`` fire when
+            fewer than ``k`` encoder outputs are positive.
+        """
+        if x.shape[-1] != self.n_inputs:
+            raise ValueError(
+                f"expected last dimension {self.n_inputs}, got {x.shape[-1]}"
+            )
+        hidden = torch.relu(self.encoder(x - self.decoder.bias))
+        values, indices = torch.topk(hidden, self.k, dim=-1)
+        return torch.zeros_like(hidden).scatter_(-1, indices, values)
+
+    def decode(self, z):
+        """Decode a sparse feature code back to standardised activations.
+
+        Parameters
+        ----------
+        z : torch.Tensor
+            Feature code of shape ``(..., n_features)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Reconstruction of shape ``(..., n_inputs)``.
+        """
+        if z.shape[-1] != self.n_features:
+            raise ValueError(
+                f"expected last dimension {self.n_features}, got {z.shape[-1]}"
+            )
+        return self.decoder(z)
+
+    def forward(self, x):
+        """Encode and decode standardised activations.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Standardised activations of shape ``(..., n_inputs)``.
+
+        Returns
+        -------
+        recon : torch.Tensor
+            Reconstruction of shape ``(..., n_inputs)``.
+        latent : torch.Tensor
+            Feature code of shape ``(..., n_features)``.
+        """
+        latent = self.encode(x)
+        return self.decode(latent), latent
+
+    def normalize_decoder_(self):
+        """Rescale decoder columns to unit norm, in place."""
+        with torch.no_grad():
+            weight = self.decoder.weight
+            weight.div_(weight.norm(dim=0, keepdim=True).clamp_min(1e-12))
+
+    def set_activation_normalization(self, mean, std):
+        """Store the per-dimension statistics used to standardise activations.
+
+        Parameters
+        ----------
+        mean : array-like
+            Per-dimension mean, of shape ``(n_inputs,)``.
+        std : array-like
+            Per-dimension standard deviation, of shape ``(n_inputs,)``. Must
+            be finite and strictly positive.
+
+        Raises
+        ------
+        ValueError
+            If either argument has the wrong shape or holds a non-finite
+            value, or if any standard deviation is not strictly positive.
+        """
+        mean = torch.as_tensor(mean, dtype=self.activation_mean.dtype)
+        std = torch.as_tensor(std, dtype=self.activation_std.dtype)
+        if mean.shape != (self.n_inputs,) or std.shape != (self.n_inputs,):
+            raise ValueError(
+                f"mean and std must both have shape ({self.n_inputs},), got "
+                f"{tuple(mean.shape)} and {tuple(std.shape)}"
+            )
+        if not (torch.isfinite(mean).all() and torch.isfinite(std).all()):
+            raise ValueError("mean and std must be finite")
+        if not (std > 0).all():
+            raise ValueError("std must be strictly positive")
+        with torch.no_grad():
+            self.activation_mean.copy_(mean.to(self.activation_mean.device))
+            self.activation_std.copy_(std.to(self.activation_std.device))
+
+    def reconstruct_activations(self, x):
+        """Reconstruct raw activations, standardising and inverting internally.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Raw activations of shape ``(..., n_inputs)``, on the scale the
+            layer emits.
+
+        Returns
+        -------
+        torch.Tensor
+            Reconstruction of the same shape, on the same scale.
+        """
+        z = self.encode((x - self.activation_mean) / self.activation_std)
+        return self.decode(z) * self.activation_std + self.activation_mean

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -913,6 +913,17 @@ removed even when the forward pass raises.
      capture_activations
      run_with_activation_substitution
 
+Sparse Autoencoders
+===================
+
+Decompose a layer's activations into a sparse combination of learned directions,
+keeping only the largest few per activation.
+
+.. autosummary::
+    :toctree: generated/
+
+     SparseAutoencoder
+
 Topography
 ==========
 

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -69,6 +69,10 @@ Enhancements
   replace a submodule's output during a forward pass
   (:gh:`1138` by `Vandit Shah`_)
 
+- Add :class:`braindecode.visualization.SparseAutoencoder`, a Top-K sparse
+  autoencoder that decomposes a layer's activations into a sparse combination of
+  learned directions (:gh:`1152` by `Vandit Shah`_)
+
 - Preserve the recording-local row of each canonical MNE annotation as
   ``i_trial_in_dataset`` in event-window metadata, keeping it aligned with
   targets and annotation extras through event mapping, duration filtering,

--- a/test/unit_tests/visualization/test_sae.py
+++ b/test/unit_tests/visualization/test_sae.py
@@ -1,0 +1,129 @@
+import pytest
+import torch
+
+from braindecode.visualization import SparseAutoencoder
+
+N_INPUTS = 4
+EXPANSION = 2
+K = 3
+
+
+def _sae():
+    return SparseAutoencoder(n_inputs=N_INPUTS, expansion=EXPANSION, k=K).eval()
+
+
+def test_encode_keeps_at_most_k_and_preserves_leading_dims():
+    sae = _sae()
+    z = sae.encode(torch.randn(2, 5, N_INPUTS))
+
+    assert z.shape == (2, 5, N_INPUTS * EXPANSION)
+    assert ((z != 0).sum(-1) <= K).all()
+
+
+def test_relu_can_leave_fewer_than_k_active():
+    """The rectifier binds before the mask, so ``k`` is a bound, not a count."""
+    sae = _sae()
+    with torch.no_grad():
+        sae.encoder.bias.fill_(-50.0)
+
+    z = sae.encode(torch.randn(6, N_INPUTS))
+
+    assert (z == 0).all()
+
+
+def test_the_decoder_bias_is_subtracted_before_encoding():
+    """The input and output biases are tied, so shifting one cancels it."""
+    sae = _sae()
+    x = torch.randn(6, N_INPUTS)
+    with torch.no_grad():
+        sae.decoder.bias.zero_()
+    baseline = sae.encode(x)
+
+    shift = torch.arange(1.0, N_INPUTS + 1.0)
+    with torch.no_grad():
+        sae.decoder.bias.copy_(shift)
+
+    torch.testing.assert_close(sae.encode(x + shift), baseline)
+
+
+def test_gradients_reach_the_selected_features_and_no_others():
+    """A mask that dropped the gradient would leave the encoder untrainable."""
+    sae = _sae()
+    with torch.no_grad():
+        sae.encoder.bias.fill_(10.0)
+        sae.decoder.weight.fill_(1.0)
+        sae.normalize_decoder_()
+
+    recon, latent = sae(torch.ones(1, N_INPUTS))
+    recon.sum().backward()
+
+    fired = latent[0] != 0
+    assert fired.sum() == K
+    assert torch.equal(sae.encoder.weight.grad.abs().sum(dim=1) != 0, fired)
+
+
+def test_decoder_columns_are_unit_norm():
+    sae = _sae()
+    norms = sae.decoder.weight.norm(dim=0)
+
+    torch.testing.assert_close(norms, torch.ones_like(norms))
+
+
+def test_reconstruct_activations_applies_the_stored_statistics():
+    """Feeding the mean itself standardises to zero, pinning both directions.
+
+    The expected code comes from encoding zeros, so it is wrong if the input
+    is not standardised on the way in, and the expected scale is wrong if the
+    reconstruction is not de-standardised on the way out.
+    """
+    sae = _sae()
+    mean = torch.arange(1.0, N_INPUTS + 1.0)
+    std = torch.full((N_INPUTS,), 2.0)
+    sae.set_activation_normalization(mean, std)
+
+    out = sae.reconstruct_activations(mean.expand(6, N_INPUTS))
+
+    expected = sae.decode(sae.encode(torch.zeros(6, N_INPUTS))) * std + mean
+    torch.testing.assert_close(out, expected)
+    # Buffers, not plain attributes: a saved autoencoder that lost these would
+    # reload with mean 0 and std 1 and reconstruct wrongly without erroring.
+    assert {"activation_mean", "activation_std"} <= set(sae.state_dict())
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        (dict(n_inputs=True), "n_inputs must be a positive integer"),
+        (dict(n_inputs=0), "n_inputs must be a positive integer"),
+        (dict(k=True), "k must be an integer"),
+        (dict(k=2.0), "k must be an integer"),
+        (dict(k=N_INPUTS * EXPANSION + 1), "k must be an integer"),
+    ],
+)
+def test_constructor_rejects_unusable_dimensions(kwargs, match):
+    """``int(True)`` is 1, so a bool would otherwise be silently accepted."""
+    with pytest.raises(ValueError, match=match):
+        SparseAutoencoder(**{"n_inputs": N_INPUTS, "expansion": EXPANSION, **kwargs})
+
+
+@pytest.mark.parametrize(
+    "method, width", [("encode", N_INPUTS), ("decode", N_INPUTS * EXPANSION)]
+)
+def test_wrong_width_names_the_expected_dimension(method, width):
+    sae = _sae()
+    with pytest.raises(ValueError, match=f"expected last dimension {width}"):
+        getattr(sae, method)(torch.randn(6, width + 1))
+
+
+@pytest.mark.parametrize(
+    "mean, std, match",
+    [
+        (torch.zeros(N_INPUTS + 1), torch.ones(N_INPUTS), "must both have shape"),
+        (torch.full((N_INPUTS,), float("nan")), torch.ones(N_INPUTS), "must be finite"),
+        (torch.zeros(N_INPUTS), torch.zeros(N_INPUTS), "strictly positive"),
+    ],
+)
+def test_activation_normalization_rejects_unusable_statistics(mean, std, match):
+    """A zero standard deviation would divide a constant dimension to infinity."""
+    with pytest.raises(ValueError, match=match):
+        _sae().set_activation_normalization(mean, std)


### PR DESCRIPTION
Adds `SparseAutoencoder` to `braindecode.visualization`: a Top-K sparse autoencoder over a layer's activations. It encodes an activation into `n_inputs * expansion` features, keeps the `k` largest rectified encoder outputs, and decodes back. Decoder columns are constrained to unit norm, and the input and output biases are tied.

This is item 2 of the split @bruAristimunha requested in #1120: the core module and its tests only, with no optimizer, dead-feature resampling, diagnostics, splitter, gallery, or data runner.

The implementation is based exclusively on these two publications:

- [Makhzani & Frey (2014), *k-Sparse Autoencoders*](https://arxiv.org/abs/1312.5663) — top-k feature selection.
- [Bricken et al. (2023), *Towards Monosemanticity*](https://transformer-circuits.pub/2023/monosemantic-features) — rectified encoder, tied input/output bias, and unit-norm decoder columns.

`activation_mean` and `activation_std` are registered buffers, so the standardization parameters used at fit time survive a `state_dict` round trip. `reconstruct_activations` is shaped to pass directly to `run_with_activation_substitution` from #1138.

Tests are in `test/unit_tests/visualization/test_sae.py` - 9 tests, 16 cases, ~2 s. They cover the sparsity bound, rectifier, tied bias, gradient flow only through selected features, unit-norm decoder columns, standardization round trip, and input contracts.

Placed in `visualization/` following #1138.