### PR TITLE
Fix inconsistent event targets and preserve window dataset settings

### DIFF
--- a/braindecode/datasets/base.py
+++ b/braindecode/datasets/base.py
@@ -5,6 +5,7 @@
 #          Simon Brandt <simonbrandt@protonmail.com>
 #          David Sabbagh <dav.sabbagh@gmail.com>
 #          Robin Schirrmeister <robintibor@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -1398,6 +1399,9 @@ class BaseConcatDataset(ConcatDataset, HubDatasetMixin, Generic[T]):
                 df = ds._windows.metadata
             else:
                 df = ds.metadata
+            if isinstance(df, pd.DataFrame):
+                # copy so the description columns stay out of the dataset
+                df = df.copy()
             for k, v in ds.description.items():
                 df[k] = v
             all_dfs.append(df)

--- a/braindecode/datautil/serialization.py
+++ b/braindecode/datautil/serialization.py
@@ -1,6 +1,7 @@
 """Convenience functions for storing and loading of windows datasets."""
 
 # Authors: Lukas Gemein <l.gemein@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -270,7 +271,9 @@ def _load_parallel(path, i, preload, is_raw, has_stored_windows):
     else:
         window_kwargs = _load_kwargs_json("window_kwargs", sub_dir)
         windows_ds_kwargs = [
-            kwargs[1] for kwargs in window_kwargs if kwargs[0] == "WindowsDataset"
+            kwargs[1]
+            for kwargs in window_kwargs
+            if kwargs[0] in ("WindowsDataset", "EEGWindowsDataset")
         ]
         windows_ds_kwargs = windows_ds_kwargs[0] if len(windows_ds_kwargs) == 1 else {}
         if is_raw:

