### PR TITLE
Fix CombinedConv bias folding when a dimension is 1

### DIFF
--- a/braindecode/modules/convolution.py
+++ b/braindecode/modules/convolution.py
@@ -191,11 +191,13 @@ class CombinedConv(nn.Module):
             time_bias = self.conv_time.bias
             if time_bias is None:
                 raise RuntimeError("conv_time.bias is None despite bias_time=True")
+            # squeeze only the singleton kernel dimension: a bare squeeze() also
+            # drops n_filters_spat / n_filters_time / in_chans when they are 1
             calculated_bias = (
-                self.conv_spat.weight.squeeze()
+                self.conv_spat.weight.squeeze(2)
                 .sum(-1)
                 .mm(time_bias.unsqueeze(-1))
-                .squeeze()
+                .squeeze(-1)
             )
         if self.bias_spat:
             spat_bias = self.conv_spat.bias

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -33,6 +33,15 @@ Enhancements
   :class:`braindecode.models.SensingDynamics` for dense hand-pose
   regression from surface EMG (:gh:`1132` by `Bruno Aristimunha`_).
 
+Bug fixes
+==========
+
+- Fix :class:`braindecode.modules.CombinedConv` raising ``RuntimeError: self
+  must be a matrix`` when ``in_chans``, ``n_filters_time`` or ``n_filters_spat``
+  is 1, which made :class:`braindecode.models.ShallowFBCSPNet` and
+  :class:`braindecode.models.Deep4Net` unusable on single-channel data. By
+  `Julien Gadonneix`_.
+
 
 Current 1.8.0 (2026-08-31)
 ===============================
@@ -1717,3 +1726,4 @@ Authors
 .. _Jon Huml: https://github.com/jonathanhuml
 .. _Azra Bano: https://github.com/azrabano23
 .. _Aditya Singh: https://github.com/adityasingh2400
+.. _Julien Gadonneix: https://github.com/julien-gadonneix

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -39,8 +39,8 @@ Bug fixes
 - Fix :class:`braindecode.modules.CombinedConv` raising ``RuntimeError: self
   must be a matrix`` when ``in_chans``, ``n_filters_time`` or ``n_filters_spat``
   is 1, which made :class:`braindecode.models.ShallowFBCSPNet` and
-  :class:`braindecode.models.Deep4Net` unusable on single-channel data. By
-  `Julien Gadonneix`_.
+  :class:`braindecode.models.Deep4Net` unusable on single-channel data
+  (:gh:`1154` by `Julien Gadonneix`_).
 
 
 Current 1.8.0 (2026-08-31)

--- a/test/unit_tests/models/test_modules.py
+++ b/test/unit_tests/models/test_modules.py
@@ -241,13 +241,22 @@ def test_dense_spatial_filter_forward_collapse_false():
 @pytest.mark.parametrize(
     "bias_time,bias_spat", [(False, False), (False, True), (True, False), (True, True)]
 )
-def test_combined_conv(bias_time, bias_spat):
+@pytest.mark.parametrize(
+    "in_chans,n_filters_time,n_filters_spat",
+    [(44, 40, 40), (1, 40, 40), (44, 40, 1), (44, 1, 1)],
+)
+def test_combined_conv(bias_time, bias_spat, in_chans, n_filters_time, n_filters_spat):
     batch_size = 64
-    in_chans = 44
     timepoints = 1000
 
     data = torch.rand([batch_size, 1, timepoints, in_chans])
-    conv = CombinedConv(in_chans=in_chans, bias_spat=bias_spat, bias_time=bias_time)
+    conv = CombinedConv(
+        in_chans=in_chans,
+        n_filters_time=n_filters_time,
+        n_filters_spat=n_filters_spat,
+        bias_spat=bias_spat,
+        bias_time=bias_time,
+    )
 
     combined_out = conv(data)
     sequential_out = conv.conv_spat(conv.conv_time(data))


### PR DESCRIPTION
`CombinedConv.forward` folds the time and spatial biases with

```python
self.conv_spat.weight.squeeze().sum(-1).mm(time_bias.unsqueeze(-1)).squeeze()
```

`conv_spat.weight` is `(n_filters_spat, n_filters_time, 1, in_chans)` and the bare `squeeze()` is only meant to drop the singleton kernel dimension. When `in_chans`, `n_filters_time` or `n_filters_spat` is also 1 it drops those too, so `sum(-1)` returns a vector and `mm` fails with `RuntimeError: self must be a matrix`.

This makes `ShallowFBCSPNet` and `Deep4Net` unusable on single-channel data:

```python
ShallowFBCSPNet(n_chans=1, n_times=1536, n_outputs=4)  # RuntimeError
```

Squeezing explicit dimensions (`squeeze(2)` and `squeeze(-1)`) fixes it. The output is unchanged wherever the current code works, and matches the sequential `conv_spat(conv_time(x))` reference in every case.

`test_combined_conv` is parametrized over the singleton shapes; it fails on master and passes here.

Made with [Cursor](https://cursor.com)