### PR TITLE
Fix FutureWarning for renamed standard montages on MNE >= 1.13

### DIFF
--- a/braindecode/augmentation/functional.py
+++ b/braindecode/augmentation/functional.py
@@ -1002,7 +1002,7 @@ def sensors_rotation(
         ``mne`` through::
 
          >>> ten_twenty_montage = mne.channels.make_standard_montage(
-         ...    'standard_1020'
+         ...    'standard_1020'  # 'colin27_1020' on MNE >= 1.13
          ... ).get_positions()['ch_pos']
     axis : 'x' | 'y' | 'z'
         Axis around which to rotate.

--- a/braindecode/augmentation/transforms.py
+++ b/braindecode/augmentation/transforms.py
@@ -13,6 +13,8 @@ import numpy as np
 import torch
 from mne.channels import make_standard_montage
 
+from braindecode.util import resolve_montage_name
+
 from .base import Transform
 from .functional import (
     amplitude_scale,
@@ -703,7 +705,7 @@ def _get_standard_10_20_positions(raw_or_epoch=None, ordered_ch_names=None):
     )
     if ordered_ch_names is None:
         ordered_ch_names = raw_or_epoch.info["ch_names"]
-    ten_twenty_montage = make_standard_montage("standard_1020")
+    ten_twenty_montage = make_standard_montage(resolve_montage_name("standard_1020"))
     positions_dict = ten_twenty_montage.get_positions()["ch_pos"]
     positions_subdict = {
         k: positions_dict[k] for k in ordered_ch_names if k in positions_dict
@@ -729,7 +731,7 @@ class SensorsRotation(Transform):
         `mne` through::
 
          >>> ten_twenty_montage = mne.channels.make_standard_montage(
-         ...    'standard_1020'
+         ...    'standard_1020'  # 'colin27_1020' on MNE >= 1.13
          ... ).get_positions()['ch_pos']
 
     axis : 'x' | 'y' | 'z', optional

--- a/braindecode/datasets/tuh.py
+++ b/braindecode/datasets/tuh.py
@@ -25,6 +25,7 @@ import pandas as pd
 from joblib import Parallel, delayed
 
 from braindecode.datasets.base import BaseConcatDataset, RawDataset
+from braindecode.util import resolve_montage_name
 
 
 class TUH(BaseConcatDataset):
@@ -182,7 +183,9 @@ class TUH(BaseConcatDataset):
         }
         raw.rename_channels(mapping_strip)
 
-        montage1005 = mne.channels.make_standard_montage("standard_1005")
+        montage1005 = mne.channels.make_standard_montage(
+            resolve_montage_name("standard_1005")
+        )
         mapping_eeg_names = {
             c.upper(): c for c in montage1005.ch_names if c.upper() in raw.ch_names
         }
@@ -207,7 +210,9 @@ class TUH(BaseConcatDataset):
 
     @staticmethod
     def _set_montage(raw):
-        montage = mne.channels.make_standard_montage("standard_1005")
+        montage = mne.channels.make_standard_montage(
+            resolve_montage_name("standard_1005")
+        )
         raw.set_montage(montage, on_missing="ignore")
 
     @staticmethod

--- a/braindecode/models/dgcnn.py
+++ b/braindecode/models/dgcnn.py
@@ -19,6 +19,7 @@ from sklearn.neighbors import kneighbors_graph
 
 from braindecode.models.base import EEGModuleMixin
 from braindecode.models.util import extract_channel_locations_from_chs_info
+from braindecode.util import resolve_montage_name
 
 
 class _GraphConvolution(nn.Module):
@@ -146,7 +147,9 @@ def _build_initial_adjacency(chs_info, n_chans, n_neighbors=5):
         # Try to infer positions from channel names via a standard montage
         try:
             ch_names = [ch["ch_name"] for ch in chs_info[:n_chans]]
-            montage = mne.channels.make_standard_montage("standard_1005")
+            montage = mne.channels.make_standard_montage(
+                resolve_montage_name("standard_1005")
+            )
             info = mne.create_info(ch_names=ch_names, sfreq=256, ch_types="eeg")
             info.set_montage(montage, on_missing="raise")
             electrode_positions = extract_channel_locations_from_chs_info(

--- a/braindecode/models/eegpt.py
+++ b/braindecode/models/eegpt.py
@@ -16,6 +16,7 @@ from braindecode.models.base import EEGModuleMixin
 from braindecode.modules import DropPath
 from braindecode.modules.convolution import Conv1dWithConstraint
 from braindecode.modules.linear import LinearWithConstraint
+from braindecode.util import resolve_montage_name
 
 
 class EEGPT(EEGModuleMixin, nn.Module):
@@ -494,7 +495,7 @@ _ALLOWED_CHANNELS = {
 
 
 def _get_eegpt_channels():
-    montage = mne.channels.make_standard_montage("standard_1020")
+    montage = mne.channels.make_standard_montage(resolve_montage_name("standard_1020"))
     return [ch.upper() for ch in montage.ch_names if ch.upper() in _ALLOWED_CHANNELS]
 
 
@@ -1449,7 +1450,7 @@ from mne.channels import make_standard_montage  # noqa: E402
 
 from braindecode.models.interpolated import InterpolatedModel  # noqa: E402
 
-montage = make_standard_montage("standard_1020")
+montage = make_standard_montage(resolve_montage_name("standard_1020"))
 ch_pos = {
     ch.upper(): (ch, loc) for ch, loc in montage.get_positions()["ch_pos"].items()
 }

--- a/braindecode/models/interpolated.py
+++ b/braindecode/models/interpolated.py
@@ -9,6 +9,7 @@ import numpy as np
 import torch.nn as nn
 
 from braindecode.modules.interpolation import ChannelInterpolationLayer
+from braindecode.util import resolve_montage_name
 
 
 def InterpolatedModel(
@@ -157,7 +158,9 @@ def _build_chs_info_from_montage(names: list[str], montage: str) -> list[dict]:
     names : list of str
         Channel names in the desired order.
     montage : str
-        Name of an MNE standard montage (e.g. ``"standard_1005"``).
+        Name of an MNE standard montage (e.g. ``"standard_1005"``, renamed to
+        ``"colin27_1005"`` in MNE >= 1.13; both spellings are accepted here
+        for any supported MNE version).
 
     Returns
     -------
@@ -170,7 +173,7 @@ def _build_chs_info_from_montage(names: list[str], montage: str) -> list[dict]:
     """
     import mne
 
-    mtg = mne.channels.make_standard_montage(montage)
+    mtg = mne.channels.make_standard_montage(resolve_montage_name(montage))
     ch_pos = mtg.get_positions()["ch_pos"]
     out = []
     for n in names:

--- a/braindecode/util.py
+++ b/braindecode/util.py
@@ -338,6 +338,50 @@ def create_mne_dummy_raw(
     return raw, save_fname
 
 
+# MNE 1.13 renamed these standard montages and deprecated the legacy names,
+# which will raise in MNE 1.14 (mne-python#13903). As braindecode supports
+# ``mne>=1.11``, the spelling has to be resolved against the installed MNE
+# version instead of being hard-coded. The rename does not change electrode
+# positions: the new montage files are byte-identical to the legacy ones.
+_RENAMED_STANDARD_MONTAGES = {
+    "standard_1005": "colin27_1005",
+    "standard_1020": "colin27_1020",
+}
+
+
+def resolve_montage_name(name):
+    """Resolve an MNE standard montage name for the installed MNE version.
+
+    MNE 1.13 renamed the ``standard_1005`` and ``standard_1020`` montages to
+    ``colin27_1005`` and ``colin27_1020`` and deprecated the legacy names,
+    which will raise in MNE 1.14 [1]_. As braindecode supports ``mne>=1.11``,
+    this helper returns the spelling understood by the installed MNE version,
+    so that neither a ``FutureWarning`` (MNE >= 1.13) nor a ``ValueError``
+    (MNE < 1.13, new names unknown) can occur.
+
+    Parameters
+    ----------
+    name : str
+        Name of a standard montage, in either the legacy or the current
+        spelling.
+
+    Returns
+    -------
+    str
+        ``name`` itself, unless it is one of the renamed montages and the
+        installed MNE knows the new spelling, in which case the new spelling
+        is returned.
+
+    References
+    ----------
+    .. [1] https://github.com/mne-tools/mne-python/pull/13903
+    """
+    new_name = _RENAMED_STANDARD_MONTAGES.get(name)
+    if new_name is not None and new_name in mne.channels.get_builtin_montages():
+        return new_name
+    return name
+
+
 def _looks_like_channel_mask(tensor):
     """Tell the channel mask from channel positions in an extended batch.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -812,6 +812,7 @@ Functions available in braindecode util module.
     :toctree: generated/
 
      set_random_seeds
+     resolve_montage_name
 
 ***************
  Visualization

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -40,6 +40,14 @@ Enhancements
 Bug fixes
 ==========
 
+- Fix a ``FutureWarning`` raised by MNE >= 1.13 when importing
+  :mod:`braindecode` or using models, datasets and augmentations that build
+  on the ``standard_1005``/``standard_1020`` montages: MNE renamed these
+  montages to ``colin27_1005``/``colin27_1020`` and will remove the legacy
+  names in MNE 1.14, so their spelling is now resolved against the installed
+  MNE version via :func:`braindecode.util.resolve_montage_name`
+  (:gh:`1163` by `Li Qing`_).
+
 - Fix :class:`braindecode.modules.CombinedConv` raising ``RuntimeError: self
   must be a matrix`` when ``in_chans``, ``n_filters_time`` or ``n_filters_spat``
   is 1, which made :class:`braindecode.models.ShallowFBCSPNet` and
@@ -1731,3 +1739,4 @@ Authors
 .. _Azra Bano: https://github.com/azrabano23
 .. _Aditya Singh: https://github.com/adityasingh2400
 .. _Julien Gadonneix: https://github.com/julien-gadonneix
+.. _Li Qing: https://github.com/qinxwew

--- a/test/unit_tests/models/test_interpolation.py
+++ b/test/unit_tests/models/test_interpolation.py
@@ -58,13 +58,14 @@ def test_forward_applies_matrix_over_channel_axis():
     torch.testing.assert_close(y[0, 1], torch.tensor([1.0, 2.0, 3.0]))
 
 
-def _montage_ch(name):
+def _montage_ch(name, pos_name=None):
     # Positions from a real montage: we pick a handful of 10-20 names.
     import mne
 
     mtg = mne.channels.make_standard_montage("standard_1005")
     pos = mtg.get_positions()["ch_pos"]
-    return {"ch_name": name, "kind": "eeg", "loc": np.asarray(pos[name], dtype=float)}
+    loc = np.asarray(pos[pos_name or name], dtype=float)
+    return {"ch_name": name, "kind": "eeg", "loc": loc}
 
 
 def test_compute_mne_matrix_returns_correct_shape():
@@ -79,20 +80,30 @@ def test_compute_mne_matrix_returns_correct_shape():
 
 
 def test_always_mode_uses_mne_even_when_names_match():
-    # Identical src and tgt by name — in name_match this would be identity,
-    # in always mode it uses the MNE matrix (NOT identity).
-    # Use at least 4 channels to satisfy MNE's minimum digitization requirement.
+    # All names match, so name_match would short-circuit to a permutation
+    # matrix. In always mode the MNE interpolation is computed from the
+    # positions, so with different tgt positions the result must NOT be a
+    # permutation. (For identical positions the spline self-interpolation is
+    # numerically exact identity, so the positions must differ for this test
+    # to distinguish the two modes.)
     names = ["Fz", "Cz", "Pz", "C3", "C4"]
+    pos_names = ["F3", "F4", "P3", "P4", "Oz"]
     src = [_montage_ch(n) for n in names]
-    tgt = [_montage_ch(n) for n in names]
+    tgt = [_montage_ch(n, p) for n, p in zip(names, pos_names)]
     layer = ChannelInterpolationLayer(src, tgt, mode="always")
     assert layer.matrix.shape == (5, 5)
-    # MNE on identical positions will approximate identity but likely not
-    # be exactly identity. Check non-trivial off-diagonal structure.
-    off_diag = layer.matrix - torch.diag(torch.diagonal(layer.matrix))
-    assert torch.any(off_diag.abs() > 1e-6), (
-        "expected non-trivial MNE-computed matrix, got pure diagonal"
+    # Spline interpolation onto different positions mixes several sources
+    # into each target: no row is close to a one-hot.
+    for i, row in enumerate(layer.matrix):
+        n_large = (row.abs() > 0.1).sum().item()
+        assert n_large > 1, f"row {i} looks one-hot ({n_large} large entries)"
+    # Spline preserves constant signals: each row sums to one.
+    torch.testing.assert_close(
+        layer.matrix.sum(axis=1), torch.ones(5), atol=1e-3, rtol=0
     )
+    # Contrast: the same inputs in name_match mode yield the permutation.
+    layer_nm = ChannelInterpolationLayer(src, tgt, mode="name_match")
+    torch.testing.assert_close(layer_nm.matrix, torch.eye(5))
 
 
 def test_name_match_partial_overwrites_matched_rows_with_one_hots():

--- a/test/unit_tests/test_util.py
+++ b/test/unit_tests/test_util.py
@@ -5,6 +5,7 @@
 
 import os
 import tempfile
+import warnings
 from unittest import mock
 
 import h5py
@@ -24,6 +25,7 @@ from braindecode.util import (
     get_balanced_batches,
     np_to_th,
     read_all_file_names,
+    resolve_montage_name,
     set_random_seeds,
     th_to_np,
 )
@@ -484,3 +486,37 @@ def test_throwaway_index_loader_routes_pos_and_mask():
     # regression casts y to float even on the dict path
     _, yy, _ = _route((X, torch.randn(B), crop, pos, mask), is_regression=True)
     assert yy.dtype == torch.float32
+
+
+def test_resolve_montage_name():
+    renamed = {
+        "standard_1005": "colin27_1005",
+        "standard_1020": "colin27_1020",
+    }
+    for legacy, new in renamed.items():
+        resolved = resolve_montage_name(legacy)
+        assert resolved in (legacy, new)
+        assert resolved in mne.channels.get_builtin_montages()
+
+    # names that were not renamed pass through untouched
+    assert resolve_montage_name("biosemi64") == "biosemi64"
+    assert resolve_montage_name("easycap-M1") == "easycap-M1"
+
+
+def test_resolve_montage_name_raises_no_future_warning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        for name in ("standard_1005", "standard_1020"):
+            montage = mne.channels.make_standard_montage(resolve_montage_name(name))
+            assert isinstance(montage, mne.channels.DigMontage)
+
+
+def test_eegpt_channel_building_raises_no_future_warning():
+    # gh-1163: building EEGPT's canonical channel list used to emit MNE's
+    # montage deprecation FutureWarning already at import time
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        from braindecode.models.eegpt import _get_eegpt_channels
+
+        channels = _get_eegpt_channels()
+    assert len(channels) > 0


### PR DESCRIPTION
Fixes #1163.

## Summary

MNE 1.13 renamed the `standard_1005`/`standard_1020` standard montages to `colin27_1005`/`colin27_1020` and deprecated the legacy names, which will **raise** in MNE 1.14 (mne-tools/mne-python#13903). Because `braindecode.models.eegpt` builds its canonical channel list at import time, importing `braindecode` with MNE >= 1.13 emits the warning reported in the issue:

```
FutureWarning: Montage name 'standard_1020' is deprecated and will be removed in MNE 1.14.
Use 'colin27_1020' instead.
```

Since `braindecode` supports `mne>=1.11.0`, and `colin27_*` only exists from MNE 1.13 on (while the legacy names disappear in 1.14), neither spelling can be hard-coded. This PR adds `braindecode.util.resolve_montage_name()`, which picks the spelling the installed MNE knows via the public `mne.channels.get_builtin_montages()` — no version parsing, no private API — and routes every internal montage lookup through it:

- `braindecode/models/eegpt.py` (2 sites; one runs at import time — the site from the issue traceback)
- `braindecode/models/dgcnn.py` (`standard_1005`)
- `braindecode/models/interpolated.py` (`_build_chs_info_from_montage` now accepts both spellings on every supported MNE version)
- `braindecode/datasets/tuh.py` (2 sites; `standard_1005` is renamed by the same MNE PR and would have started failing on MNE 1.14)
- `braindecode/augmentation/transforms.py`

Electrode positions are unaffected: `colin27_1020.elc` is byte-identical to the previous `standard_1020.elc` (verified against mne-python v1.12.0 and v1.13.0) — the rename is purely cosmetic.

## Validation

- `pytest test/unit_tests/test_util.py` — new regression tests: (i) both renamed montages resolve to a spelling the installed MNE knows, (ii) building them through the helper raises no `FutureWarning`, (iii) EEGPT channel building — the import-time path from the issue — raises no `FutureWarning`
- `ruff format --check` and `ruff check --select=F401,I` on all touched files
- CI

Tests/examples that call `make_standard_montage('standard_1020')` directly are intentionally left untouched to keep this PR focused on the library code: they only emit a warning today and can be migrated once MNE 1.14 actually lands.