--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -427,7 +427,8 @@ def create_windows_from_events(
     # If user did not specify mapping, we extract all events from all datasets
     # and map them to increasing integers starting from 0
     infer_mapping = mapping is None
-    mapping = dict() if infer_mapping else mapping
+    if infer_mapping:
+        mapping = _infer_mapping(concat_ds)
     infer_window_size_stride = window_size_samples is None
 
     if drop_bad_windows is not None:
@@ -636,6 +637,16 @@ def create_fixed_length_windows(
         for ds in concat_ds.datasets
     )
     return BaseConcatDataset(list_of_windows_ds)
+
+
+def _infer_mapping(concat_ds):
+    # built once here so parallel workers do not each start counting from 0
+    mapping: dict[str, int] = dict()
+    for ds in concat_ds.datasets:
+        for event_name in np.unique(ds.raw.annotations.description):
+            if event_name not in mapping:
+                mapping[event_name] = len(mapping)
+    return mapping
 
 
 def _create_windows_from_events(

--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -301,9 +301,12 @@ def create_windows_from_events(
         emits a ``DeprecationWarning`` and this parameter will be removed in
         version 2.0.
     mapping: dict(str: int)
-        Mapping from event description to numerical target value. Must be
-        provided when any of ``trial_start_offset_samples``,
-        ``trial_stop_offset_samples``, or ``window_stride_samples`` is a dict.
+        Mapping from event description to numerical target value. If None, the
+        event descriptions of all datasets are numbered from 0 in the order they
+        are first met, and this mapping is shared by every dataset regardless
+        of ``n_jobs``. Must be provided when any of
+        ``trial_start_offset_samples``, ``trial_stop_offset_samples``, or
+        ``window_stride_samples`` is a dict.
     preload: bool
         If True, preload the data of the Epochs objects. This is useful to
         reduce disk reading overhead when returning windows in a training

--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -680,8 +680,9 @@ def _create_windows_from_events(
     ds : RawDataset
         Dataset containing continuous data and description.
     infer_mapping : bool
-        If True, extract all events from all datasets and map them to
-        increasing integers starting from 0.
+        If True, add the event descriptions of ``ds`` missing from ``mapping``
+        to it with increasing integers. `create_windows_from_events` already
+        fills the mapping from all datasets before calling this function.
     infer_window_size_stride : bool
         If True, infer the stride from the original trial size of the first
         trial and trial_start_offset_samples and trial_stop_offset_samples.

--- a/braindecode/preprocessing/windowers.py
+++ b/braindecode/preprocessing/windowers.py
@@ -302,11 +302,11 @@ def create_windows_from_events(
         version 2.0.
     mapping: dict(str: int)
         Mapping from event description to numerical target value. If None, the
-        event descriptions of all datasets are numbered from 0 in the order they
-        are first met, and this mapping is shared by every dataset regardless
-        of ``n_jobs``. Must be provided when any of
-        ``trial_start_offset_samples``, ``trial_stop_offset_samples``, or
-        ``window_stride_samples`` is a dict.
+        event descriptions of all datasets are numbered from 0 in dataset
+        order, with descriptions sorted within each dataset. This mapping is
+        shared by every dataset regardless of ``n_jobs``. Must be provided
+        when any of ``trial_start_offset_samples``,
+        ``trial_stop_offset_samples``, or ``window_stride_samples`` is a dict.
     preload: bool
         If True, preload the data of the Epochs objects. This is useful to
         reduce disk reading overhead when returning windows in a training

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -53,6 +53,14 @@ Bug fixes
   could receive different integer targets across recordings. By `Sarthak
   Tayal`_.
 
+- Make :func:`braindecode.datautil.load_concat_dataset` restore the
+  ``targets_from`` and ``last_target_only`` settings of a saved
+  :class:`braindecode.datasets.EEGWindowsDataset`. The loader looked the stored
+  settings up under the name ``WindowsDataset`` while the windowers record them
+  under ``EEGWindowsDataset``, so a dataset windowed with
+  ``targets_from="channels"`` came back reading its targets from the metadata.
+  By `Sarthak Tayal`_.
+
 
 Current 1.8.0 (2026-08-31)
 ===============================

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -61,6 +61,11 @@ Bug fixes
   ``targets_from="channels"`` came back reading its targets from the metadata.
   By `Sarthak Tayal`_.
 
+- Make :meth:`braindecode.datasets.BaseConcatDataset.get_metadata` work on a
+  copy of the metadata of each dataset. The description columns were written
+  into the metadata frame of the dataset itself, replacing any column sharing a
+  name with a description key such as ``target``. By `Sarthak Tayal`_.
+
 
 Current 1.8.0 (2026-08-31)
 ===============================

--- a/docs/whats_new.rst
+++ b/docs/whats_new.rst
@@ -46,6 +46,13 @@ Bug fixes
   :class:`braindecode.models.Deep4Net` unusable on single-channel data
   (:gh:`1154` by `Julien Gadonneix`_).
 
+- Make :func:`braindecode.preprocessing.create_windows_from_events` infer the
+  event mapping once for the whole dataset before the recordings are windowed.
+  With ``mapping=None`` and ``n_jobs`` above one, every worker numbered the
+  event descriptions of its own recording from zero, so the same description
+  could receive different integer targets across recordings. By `Sarthak
+  Tayal`_.
+
 
 Current 1.8.0 (2026-08-31)
 ===============================

--- a/test/unit_tests/datasets/test_dataset.py
+++ b/test/unit_tests/datasets/test_dataset.py
@@ -1,5 +1,6 @@
 # Authors: Maciej Sliwowski <maciek.sliwowski@gmail.com>
 #          Lukas Gemein <l.gemein@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD (3-clause)
 
@@ -1006,3 +1007,26 @@ def test_windows_dataset_fast_vs_preload_consistency(basic_raw_and_metadata, tmp
         np.testing.assert_array_equal(X_fast, X_preloaded)
         assert y_fast == y_preloaded
         assert crop_fast == crop_preloaded
+
+
+def test_get_metadata_leaves_dataset_metadata_untouched(concat_ds_targets):
+    concat_ds, _ = concat_ds_targets
+    windows_ds = create_windows_from_events(
+        concat_ds=concat_ds,
+        trial_start_offset_samples=0,
+        trial_stop_offset_samples=0,
+        window_size_samples=100,
+        window_stride_samples=100,
+        on_last_window="overlap",
+    )
+    # a description key sharing its name with a metadata column
+    windows_ds.set_description({"target": [99] * len(windows_ds.datasets)})
+    metadata_before = [ds.metadata.copy() for ds in windows_ds.datasets]
+    targets_before = [y for _, y, _ in windows_ds]
+
+    metadata = windows_ds.get_metadata()
+
+    assert "subject" in metadata.columns
+    for ds, before in zip(windows_ds.datasets, metadata_before):
+        pd.testing.assert_frame_equal(ds.metadata, before)
+    assert [y for _, y, _ in windows_ds] == targets_before

--- a/test/unit_tests/datautil/test_serialization.py
+++ b/test/unit_tests/datautil/test_serialization.py
@@ -496,9 +496,7 @@ def test_save_concat_dataset(tmpdir, setup_concat_raw_dataset):
 
 def test_load_concat_windows_dataset_channel_targets(tmp_path):
     info = mne.create_info(["Cz", "target"], sfreq=100, ch_types=["eeg", "misc"])
-    raw = mne.io.RawArray(
-        np.random.RandomState(0).randn(2, 1000), info, verbose=False
-    )
+    raw = mne.io.RawArray(np.random.RandomState(0).randn(2, 1000), info, verbose=False)
     windows = create_fixed_length_windows(
         BaseConcatDataset([RawDataset(raw, description={"recording": 0})]),
         window_size_samples=100,

--- a/test/unit_tests/datautil/test_serialization.py
+++ b/test/unit_tests/datautil/test_serialization.py
@@ -1,4 +1,5 @@
 # Authors: Lukas Gemein <l.gemein@gmail.com>
+#          Sarthak Tayal <sarthaktayal2@gmail.com>
 #
 # License: BSD-3
 
@@ -20,6 +21,7 @@ from braindecode.datautil.serialization import (
 )
 from braindecode.preprocessing import (
     Preprocessor,
+    create_fixed_length_windows,
     create_windows_from_events,
     preprocess,
 )
@@ -490,3 +492,29 @@ def test_save_concat_dataset(tmpdir, setup_concat_raw_dataset):
     # Call the save_concat_dataset function
     with pytest.warns(UserWarning):
         save_concat_dataset(tmpdir, setup_concat_raw_dataset, overwrite=False)
+
+
+def test_load_concat_windows_dataset_channel_targets(tmp_path):
+    info = mne.create_info(["Cz", "target"], sfreq=100, ch_types=["eeg", "misc"])
+    raw = mne.io.RawArray(
+        np.random.RandomState(0).randn(2, 1000), info, verbose=False
+    )
+    windows = create_fixed_length_windows(
+        BaseConcatDataset([RawDataset(raw, description={"recording": 0})]),
+        window_size_samples=100,
+        window_stride_samples=100,
+        on_last_window="overlap",
+        targets_from="channels",
+        last_target_only=False,
+    )
+    windows.save(tmp_path, overwrite=False)
+    loaded = load_concat_dataset(tmp_path, preload=False)
+
+    for before, after in zip(windows.datasets, loaded.datasets):
+        assert after.targets_from == before.targets_from
+        assert after.last_target_only == before.last_target_only
+    for i in range(len(windows)):
+        x_before, y_before, _ = windows[i]
+        x_after, y_after, _ = loaded[i]
+        np.testing.assert_allclose(x_after, x_before, rtol=1e-4, atol=1e-5)
+        np.testing.assert_allclose(y_after, y_before, rtol=1e-4, atol=1e-5)

--- a/test/unit_tests/preprocessing/test_windowers.py
+++ b/test/unit_tests/preprocessing/test_windowers.py
@@ -2151,3 +2151,30 @@ def test_fixed_length_no_size_policy_is_moot(
         replacement_dataset.metadata,
     )
     assert deprecated_dataset.window_kwargs == replacement_dataset.window_kwargs
+
+
+def test_windows_from_events_infer_mapping_n_jobs(tmpdir_factory):
+    # every recording sees a different subset of the event types
+    descriptions = [5 * ["T0", "T1"], 5 * ["T1", "T2"], 10 * ["T2"]]
+    concat_ds = BaseConcatDataset(
+        [
+            RawDataset(
+                _get_raw(tmpdir_factory, description),
+                description=pd.Series({"file_id": i}),
+            )
+            for i, description in enumerate(descriptions)
+        ]
+    )
+    expected = [5 * [0, 1], 5 * [1, 2], 10 * [2]]
+    for n_jobs in [1, 2]:
+        windows = create_windows_from_events(
+            concat_ds=concat_ds,
+            trial_start_offset_samples=0,
+            trial_stop_offset_samples=0,
+            window_size_samples=100,
+            window_stride_samples=100,
+            on_last_window="overlap",
+            n_jobs=n_jobs,
+        )
+        for ds, targets in zip(windows.datasets, expected):
+            np.testing.assert_array_equal(ds.metadata["target"], targets)


### PR DESCRIPTION
Windowed datasets could return different targets after parallel windowing, reloading, or reading metadata. This change fixes three paths that caused those differences.

- `create_windows_from_events` now infers one event mapping across all recordings before starting parallel workers. With `mapping=None`, a recording containing only `right` previously assigned it target `0` when processed in a separate worker, even if `right` was target `1` in another recording. The target IDs now agree across `n_jobs` settings.
- `load_concat_dataset` now restores `targets_from` and `last_target_only` from saved `EEGWindowsDataset` settings. Previously, reloading a dataset with channel targets silently fell back to metadata targets. The loader still accepts the older `WindowsDataset` setting name.
- `BaseConcatDataset.get_metadata` now adds description columns to a copy. Previously, a description key such as `target` could overwrite the source metadata and change later reads of the dataset.

Closes #1165
